### PR TITLE
Insert cleanup

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,5 @@
 [settings]
 line_length=100
 multi_line_output=0
-known_third_party=
+known_third_party=aiosqlite,ciso8601
 not_skip=__init__.py

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+0.10.9
+------
+- Uses macros on SQLite driver to minimise syncronisation. ``aiosqlite>=0.7.0``
+- Uses prepared statements for insert, large insert performance increase.
+- Pre-generate base pypika query object per model, providing general purpose speedup.
+
 0.10.8
 ------
 - Performance fixes from ``pypika>=0.15.6``

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,7 @@ sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 
 project = 'Tortoise'
-copyright = '2018, Andrey Bondar'
+copyright = '2018, Andrey Bondar'  # pylint: disable=W0622
 author = 'Andrey Bondar'
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,8 +7,8 @@
 aenum==2.0.8              # via pypika
 aiocontextvars==0.1.2 ; python_version < "3.7"
 aiomysql==0.0.19
-aiosqlite==0.6.0
-alabaster==0.7.11         # via sphinx
+aiosqlite==0.7.0
+alabaster==0.7.12         # via sphinx
 asn1crypto==0.24.0        # via cryptography
 astroid==2.0.4            # via pylint
 asyncpg==0.17.0
@@ -18,20 +18,21 @@ bandit==1.5.1
 certifi==2018.8.24        # via requests
 cffi==1.11.5              # via cryptography
 chardet==3.0.4            # via requests
-ciso8601==2.0.1
+ciso8601==2.1.1
 click==7.0                # via pip-tools
 cloud-sptheme==1.9.4
-colorama==0.3.9           # via green
+colorama==0.4.0           # via green
 coverage==4.5.1           # via coveralls, green
-coveralls==1.5.0
+coveralls==1.5.1
 cryptography==2.3.1       # via pymysql
 docopt==0.6.2             # via coveralls
 docutils==0.14
+filelock==3.0.9           # via tox
 flake8-isort==2.5
 flake8==3.5.0             # via flake8-isort
-gitdb2==2.0.4             # via gitpython
+gitdb2==2.0.5             # via gitpython
 gitpython==2.1.11         # via bandit
-green==2.12.1
+green==2.13.0
 idna==2.7                 # via cryptography, requests
 imagesize==1.1.0          # via sphinx
 isort==4.3.4              # via flake8-isort, pylint
@@ -42,23 +43,23 @@ mccabe==0.6.1             # via flake8, pylint
 mypy-extensions==0.4.1    # via mypy
 mypy==0.630
 packaging==18.0           # via sphinx
-pbr==4.2.0                # via stevedore
-pip-tools==3.0.0
+pbr==4.3.0                # via stevedore
+pip-tools==3.1.0
 pluggy==0.7.1             # via tox
-py==1.6.0                 # via tox
+py==1.7.0                 # via tox
 pycodestyle==2.3.1        # via flake8
 pycparser==2.19           # via cffi
 pyflakes==1.6.0           # via flake8
 pygments==2.2.0
 pylint==2.1.1
 pymysql==0.9.2            # via aiomysql
-pyparsing==2.2.1          # via packaging
-pypika==0.15.6
+pyparsing==2.2.2          # via packaging
+pypika==0.15.7
 pytz==2018.5              # via babel
 pyyaml==3.13              # via bandit
 requests==2.19.1          # via coveralls, sphinx
 six==1.11.0               # via astroid, bandit, cryptography, packaging, pip-tools, sphinx, stevedore, tox
-smmap2==2.0.4             # via gitdb2
+smmap2==2.0.5             # via gitdb2
 snowballstemmer==1.2.1    # via sphinx
 sphinx-autodoc-typehints==1.3.0
 sphinx==1.8.1
@@ -66,8 +67,8 @@ sphinxcontrib-websupport==1.1.0  # via sphinx
 stevedore==1.29.0         # via bandit
 termstyle==0.1.11         # via green
 testfixtures==6.3.0       # via flake8-isort
-toml==0.9.6               # via tox
-tox==3.4.0
+toml==0.10.0              # via tox
+tox==3.5.2
 typed-ast==1.1.0          # via astroid, mypy
 unidecode==1.0.22         # via green
 urllib3==1.23             # via requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pypika>=0.15.6,<1.0
 ciso8601>=2.0
 aiocontextvars==0.1.2;python_version<"3.7"
