### PR TITLE
Performance tuning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,10 @@
 Changelog
 =========
+
+0.10.8
+------
+- Performance fixes from ``pypika`` and object retrieval
+
 0.10.7
 ------
 - Fixed SQLite relative db path and :memory: now also works

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,7 +19,7 @@ certifi==2018.8.24        # via requests
 cffi==1.11.5              # via cryptography
 chardet==3.0.4            # via requests
 ciso8601==2.0.1
-click==6.7                # via pip-tools
+click==7.0                # via pip-tools
 cloud-sptheme==1.9.4
 colorama==0.3.9           # via green
 coverage==4.5.1           # via coveralls, green
@@ -41,7 +41,7 @@ markupsafe==1.0           # via jinja2
 mccabe==0.6.1             # via flake8, pylint
 mypy-extensions==0.4.1    # via mypy
 mypy==0.630
-packaging==17.1           # via sphinx
+packaging==18.0           # via sphinx
 pbr==4.2.0                # via stevedore
 pip-tools==3.0.0
 pluggy==0.7.1             # via tox
@@ -53,7 +53,7 @@ pygments==2.2.0
 pylint==2.1.1
 pymysql==0.9.2            # via aiomysql
 pyparsing==2.2.1          # via packaging
-pypika==0.15.5
+pypika==0.15.6
 pytz==2018.5              # via babel
 pyyaml==3.13              # via bandit
 requests==2.19.1          # via coveralls, sphinx

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pypika>=0.15.4,<1.0
+pypika>=0.15.6,<1.0
 ciso8601>=2.0
 aiocontextvars==0.1.2;python_version<"3.7"
 aiosqlite>=0.6.0

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -374,4 +374,4 @@ def run_async(coro):
         loop.run_until_complete(Tortoise.close_connections())
 
 
-__version__ = "0.10.7"
+__version__ = "0.10.8"

--- a/tortoise/backends/asyncpg/client.py
+++ b/tortoise/backends/asyncpg/client.py
@@ -173,7 +173,7 @@ class TransactionWrapper(AsyncpgDBClient, BaseTransactionWrapper):
     async def commit(self):
         try:
             await self.transaction.commit()
-        except (AttributeError, asyncpg.exceptions._base.InterfaceError) as exc:
+        except asyncpg.exceptions._base.InterfaceError as exc:
             raise TransactionManagementError(exc)
         if self._pool:
             await self._pool.release(self._connection)
@@ -183,7 +183,7 @@ class TransactionWrapper(AsyncpgDBClient, BaseTransactionWrapper):
     async def rollback(self):
         try:
             await self.transaction.rollback()
-        except (AttributeError, asyncpg.exceptions._base.InterfaceError) as exc:
+        except asyncpg.exceptions._base.InterfaceError as exc:
             raise TransactionManagementError(exc)
         if self._pool:
             await self._pool.release(self._connection)

--- a/tortoise/backends/asyncpg/client.py
+++ b/tortoise/backends/asyncpg/client.py
@@ -18,8 +18,8 @@ class AsyncpgDBClient(BaseDBAsyncClient):
     executor_class = AsyncpgExecutor
     schema_generator = AsyncpgSchemaGenerator
 
-    def __init__(self, user, password, database, host, port, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, user, password, database, host, port, **kwargs):
+        super().__init__(**kwargs)
 
         self.user = user
         self.password = password

--- a/tortoise/backends/base/client.py
+++ b/tortoise/backends/base/client.py
@@ -37,7 +37,7 @@ class BaseDBAsyncClient:
     def _in_transaction(self):
         raise NotImplementedError()  # pragma: nocoverage
 
-    async def execute_query(self, query):
+    async def execute_query(self, query, get_inserted_id=False):
         raise NotImplementedError()  # pragma: nocoverage
 
     async def execute_script(self, script):
@@ -62,11 +62,11 @@ class ConnectionWrapper:
 
 
 class SingleConnectionWrapper(BaseDBAsyncClient):
+    # pylint: disable=W0223
+
     def __init__(self, connection_name, connection, closing_callback=None):
-        self.connection_name = connection_name
+        super().__init__(connection_name, single_connection=True)
         self.connection = connection
-        self.log = logging.getLogger('db_client')
-        self.single_connection = True
         self.closing_callback = closing_callback
 
     def acquire_connection(self):

--- a/tortoise/backends/base/client.py
+++ b/tortoise/backends/base/client.py
@@ -62,11 +62,13 @@ class ConnectionWrapper:
 
 
 class SingleConnectionWrapper(BaseDBAsyncClient):
-    # pylint: disable=W0223
+    # pylint: disable=W0223,W0231
 
     def __init__(self, connection_name, connection, closing_callback=None):
-        super().__init__(connection_name, single_connection=True)
+        self.log = logging.getLogger('db_client')
+        self.connection_name = connection_name
         self.connection = connection
+        self.single_connection = True
         self.closing_callback = closing_callback
 
     def acquire_connection(self):

--- a/tortoise/backends/base/config_generator.py
+++ b/tortoise/backends/base/config_generator.py
@@ -10,7 +10,7 @@ urlparse.uses_netloc.append('mysql')
 DB_LOOKUP = {
     'postgres': {
         'engine': 'tortoise.backends.asyncpg',
-        'vars': {
+        'vmap': {
             'path': 'database',
             'hostname': 'host',
             'port': 'port',
@@ -21,13 +21,13 @@ DB_LOOKUP = {
     'sqlite': {
         'engine': 'tortoise.backends.sqlite',
         'skip_first_char': False,
-        'vars': {
+        'vmap': {
             'path': 'file_path',
         },
     },
     'mysql': {
         'engine': 'tortoise.backends.mysql',
-        'vars': {
+        'vmap': {
             'path': 'database',
             'hostname': 'host',
             'port': 'port',
@@ -61,20 +61,20 @@ def expand_db_url(db_url: str, testing: bool = False) -> dict:
         path = path.replace('\\{', '{').replace('\\}', '}')
         path = path.format(uuid.uuid4().hex)
 
-    vars = {}  # type: dict
-    vars.update(db['vars'])
-    params[vars['path']] = path
-    if vars.get('hostname'):
-        params[vars['hostname']] = str(url.hostname or '')
+    vmap = {}  # type: dict
+    vmap.update(db['vmap'])
+    params[vmap['path']] = path
+    if vmap.get('hostname'):
+        params[vmap['hostname']] = str(url.hostname or '')
     try:
-        if vars.get('port'):
-            params[vars['port']] = str(url.port or '')
+        if vmap.get('port'):
+            params[vmap['port']] = str(url.port or '')
     except ValueError:
         raise ConfigurationError('Port is not an integer')
-    if vars.get('username'):
-        params[vars['username']] = str(url.username or '')
-    if vars.get('password'):
-        params[vars['password']] = str(url.password or '')
+    if vmap.get('username'):
+        params[vmap['username']] = str(url.username or '')
+    if vmap.get('password'):
+        params[vmap['password']] = str(url.password or '')
 
     return {
         'engine': db['engine'],

--- a/tortoise/backends/base/schema_generator.py
+++ b/tortoise/backends/base/schema_generator.py
@@ -47,9 +47,6 @@ class BaseSchemaGenerator:
         # has to implement in children
         raise NotImplementedError()  # pragma: nocoverage
 
-    def _get_auto_now_add_default(self):
-        raise NotImplementedError()  # pragma: nocoverage
-
     def _get_table_sql(self, model) -> dict:
         fields_to_create = []
         m2m_tables_for_create = []

--- a/tortoise/backends/mysql/client.py
+++ b/tortoise/backends/mysql/client.py
@@ -18,8 +18,8 @@ class MySQLClient(BaseDBAsyncClient):
     executor_class = MySQLExecutor
     schema_generator = MySQLSchemaGenerator
 
-    def __init__(self, user, password, database, host, port, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, user, password, database, host, port, **kwargs):
+        super().__init__(**kwargs)
 
         self.user = user
         self.password = password

--- a/tortoise/backends/sqlite/client.py
+++ b/tortoise/backends/sqlite/client.py
@@ -16,8 +16,8 @@ class SqliteClient(BaseDBAsyncClient):
     executor_class = SqliteExecutor
     schema_generator = SqliteSchemaGenerator
 
-    def __init__(self, file_path, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, file_path, **kwargs):
+        super().__init__(**kwargs)
         self.filename = file_path
         self._transaction_class = type(
             'TransactionWrapper', (TransactionWrapper, self.__class__), {}

--- a/tortoise/fields.py
+++ b/tortoise/fields.py
@@ -29,7 +29,7 @@ class Field:
     """
     def __init__(
         self,
-        type=None,
+        type=None,  # pylint: disable=W0622
         source_field: Optional[str] = None,
         generated: bool = False,
         pk: bool = False,
@@ -301,7 +301,7 @@ class ManyToManyField(Field):
 
 
 class BackwardFKRelation:
-    def __init__(self, type, relation_field, **kwargs):
+    def __init__(self, type, relation_field, **kwargs):  # pylint: disable=W0622
         self.type = type
         self.relation_field = relation_field
 

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -332,10 +332,8 @@ class Model(metaclass=ModelMeta):
 
         for key in self._meta.backward_fk_fields:
             field = self._meta.fields_map[key]
-            setattr(
-                self, key,
-                RelationQueryContainer(field.type, field.relation_field, self, is_new)
-            )
+            setattr(self, key, RelationQueryContainer(
+                field.type, field.relation_field, self, is_new))  # type: ignore
 
         for key in self._meta.m2m_fields:
             field = self._meta.fields_map[key]

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -284,7 +284,7 @@ class QuerySet(AwaitableQuery):
             queryset._available_custom_filters.update(get_filters_for_field(key, None, key))
         return queryset
 
-    def values_list(self, *fields: str, flat: bool = False):
+    def values_list(self, *fields: str, flat: bool = False):  # pylint: disable=W0621
         """
         Make QuerySet returns list of tuples for given args instead of objects.
         If ```flat=True`` and only one arg is passed can return flat list.
@@ -581,6 +581,8 @@ class CountQuery(AwaitableQuery):
 
 
 class FieldSelectQuery(AwaitableQuery):
+    # pylint: disable=W0223
+
     def _join_table_with_forwarded_fields(self, model, field, forwarded_fields):
         table = Table(model._meta.table)
         if field in model._meta.fields_db_projection and not forwarded_fields:


### PR DESCRIPTION
`tortoise.models.__init__` restructure give 25-30% speedup in select benchmark.
Usage of `pypika>=0.15.6` gives 53% speedup in insert benchmark.

I also cleared up a few lint warnings.
As per findings in https://github.com/tortoise/orm-benchmarks
(The benchmark is currently only using SQLite, but both these changes should be generic)