-aiosqlite>=0.6.0
+aiosqlite>=0.7.0

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -207,6 +207,12 @@ class Tortoise:
         return config
 
     @classmethod
+    def _build_initial_querysets(cls):
+        for app in cls.apps.values():
+            for model in app.values():
+                model._meta.basequery = model._meta.db.query_class.from_(model._meta.table)
+
+    @classmethod
     async def init(
             cls,
             config: Optional[dict] = None,
@@ -302,6 +308,8 @@ class Tortoise:
         cls._init_apps(apps_config)
 
         cls._init_relations()
+
+        cls._build_initial_querysets()
 
         cls._inited = True
 

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -382,4 +382,4 @@ def run_async(coro):
         loop.run_until_complete(Tortoise.close_connections())
 
 
-__version__ = "0.10.8"
+__version__ = "0.10.9"

--- a/tortoise/backends/asyncpg/client.py
+++ b/tortoise/backends/asyncpg/client.py
@@ -1,4 +1,6 @@
 import logging
+from functools import wraps
+from typing import List, SupportsInt, Optional  # noqa
 
 import asyncpg
 from pypika import PostgreSQLQuery
@@ -12,13 +14,27 @@ from tortoise.exceptions import (ConfigurationError, DBConnectionError, Integrit
 from tortoise.transactions import current_transaction_map
 
 
+def translate_exceptions(func):
+    @wraps(func)
+    async def wrapped(self, query):
+        self.log.debug(query)
+        try:
+            return await func(self, query)
+        except asyncpg.exceptions.SyntaxOrAccessError as exc:
+            raise OperationalError(exc)
+        except asyncpg.exceptions.IntegrityConstraintViolationError as exc:
+            raise IntegrityError(exc)
+    return wrapped
+
+
 class AsyncpgDBClient(BaseDBAsyncClient):
     DSN_TEMPLATE = 'postgres://{user}:{password}@{host}:{port}/{database}'
     query_class = PostgreSQLQuery
     executor_class = AsyncpgExecutor
     schema_generator = AsyncpgSchemaGenerator
 
-    def __init__(self, user, password, database, host, port, **kwargs):
+    def __init__(self, user: str, password: str, database: str, host: str, port: SupportsInt,
+                 **kwargs) -> None:
         super().__init__(**kwargs)
 
         self.user = user
@@ -34,14 +50,14 @@ class AsyncpgDBClient(BaseDBAsyncClient):
             port=self.port,
             database=self.database
         )
-        self._db_pool = None
-        self._connection = None
+        self._db_pool = None  # Type: Optional[asyncpg.pool.Pool]
+        self._connection = None  # Type: Optional[asyncpg.Connection]
 
         self._transaction_class = type(
             'TransactionWrapper', (TransactionWrapper, self.__class__), {}
         )
 
-    async def create_connection(self):
+    async def create_connection(self) -> None:
         try:
             if not self.single_connection:
                 self._db_pool = await asyncpg.create_pool(self.dsn)
@@ -56,13 +72,13 @@ class AsyncpgDBClient(BaseDBAsyncClient):
                 self.database
             ))
 
-    async def close(self):
-        if not self.single_connection:
+    async def close(self) -> None:
+        if self._db_pool:
             await self._db_pool.close()
-        else:
+        if self._connection:
             await self._connection.close()
 
-    async def db_create(self):
+    async def db_create(self) -> None:
         single_connection = self.single_connection
         self.single_connection = True
         self._connection = await asyncpg.connect(self.DSN_TEMPLATE.format(
@@ -75,10 +91,10 @@ class AsyncpgDBClient(BaseDBAsyncClient):
         await self.execute_script(
             'CREATE DATABASE "{}" OWNER "{}"'.format(self.database, self.user)
         )
-        await self._connection.close()
+        await self._connection.close()  # type: ignore
         self.single_connection = single_connection
 
-    async def db_delete(self):
+    async def db_delete(self) -> None:
         single_connection = self.single_connection
         self.single_connection = True
         self._connection = await asyncpg.connect(self.DSN_TEMPLATE.format(
@@ -92,30 +108,35 @@ class AsyncpgDBClient(BaseDBAsyncClient):
             await self.execute_script('DROP DATABASE "{}"'.format(self.database))
         except asyncpg.InvalidCatalogNameError:
             pass
-        await self._connection.close()
+        await self._connection.close()  # type: ignore
         self.single_connection = single_connection
 
-    def acquire_connection(self):
+    def acquire_connection(self) -> ConnectionWrapper:
         if not self.single_connection:
-            return self._db_pool.acquire()
+            return self._db_pool.acquire()  # type: ignore
         else:
             return ConnectionWrapper(self._connection)
 
-    def _in_transaction(self):
+    def _in_transaction(self) -> 'TransactionWrapper':
         if self.single_connection:
             return self._transaction_class(self.connection_name, connection=self._connection)
         else:
             return self._transaction_class(self.connection_name, pool=self._db_pool)
 
-    async def execute_query(self, query, get_inserted_id=False):
-        try:
-            async with self.acquire_connection() as connection:
-                self.log.debug(query)
-                return await connection.fetch(query)
-        except asyncpg.exceptions.SyntaxOrAccessError as exc:
-            raise OperationalError(exc)
-        except asyncpg.exceptions.IntegrityConstraintViolationError as exc:
-            raise IntegrityError(exc)
+    @translate_exceptions
+    async def execute_insert(self, query: str) -> int:
+        async with self.acquire_connection() as connection:
+            return (await connection.fetch(query))[0][0]
+
+    @translate_exceptions
+    async def execute_query(self, query: str) -> List[dict]:
+        async with self.acquire_connection() as connection:
+            return await connection.fetch(query)
+
+    @translate_exceptions
+    async def execute_script(self, query: str) -> None:
+        async with self.acquire_connection() as connection:
+            await connection.execute(query)
 
     async def get_single_connection(self):
         if self.single_connection:
@@ -128,19 +149,9 @@ class AsyncpgDBClient(BaseDBAsyncClient):
         if not self.single_connection:
             await self._db_pool.release(single_connection.connection)
 
-    async def execute_script(self, script):
-        try:
-            async with self.acquire_connection() as connection:
-                self.log.debug(script)
-                await connection.execute(script)
-        except asyncpg.exceptions.SyntaxOrAccessError as exc:
-            raise OperationalError(exc)
-        except asyncpg.exceptions.IntegrityConstraintViolationError as exc:
-            raise IntegrityError(exc)
-
 
 class TransactionWrapper(AsyncpgDBClient, BaseTransactionWrapper):
-    def __init__(self, connection_name, pool=None, connection=None):
+    def __init__(self, connection_name: str, pool=None, connection=None) -> None:
         if pool and connection:
             raise ConfigurationError('You must pass either connection or pool')
         self._connection = connection
@@ -155,7 +166,7 @@ class TransactionWrapper(AsyncpgDBClient, BaseTransactionWrapper):
         self.connection_name = connection_name
         self.transaction = None
 
-    def acquire_connection(self):
+    def acquire_connection(self) -> ConnectionWrapper:
         return ConnectionWrapper(self._connection)
 
     async def _get_connection(self):

--- a/tortoise/backends/asyncpg/client.py
+++ b/tortoise/backends/asyncpg/client.py
@@ -128,7 +128,7 @@ class AsyncpgDBClient(BaseDBAsyncClient):
         async with self.acquire_connection() as connection:
             # TODO: Cache prepared statement
             stmt = await connection.prepare(query)
-            return (await stmt.fetchval(*values))
+            return await stmt.fetchval(*values)
 
     @translate_exceptions
     async def execute_query(self, query: str) -> List[dict]:

--- a/tortoise/backends/asyncpg/executor.py
+++ b/tortoise/backends/asyncpg/executor.py
@@ -1,22 +1,13 @@
+from typing import List
+
 from pypika import Table
 
 from tortoise.backends.base.executor import BaseExecutor
 
 
 class AsyncpgExecutor(BaseExecutor):
-    async def execute_insert(self, instance):
-        self.connection = await self.db.get_single_connection()
-        regular_columns, columns = self._prepare_insert_columns()
-        values = self._prepare_insert_values(
-            instance=instance,
-            regular_columns=regular_columns,
-        )
-
-        query = str(
+    def _prepare_insert_statement(self, columns: List[str]) -> str:
+        return str(
             self.connection.query_class.into(Table(self.model._meta.table)).columns(*columns)
-            .insert(*values).returning('id')
-        )
-        instance.id = await self.connection.execute_insert(query)
-        await self.db.release_single_connection(self.connection)
-        self.connection = None
-        return instance
+            .insert('???').returning('id')
+        ).replace("'???'", ','.join(['$%d' % (i + 1, ) for i in range(len(columns))]))

--- a/tortoise/backends/asyncpg/executor.py
+++ b/tortoise/backends/asyncpg/executor.py
@@ -16,8 +16,7 @@ class AsyncpgExecutor(BaseExecutor):
             self.connection.query_class.into(Table(self.model._meta.table)).columns(*columns)
             .insert(*values).returning('id')
         )
-        result = await self.connection.execute_query(query)
-        instance.id = result[0][0]
+        instance.id = await self.connection.execute_insert(query)
         await self.db.release_single_connection(self.connection)
         self.connection = None
         return instance

--- a/tortoise/backends/asyncpg/executor.py
+++ b/tortoise/backends/asyncpg/executor.py
@@ -6,17 +6,17 @@ from tortoise.backends.base.executor import BaseExecutor
 class AsyncpgExecutor(BaseExecutor):
     async def execute_insert(self, instance):
         self.connection = await self.db.get_single_connection()
-        regular_columns = self._prepare_insert_columns()
-        columns, values = self._prepare_insert_values(
+        regular_columns, columns = self._prepare_insert_columns()
+        values = self._prepare_insert_values(
             instance=instance,
             regular_columns=regular_columns,
         )
 
-        query = (
+        query = str(
             self.connection.query_class.into(Table(self.model._meta.table)).columns(*columns)
             .insert(*values).returning('id')
         )
-        result = await self.connection.execute_query(str(query))
+        result = await self.connection.execute_query(query)
         instance.id = result[0][0]
         await self.db.release_single_connection(self.connection)
         self.connection = None

--- a/tortoise/backends/base/client.py
+++ b/tortoise/backends/base/client.py
@@ -12,7 +12,7 @@ class BaseDBAsyncClient:
     executor_class = BaseExecutor
     schema_generator = BaseSchemaGenerator
 
-    def __init__(self, connection_name: str, single_connection: bool=True, **kwargs) -> None:
+    def __init__(self, connection_name: str, single_connection: bool = True, **kwargs) -> None:
         self.log = logging.getLogger('db_client')
         self.single_connection = single_connection
         self.connection_name = connection_name
@@ -38,7 +38,7 @@ class BaseDBAsyncClient:
     def _in_transaction(self) -> 'BaseTransactionWrapper':
         raise NotImplementedError()  # pragma: nocoverage
 
-    async def execute_insert(self, query: str) -> int:
+    async def execute_insert(self, query: str, values: list) -> int:
         raise NotImplementedError()  # pragma: nocoverage
 
     async def execute_query(self, query: str) -> Sequence[dict]:

--- a/tortoise/backends/base/executor.py
+++ b/tortoise/backends/base/executor.py
@@ -60,7 +60,7 @@ class BaseExecutor:
 
     async def execute_insert(self, instance):
         self.connection = await self.db.get_single_connection()
-        key = '%s:%s' % (self.db.connection_name, self.model._meta.table)
+        key = '{}:{}'.format(self.db.connection_name, self.model._meta.table)
         if key not in INSERT_CACHE:
             regular_columns, columns = self._prepare_insert_columns()
             query = self._prepare_insert_statement(columns)

--- a/tortoise/backends/mysql/executor.py
+++ b/tortoise/backends/mysql/executor.py
@@ -60,7 +60,7 @@ class MySQLExecutor(BaseExecutor):
             .insert(*values)
         )
 
-        instance.id = await self.connection.execute_query(query, get_inserted_id=True)
+        instance.id = await self.connection.execute_insert(query)
         await self.db.release_single_connection(self.connection)
         self.connection = None
         return instance

--- a/tortoise/backends/mysql/executor.py
+++ b/tortoise/backends/mysql/executor.py
@@ -49,18 +49,18 @@ FILTER_FUNC_OVERRIDE = {
 class MySQLExecutor(BaseExecutor):
     async def execute_insert(self, instance):
         self.connection = await self.db.get_single_connection()
-        regular_columns = self._prepare_insert_columns()
-        columns, values = self._prepare_insert_values(
+        regular_columns, columns = self._prepare_insert_columns()
+        values = self._prepare_insert_values(
             instance=instance,
             regular_columns=regular_columns,
         )
 
-        query = (
+        query = str(
             MySQLQuery.into(Table(self.model._meta.table)).columns(*columns)
             .insert(*values)
         )
 
-        instance.id = await self.connection.execute_query(str(query), get_inserted_id=True)
+        instance.id = await self.connection.execute_query(query, get_inserted_id=True)
         await self.db.release_single_connection(self.connection)
         self.connection = None
         return instance

--- a/tortoise/backends/sqlite/client.py
+++ b/tortoise/backends/sqlite/client.py
@@ -1,6 +1,8 @@
 import logging
 import os
 import sqlite3
+from functools import wraps
+from typing import List, Optional  # noqa
 
 import aiosqlite
 
@@ -12,89 +14,94 @@ from tortoise.exceptions import IntegrityError, OperationalError, TransactionMan
 from tortoise.transactions import current_transaction_map
 
 
+def translate_exceptions(func):
+    @wraps(func)
+    async def wrapped(self, query):
+        self.log.debug(query)
+        try:
+            return await func(self, query)
+        except sqlite3.OperationalError as exc:
+            raise OperationalError(exc)
+        except sqlite3.IntegrityError as exc:
+            raise IntegrityError(exc)
+    return wrapped
+
+
 class SqliteClient(BaseDBAsyncClient):
     executor_class = SqliteExecutor
     schema_generator = SqliteSchemaGenerator
 
-    def __init__(self, file_path, **kwargs):
+    def __init__(self, file_path: str, **kwargs) -> None:
         super().__init__(**kwargs)
         self.filename = file_path
         self._transaction_class = type(
             'TransactionWrapper', (TransactionWrapper, self.__class__), {}
         )
-        self._connection = None
+        self._connection = None  # type: Optional[aiosqlite.Connection]
 
-    async def create_connection(self):
+    async def create_connection(self) -> None:
         if not self._connection:  # pragma: no branch
             self._connection = aiosqlite.connect(self.filename, isolation_level=None)
             self._connection.start()
             await self._connection._connect()
+            self._connection._conn.row_factory = sqlite3.Row
 
-    async def close(self):
+    async def close(self) -> None:
         if self._connection:
             await self._connection.close()
             self._connection = None
 
-    async def db_create(self):
+    async def db_create(self) -> None:
         pass
 
-    async def db_delete(self):
+    async def db_delete(self) -> None:
         await self.close()
         try:
             os.remove(self.filename)
         except FileNotFoundError:  # pragma: nocoverage
             pass
 
-    def acquire_connection(self):
+    def acquire_connection(self) -> ConnectionWrapper:
         return ConnectionWrapper(self._connection)
 
-    def _in_transaction(self):
+    def _in_transaction(self) -> 'TransactionWrapper':
         return self._transaction_class(self.connection_name, connection=self._connection)
 
-    async def execute_query(self, query, get_inserted_id=False):
-        self.log.debug(query)
-        try:
-            async with self.acquire_connection() as connection:
-                connection._conn.row_factory = sqlite3.Row
-                cursor = await connection.execute(query)
-                results = await cursor.fetchall()
-                if get_inserted_id:
-                    await cursor.execute('SELECT last_insert_rowid()')
-                    inserted_id = await cursor.fetchone()
-                    return inserted_id
-                return [dict(row) for row in results]
-        except sqlite3.OperationalError as exc:
-            raise OperationalError(exc)
-        except sqlite3.IntegrityError as exc:
-            raise IntegrityError(exc)
+    @translate_exceptions
+    async def execute_insert(self, query: str) -> int:
+        async with self.acquire_connection() as connection:
+            cursor = await connection.execute(query)
+            await cursor.execute('SELECT last_insert_rowid()')
+            return (await cursor.fetchone())[0]
 
-    async def execute_script(self, script):
-        connection = self._connection
-        self.log.debug(script)
-        try:
-            await connection.executescript(script)
-        except sqlite3.OperationalError as exc:
-            raise OperationalError(exc)
-        except sqlite3.IntegrityError as exc:
-            raise IntegrityError(exc)
+    @translate_exceptions
+    async def execute_query(self, query: str) -> List[dict]:
+        async with self.acquire_connection() as connection:
+            cursor = await connection.execute(query)
+            return [dict(row) for row in await cursor.fetchall()]
 
-    async def get_single_connection(self):
+    @translate_exceptions
+    async def execute_script(self, query: str) -> None:
+        async with self.acquire_connection() as connection:
+            await connection.executescript(query)
+
+    async def get_single_connection(self) -> 'SqliteClient':
         return self
 
-    async def release_single_connection(self, single_connection):
+    async def release_single_connection(self, single_connection: BaseDBAsyncClient) -> None:
         pass
 
 
 class TransactionWrapper(SqliteClient, BaseTransactionWrapper):
-    def __init__(self, connection_name, connection):
+    def __init__(self, connection_name: str, connection: aiosqlite.Connection) -> None:
         self.connection_name = connection_name
-        self._connection = connection
+        self._connection = connection  # type: aiosqlite.Connection
         self.log = logging.getLogger('db_client')
         self._transaction_class = self.__class__
         self._old_context_value = None
         self._finalized = False
 
-    async def start(self):
+    async def start(self) -> None:
         try:
             await self._connection.commit()
             await self._connection.execute('BEGIN')
@@ -104,14 +111,14 @@ class TransactionWrapper(SqliteClient, BaseTransactionWrapper):
         self._old_context_value = current_transaction.get()
         current_transaction.set(self)
 
-    async def rollback(self):
+    async def rollback(self) -> None:
         if self._finalized:
             raise TransactionManagementError('Transaction already finalised')
         self._finalized = True
         await self._connection.rollback()
         current_transaction_map[self.connection_name].set(self._old_context_value)
 
-    async def commit(self):
+    async def commit(self) -> None:
         if self._finalized:
             raise TransactionManagementError('Transaction already finalised')
         self._finalized = True

--- a/tortoise/backends/sqlite/client.py
+++ b/tortoise/backends/sqlite/client.py
@@ -70,16 +70,13 @@ class SqliteClient(BaseDBAsyncClient):
     async def execute_insert(self, query: str, values: list) -> int:
         self.log.debug('%s: %s', query, values)
         async with self.acquire_connection() as connection:
-            cursor = await connection.execute(query, values)
-            await cursor.execute('SELECT last_insert_rowid()')
-            return (await cursor.fetchone())[0]
+            return (await connection.execute_insert(query, values))[0]
 
     @translate_exceptions
     async def execute_query(self, query: str) -> List[dict]:
         self.log.debug(query)
         async with self.acquire_connection() as connection:
-            cursor = await connection.execute(query)
-            return [dict(row) for row in await cursor.fetchall()]
+            return [dict(row) for row in await connection.execute_fetchall(query)]
 
     @translate_exceptions
     async def execute_script(self, query: str) -> None:

--- a/tortoise/backends/sqlite/executor.py
+++ b/tortoise/backends/sqlite/executor.py
@@ -40,8 +40,7 @@ class SqliteExecutor(BaseExecutor):
             .insert(*values)
         )
 
-        result = await self.connection.execute_query(query, get_inserted_id=True)
-        instance.id = result[0]
+        instance.id = await self.connection.execute_insert(query)
         await self.db.release_single_connection(self.connection)
         self.connection = None
         return instance

--- a/tortoise/backends/sqlite/executor.py
+++ b/tortoise/backends/sqlite/executor.py
@@ -30,17 +30,17 @@ class SqliteExecutor(BaseExecutor):
 
     async def execute_insert(self, instance):
         self.connection = await self.db.get_single_connection()
-        regular_columns = self._prepare_insert_columns()
-        columns, values = self._prepare_insert_values(
+        regular_columns, columns = self._prepare_insert_columns()
+        values = self._prepare_insert_values(
             instance=instance,
             regular_columns=regular_columns,
         )
-
-        query = (
+        query = str(
             self.connection.query_class.into(Table(self.model._meta.table)).columns(*columns)
             .insert(*values)
         )
-        result = await self.connection.execute_query(str(query), get_inserted_id=True)
+
+        result = await self.connection.execute_query(query, get_inserted_id=True)
         instance.id = result[0]
         await self.db.release_single_connection(self.connection)
         self.connection = None

--- a/tortoise/backends/sqlite/executor.py
+++ b/tortoise/backends/sqlite/executor.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+from typing import List
 
 from pypika import Table
 
@@ -28,19 +29,8 @@ class SqliteExecutor(BaseExecutor):
         fields.DecimalField: to_db_decimal,
     }
 
-    async def execute_insert(self, instance):
-        self.connection = await self.db.get_single_connection()
-        regular_columns, columns = self._prepare_insert_columns()
-        values = self._prepare_insert_values(
-            instance=instance,
-            regular_columns=regular_columns,
-        )
-        query = str(
+    def _prepare_insert_statement(self, columns: List[str]) -> str:
+        return str(
             self.connection.query_class.into(Table(self.model._meta.table)).columns(*columns)
-            .insert(*values)
-        )
-
-        instance.id = await self.connection.execute_insert(query)
-        await self.db.release_single_connection(self.connection)
-        self.connection = None
-        return instance
+            .insert('???')
+        ).replace("'???'", ','.join(['?' for _ in range(len(columns))]))

--- a/tortoise/fields.py
+++ b/tortoise/fields.py
@@ -4,9 +4,9 @@ import json
 from decimal import Decimal
 from typing import Any, Optional
 
+import ciso8601
 from pypika import Table
 
-import ciso8601
 from tortoise.exceptions import ConfigurationError, NoValuesFetched, OperationalError
 from tortoise.utils import QueryAsyncIterator
 

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -218,7 +218,8 @@ def get_filters_for_field(field_name: str, field: Optional[fields.Field], source
 class MetaInfo:
     __slots__ = ('abstract', 'table', 'app', 'fields', 'db_fields', 'm2m_fields', 'fk_fields',
                  'backward_fk_fields', 'fetch_fields', 'fields_db_projection', '_inited',
-                 'fields_db_projection_reverse', 'filters', 'fields_map', 'default_connection')
+                 'fields_db_projection_reverse', 'filters', 'fields_map', 'default_connection',
+                 'basequery')
 
     def __init__(self, meta):
         self.abstract = getattr(meta, 'abstract', False)  # type: bool
@@ -236,6 +237,7 @@ class MetaInfo:
         self.fields_map = {}  # type: Dict[str, fields.Field]
         self._inited = False
         self.default_connection = None
+        self.basequery = None
 
     @property
     def db(self):

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -142,11 +142,7 @@ class QuerySet(AwaitableQuery):
         self.fields = model._meta.db_fields
         self.model = model
 
-        if not hasattr(model._meta.db, 'query_class'):
-            # do not build Query if Tortoise wasn't inited
-            self.query = None
-        else:
-            self.query = model._meta.db.query_class.from_(model._meta.table)
+        self.query = model._meta.basequery
 
         self._prefetch_map = {}  # type: Dict[str, Set[str]]
         self._prefetch_queries = {}  # type: Dict[str, QuerySet]


### PR DESCRIPTION
This branch started with the goal of using prepared statements for inserts, but ended up being a general purpose insert/Client related cleanup.

Work done:
* [x] `_prepare_insert_columns` and `_prepare_insert_values` now do what they are called
* [x] Added type annotations to the DB Client classes (It is partial, due to some very confusing type usage, especially for "SingleConnectionsWrapper" and "TransactionWrapper" classes)
* [x] Split out specialised `execute_insert()` method
* [x] Decorators to translate exceptions, so we repeat less code.
* [x] Use macro executors from https://github.com/jreese/aiosqlite/pull/13 for less synchronization overhead.
* [x] Generate prepared statements, and use `values` as a DB driver parameter (https://github.com/kayak/pypika/issues/163 is stalled, do something slightly hacky in the interm)(We need to try and get this into pypika, as `asyncpg` needs prepared statements to perform well)
* [x] Simple, but safe query cache for inserts

Not related to inserts:
* [x] Pre-generate initial pypika query object per model, instead of in queryset instantiation, as it is immutable (gives 25-50% speedup for small fetch operations)

This should be the last performance-oriented PR from me for now, performance is up over double (and much more for sqlite)