### PR TITLE
Refactor ``Tortoise.init()`` and test runner

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,6 +4,7 @@ source =
     tortoise
 omit =
     tortoise/contrib/pylint/*
+    tortoise/contrib/test/nose2.py
     tortoise/tests/*
 [report]
 show_missing = True

--- a/.green
+++ b/.green
@@ -1,4 +1,4 @@
 # verbose       = 2
 no-skip-report= True
-initializer   = tortoise.contrib.test.initializer
+initializer   = tortoise.contrib.test.env_initializer
 finalizer     = tortoise.contrib.test.finalizer

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ python:
   - 3.5
   - 3.7
 env:
+  global:
+    TORTOISE_TEST_MODULES=tortoise.tests.testmodels
+env:
   - TORTOISE_TEST_DB="sqlite:///tmp/test-{}.sqlite"
   - TORTOISE_TEST_DB="postgres://postgres:@127.0.0.1:5432/test_{}"
   - TORTOISE_TEST_DB="mysql://root:@127.0.0.1:3306/test_{}"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Changelog
 - Refactor ``Tortoise.init()`` and test runner to not re-create connections per test, so now tests pass when using an SQLite in-memory database
 - Can pass event loop to test initializer function: ``initializer(loop=loop)``
 - Fix relative URI for SQLite
+- Better error message for invalid filter param.
 
 0.10.9
 ------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Changelog
 - Can pass event loop to test initializer function: ``initializer(loop=loop)``
 - Fix relative URI for SQLite
 - Better error message for invalid filter param.
+- Better error messages for missing/bad field params.
 
 0.10.9
 ------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.10.10
+-------
+- Refactor ``Tortoise.init()`` and test runner to not re-create connections per test, so now tests pass when using an SQLite in-memory database
+- Can pass event loop to test initializer function: ``initializer(loop=loop)``
+
 0.10.9
 ------
 - Uses macros on SQLite driver to minimise syncronisation. ``aiosqlite>=0.7.0``

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog
 -------
 - Refactor ``Tortoise.init()`` and test runner to not re-create connections per test, so now tests pass when using an SQLite in-memory database
 - Can pass event loop to test initializer function: ``initializer(loop=loop)``
+- Fix relative URI for SQLite
 
 0.10.9
 ------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ Changelog
 - Fix relative URI for SQLite
 - Better error message for invalid filter param.
 - Better error messages for missing/bad field params.
+- ``nose2`` plugin
+- Test utilities compatible with ``py.test``
 
 0.10.9
 ------

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ test: deps
 
 testall: deps
 	coverage erase
-	TORTOISE_TEST_DB=sqlite:///tmp/test-\{\}.sqlite coverage run -p --concurrency=multiprocessing `which green`
+	TORTOISE_TEST_DB=sqlite://:memory: coverage run -p --concurrency=multiprocessing `which green`
 	TORTOISE_TEST_DB=postgres://postgres:@127.0.0.1:5432/test_\{\} coverage run -p --concurrency=multiprocessing `which green`
 	TORTOISE_TEST_DB="mysql://root:@127.0.0.1:3306/test_\{\}" coverage run -p --concurrency=multiprocessing `which green`
 	coverage combine

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-checkfiles = tortoise/ examples/
+checkfiles = tortoise/ examples/ setup.py conftest.py
 mypy_flags = --warn-unused-configs --warn-redundant-casts --ignore-missing-imports --allow-untyped-decorators
 
 help:

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,9 @@
+from tortoise.contrib.test import finalizer, initializer
+
+
+def pytest_runtest_setup(item):
+    initializer(['tortoise.tests.testmodels'], db_url='sqlite://:memory:')
+
+
+def pytest_runtest_teardown(item, nextitem):
+    finalizer()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ class Mock(MagicMock):
     def __getattr__(cls, name):
         return MagicMock()
 
-MOCK_MODULES = ['aiosqlite', 'astroid', 'asyncpg', 'asynctest', 'aiomysql']
+MOCK_MODULES = ['aiosqlite', 'astroid', 'asyncpg', 'aiomysql']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 

--- a/docs/contrib.rst
+++ b/docs/contrib.rst
@@ -101,10 +101,10 @@ Furthermore, you mayset the database configuration parameter as an environment v
 
 
 Py.test
-^^^^^^^^^^^
+^^^^^^^
 
-*Nose2*
-^^^^^^^^^
+Nose2
+^^^^^
 
 Load the plugin ``tortoise.contrib.test.nose2`` either via command line::
 

--- a/docs/contrib.rst
+++ b/docs/contrib.rst
@@ -103,6 +103,19 @@ Furthermore, you mayset the database configuration parameter as an environment v
 Py.test
 ^^^^^^^
 
+Run the initializer and finalizer in your ``conftest.py`` file:
+
+.. code-block:: python3
+
+    from tortoise.contrib.test import finalizer, initializer
+
+    def pytest_runtest_setup(item):
+        initializer(['tortoise.tests.testmodels'], db_url='sqlite://:memory:')
+
+    def pytest_runtest_teardown(item, nextitem):
+        finalizer()
+
+
 Nose2
 ^^^^^
 

--- a/docs/databases.rst
+++ b/docs/databases.rst
@@ -6,11 +6,11 @@ Databases
 
 Tortoise currently supports the following databases:
 
+* SQLite
 * PostgreSQL >= 9.4 (using ``asyncpg``)
-* SQLite (using ``aiosqlite``)
 * MySQL/MariaDB (using ``aiomysql``)
 
-To use, please ensure that ``asyncpg``, ``aiosqlite`` and/or ``aiomysql`` is installed.
+To use, please ensure that ``asyncpg`` and/or ``aiomysql`` is installed.
 
 .. _db_url:
 

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -8,6 +8,16 @@ Fields
 Usage
 =====
 
+Fields are defined as properties of a ``Model`` class object:
+
+.. code-block:: python3
+
+    from tortoise.models import Model
+    from tortoise import fields
+
+    class Tournament(Model):
+        id = fields.IntField(pk=True)
+        name = fields.CharField(max_length=255)
 
 
 Reference

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -34,29 +34,29 @@ You can start writing models like this:
 
     from tortoise.models import Model
     from tortoise import fields
-    
+
     class Tournament(Model):
         id = fields.IntField(pk=True)
-        name = fields.TextField()
-    
+        name = fields.CharField(max_length=255)
+
         def __str__(self):
             return self.name
 
 
     class Event(Model):
         id = fields.IntField(pk=True)
-        name = fields.TextField()
+        name = fields.CharField(max_length=255)
         tournament = fields.ForeignKeyField('models.Tournament', related_name='events')
         participants = fields.ManyToManyField('models.Team', related_name='events', through='event_team')
-    
+
         def __str__(self):
             return self.name
 
 
     class Team(Model):
         id = fields.IntField(pk=True)
-        name = fields.TextField()
-    
+        name = fields.CharField(max_length=255)
+
         def __str__(self):
             return self.name
 
@@ -71,11 +71,11 @@ You can do it like this:
     from tortoise.utils import generate_schema
 
     async def init():
-        # Here we connect to a PostgresQL DB
-        # also specify the app name of "models"
-        # which contain models from "app.models"
+        # Here we create a SQLite DB using file "db.sqlite3"
+        #  also specify the app name of "models"
+        #  which contain models from "app.models"
         await Tortoise.init(
-            db_url='postgres://postgres:qwerty123@localhost:5432/events',
+            db_url='sqlite://db.sqlite3',
             modules={'models': ['app.models']}
         )
         # Generate the schema
@@ -101,7 +101,7 @@ After that you can start using your models:
     # Create instance by save
     tournament = Tournament(name='New Tournament')
     await tournament.save()
-    
+
     # Or by .create()
     await Event.create(name='Without participants', tournament=tournament)
     event = await Event.create(name='Test', tournament=tournament)
@@ -109,15 +109,15 @@ After that you can start using your models:
     for i in range(2):
         team = Team.create(name='Team {}'.format(i + 1))
         participants.append(team)
-    
+
     # M2M Relationship management is quite straightforward
     # (look for methods .remove(...) and .clear())
     await event.participants.add(*participants)
-    
+
     # You can query related entity just with async for
     async for team in event.participants:
         pass
-    
+
     # After making related query you can iterate with regular for,
     # which can be extremely convenient for using with other packages,
     # for example some kind of serializers with nested support
@@ -129,11 +129,11 @@ After that you can start using your models:
     selected_events = await Event.filter(
         participants=participants[0].id
     ).prefetch_related('participants', 'tournament')
-    
+
     # Tortoise ORM supports variable depth of prefetching related entities
     # This will fetch all events for team and in those team tournament will be prefetched
     await Team.all().prefetch_related('events__tournament')
-    
+
     # You can filter and order by related models too
     await Tournament.filter(
         events__name__in=['Test', 'Prod']

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,4 @@
 sphinx
 cloud_sptheme
 sphinx-autodoc-typehints
+asynctest

--- a/docs/roadmap.rst
+++ b/docs/roadmap.rst
@@ -12,7 +12,6 @@ For ``v1.0`` that involves:
 * Comprehensive test suite
 * Clear and concise examples
 * Refactored Fields Schema generation
-* Add MySQL support
 
 Mid-term
 ========
@@ -21,10 +20,7 @@ Here we have all the features that is slightly further our:
 
 * Performance work:
     * Sub queries
-    * Benchmark suite
     * Bulk operations
-    * Minimizing overhead of building query set
-    * Minimizing overhead of creating objects
     * ...
 
 * Convenience/Ease-Of-Use work:
@@ -52,6 +48,7 @@ Here we have all the features that is slightly further our:
     * Ability to easily run arb code in a migration
     * Ability to get a the Models for that exact time of the migration, to ensure safe & consistent data migrations
     * Cross-DB support
+    * Fixtures as a property of a migration
 
 * Serialization support
     * Take inspiration from ``attrs`` and ``marshmallow``

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -17,18 +17,18 @@ You can do it like this:
     from tortoise.utils import generate_schema
 
     async def init():
-        # Here we connect to a PostgresQL DB
+        # Here we create a SQLite DB using file "db.sqlite3"
         #  also specify the app name of "models"
         #  which contain models from "app.models"
         await Tortoise.init(
-            db_url='postgres://postgres:qwerty123@localhost:5432/events',
+            db_url='sqlite://db.sqlite3',
             modules={'models': ['app.models']}
         )
         # Generate the schema
         await Tortoise.generate_schemas()
     
     
-Here we create connection to PostgresQL database with default ``asyncpg`` client and then we discover & initialise models.
+Here we create connection to SQLite database client and then we discover & initialise models.
 
 ``generate_schema`` generates schema on empty database, you shouldn't run it on every app init, run it just once, maybe out of your main code.
 

--- a/docs/toc.rst
+++ b/docs/toc.rst
@@ -2,7 +2,7 @@ Table Of Contents
 =================
 
 .. toctree::
-   :maxdepth: 4
+   :maxdepth: 5
    :includehidden:
 
    index

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -29,3 +29,5 @@ tox
 asynctest
 green
 coveralls
+pytest
+nose2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -31,7 +31,7 @@ docopt==0.6.2             # via coveralls
 docutils==0.14
 filelock==3.0.9           # via tox
 flake8-isort==2.5
-flake8==3.5.0             # via flake8-isort
+flake8==3.6.0             # via flake8-isort
 gitdb2==2.0.5             # via gitpython
 gitpython==2.1.11         # via bandit
 green==2.13.0
@@ -47,20 +47,20 @@ mypy-extensions==0.4.1    # via mypy
 mypy==0.641
 nose2==0.8.0
 packaging==18.0           # via sphinx
-pbr==5.0.0                # via stevedore
+pbr==5.1.0                # via stevedore
 pip-tools==3.1.0
 pluggy==0.8.0             # via pytest, tox
 py==1.7.0                 # via pytest, tox
-pycodestyle==2.3.1        # via flake8
+pycodestyle==2.4.0        # via flake8
 pycparser==2.19           # via cffi
-pyflakes==1.6.0           # via flake8
+pyflakes==2.0.0           # via flake8
 pygments==2.2.0
 pylint==2.1.1
 pymysql==0.9.2            # via aiomysql
 pyparsing==2.2.2          # via packaging
-pypika==0.15.7
-pytest==3.9.1
-pytz==2018.5              # via babel
+pypika==0.15.8
+pytest==3.9.3
+pytz==2018.6              # via babel
 pyyaml==3.13              # via bandit
 requests==2.20.0          # via coveralls, sphinx
 six==1.11.0               # via astroid, bandit, cryptography, more-itertools, nose2, packaging, pip-tools, pytest, sphinx, stevedore, tox
@@ -69,7 +69,7 @@ snowballstemmer==1.2.1    # via sphinx
 sphinx-autodoc-typehints==1.3.0
 sphinx==1.8.1
 sphinxcontrib-websupport==1.1.0  # via sphinx
-stevedore==1.29.0         # via bandit
+stevedore==1.30.0         # via bandit
 termstyle==0.1.11         # via green
 testfixtures==6.3.0       # via flake8-isort
 toml==0.10.0              # via tox

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,16 +13,18 @@ asn1crypto==0.24.0        # via cryptography
 astroid==2.0.4            # via pylint
 asyncpg==0.17.0
 asynctest==0.12.2
+atomicwrites==1.2.1       # via pytest
+attrs==18.2.0             # via pytest
 babel==2.6.0              # via sphinx
 bandit==1.5.1
-certifi==2018.8.24        # via requests
+certifi==2018.10.15       # via requests
 cffi==1.11.5              # via cryptography
 chardet==3.0.4            # via requests
 ciso8601==2.1.1
 click==7.0                # via pip-tools
 cloud-sptheme==1.9.4
 colorama==0.4.0           # via green
-coverage==4.5.1           # via coveralls, green
+coverage==4.5.1           # via coveralls, green, nose2
 coveralls==1.5.1
 cryptography==2.3.1       # via pymysql
 docopt==0.6.2             # via coveralls
@@ -40,13 +42,15 @@ jinja2==2.10              # via sphinx
 lazy-object-proxy==1.3.1  # via astroid
 markupsafe==1.0           # via jinja2
 mccabe==0.6.1             # via flake8, pylint
+more-itertools==4.3.0     # via pytest
 mypy-extensions==0.4.1    # via mypy
-mypy==0.630
+mypy==0.641
+nose2==0.8.0
 packaging==18.0           # via sphinx
-pbr==4.3.0                # via stevedore
+pbr==5.0.0                # via stevedore
 pip-tools==3.1.0
-pluggy==0.7.1             # via tox
-py==1.7.0                 # via tox
+pluggy==0.8.0             # via pytest, tox
+py==1.7.0                 # via pytest, tox
 pycodestyle==2.3.1        # via flake8
 pycparser==2.19           # via cffi
 pyflakes==1.6.0           # via flake8
@@ -55,10 +59,11 @@ pylint==2.1.1
 pymysql==0.9.2            # via aiomysql
 pyparsing==2.2.2          # via packaging
 pypika==0.15.7
+pytest==3.9.1
 pytz==2018.5              # via babel
 pyyaml==3.13              # via bandit
-requests==2.19.1          # via coveralls, sphinx
-six==1.11.0               # via astroid, bandit, cryptography, packaging, pip-tools, sphinx, stevedore, tox
+requests==2.20.0          # via coveralls, sphinx
+six==1.11.0               # via astroid, bandit, cryptography, more-itertools, nose2, packaging, pip-tools, pytest, sphinx, stevedore, tox
 smmap2==2.0.5             # via gitdb2
 snowballstemmer==1.2.1    # via sphinx
 sphinx-autodoc-typehints==1.3.0
@@ -71,7 +76,7 @@ toml==0.10.0              # via tox
 tox==3.5.2
 typed-ast==1.1.0          # via astroid, mypy
 unidecode==1.0.22         # via green
-urllib3==1.23             # via requests
+urllib3==1.24             # via requests
 virtualenv==16.0.0        # via tox
 wrapt==1.10.11            # via astroid
 yapf==0.24.0

--- a/tortoise/backends/asyncpg/client.py
+++ b/tortoise/backends/asyncpg/client.py
@@ -1,6 +1,6 @@
 import logging
 from functools import wraps
-from typing import List, SupportsInt, Optional  # noqa
+from typing import List, Optional, SupportsInt  # noqa
 
 import asyncpg
 from pypika import PostgreSQLQuery

--- a/tortoise/backends/base/config_generator.py
+++ b/tortoise/backends/base/config_generator.py
@@ -47,7 +47,7 @@ def expand_db_url(db_url: str, testing: bool = False) -> dict:
     if db.get('skip_first_char', True):
         path = url.path[1:]
     else:
-        path = url.path + url.netloc
+        path = url.netloc + url.path
 
     if not path:
         raise ConfigurationError('No path specified for DB_URL')

--- a/tortoise/backends/mysql/client.py
+++ b/tortoise/backends/mysql/client.py
@@ -1,6 +1,6 @@
 import logging
 from functools import wraps
-from typing import List, SupportsInt, Optional  # noqa
+from typing import List, Optional, SupportsInt  # noqa
 
 import aiomysql
 import pymysql

--- a/tortoise/contrib/test/__init__.py
+++ b/tortoise/contrib/test/__init__.py
@@ -1,20 +1,21 @@
-import asyncio as _asyncio
+import asyncio
 import os as _os
-from copy import deepcopy
-from typing import List
+from asyncio.selector_events import BaseSelectorEventLoop
+from typing import List, Optional
 from unittest import SkipTest, expectedFailure, skip, skipIf, skipUnless  # noqa
 
 from asynctest import TestCase as _TestCase
 from asynctest import _fail_on
+from asynctest.case import _Policy
 
-from tortoise import Tortoise
+from tortoise import ContextVar, Tortoise
 from tortoise.backends.base.config_generator import generate_config as _generate_config
 from tortoise.exceptions import DBConnectionError
-from tortoise.transactions import start_transaction
+from tortoise.transactions import current_transaction_map, start_transaction
 
 __all__ = ('SimpleTestCase', 'IsolatedTestCase', 'TestCase', 'SkipTest', 'expectedFailure',
            'skip', 'skipIf', 'skipUnless', 'initializer', 'finalizer')
-_TORTOISE_TEST_DB = _os.environ.get('TORTOISE_TEST_DB', 'sqlite:///tmp/test-{}.sqlite')
+_TORTOISE_TEST_DB = _os.environ.get('TORTOISE_TEST_DB', 'sqlite://:memory:')
 
 expectedFailure.__doc__ = """
 Mark test as expecting failiure.
@@ -23,8 +24,9 @@ On success it will be marked as unexpected success.
 """
 
 _CONFIG = {}  # type: dict
-_APPS = {}  # type: dict
 _CONNECTIONS = {}  # type: dict
+_SELECTOR = None  # type: ignore
+_LOOP = None  # type: BaseSelectorEventLoop
 
 
 def getDBConfig(app_label: str, modules: List[str]) -> dict:
@@ -52,33 +54,46 @@ async def _init_db(config):
     await Tortoise.generate_schemas()
 
 
-def initializer():
+def restore_default():
+    Tortoise.apps = {}
+    Tortoise._connections = _CONNECTIONS.copy()
+    for name in Tortoise._connections.keys():
+        current_transaction_map[name] = ContextVar(name, default=None)
+    Tortoise._init_apps(_CONFIG['apps'])
+    Tortoise._inited = True
+
+
+def initializer(loop: Optional[BaseSelectorEventLoop] = None) -> None:
     """
     Sets up the DB for testing. Must be called as part of test environment setup.
     """
     # pylint: disable=W0603
     global _CONFIG
-    global _APPS
     global _CONNECTIONS
+    global _SELECTOR
+    global _LOOP
     _CONFIG = getDBConfig(
         app_label='models',
         modules=['tortoise.tests.testmodels'],
     )
 
-    loop = _asyncio.get_event_loop()
+    loop = loop or asyncio.get_event_loop()
+    _LOOP = loop
+    _SELECTOR = loop._selector  # type: ignore
     loop.run_until_complete(_init_db(_CONFIG))
-    _APPS = deepcopy(Tortoise.apps)
     _CONNECTIONS = Tortoise._connections.copy()
-    loop.run_until_complete(Tortoise._reset_connections())
+    Tortoise.apps = {}
+    Tortoise._connections = {}
+    Tortoise._inited = False
 
 
-def finalizer():
+def finalizer() -> None:
     """
     Cleans up the DB after testing. Must be called as part of the test environment teardown.
     """
-    Tortoise.apps = deepcopy(_APPS)
-    Tortoise._connections = _CONNECTIONS.copy()
-    loop = _asyncio.get_event_loop()
+    restore_default()
+    loop = _LOOP
+    loop._selector = _SELECTOR
     loop.run_until_complete(Tortoise._drop_databases())
 
 
@@ -92,6 +107,21 @@ class SimpleTestCase(_TestCase):
 
     Based on `asynctest <http://asynctest.readthedocs.io/>`_
     """
+    use_default_loop = True
+
+    def __init_loop(self):
+        if self.use_default_loop:
+            self.loop = _LOOP
+            loop = None
+        else:
+            loop = self.loop = asyncio.new_event_loop()
+
+        policy = _Policy(asyncio.get_event_loop_policy(),
+                         loop, self.forbid_get_event_loop)
+
+        asyncio.set_event_loop_policy(policy)
+
+        self.loop = self._patch_loop(self.loop)
 
     async def _setUpDB(self):
         pass
@@ -109,7 +139,7 @@ class SimpleTestCase(_TestCase):
         self._checker.before_test(self)
 
         self.loop.run_until_complete(self._setUpDB())
-        if _asyncio.iscoroutinefunction(self.setUp):
+        if asyncio.iscoroutinefunction(self.setUp):
             self.loop.run_until_complete(self.setUp())
         else:
             self.setUp()
@@ -118,11 +148,15 @@ class SimpleTestCase(_TestCase):
         self.loop._asynctest_ran = False
 
     def _tearDown(self) -> None:
-        self.loop.run_until_complete(self._tearDownDB())
-        if _asyncio.iscoroutinefunction(self.tearDown):
+        if asyncio.iscoroutinefunction(self.tearDown):
             self.loop.run_until_complete(self.tearDown())
         else:
             self.tearDown()
+        self.loop.run_until_complete(self._tearDownDB())
+        Tortoise.apps = {}
+        Tortoise._connections = {}
+        Tortoise._inited = False
+        current_transaction_map.clear()
 
         # post-test checks
         self._checker.check_test(self)
@@ -148,8 +182,12 @@ class IsolatedTestCase(SimpleTestCase):
         )
         await Tortoise.init(config, _create_db=True)
         await Tortoise.generate_schemas()
+        self._connections = Tortoise._connections.copy()
 
     async def _tearDownDB(self) -> None:
+        Tortoise._connections = self._connections.copy()
+        for name in Tortoise._connections.keys():
+            current_transaction_map[name] = ContextVar(name, default=None)
         await Tortoise._drop_databases()
 
 
@@ -160,13 +198,9 @@ class TestCase(SimpleTestCase):
     """
 
     async def _setUpDB(self):
-        Tortoise.apps = deepcopy(_APPS)
-        Tortoise._connections = _CONNECTIONS.copy()
-        await Tortoise.init(_CONFIG)
-
+        restore_default()
         self.transaction = await start_transaction()  # pylint: disable=W0201
 
     async def _tearDownDB(self) -> None:
+        restore_default()
         await self.transaction.rollback()
-        # Have to reset connections because tests are run in different loops
-        await Tortoise._reset_connections()

--- a/tortoise/contrib/test/__init__.py
+++ b/tortoise/contrib/test/__init__.py
@@ -144,7 +144,7 @@ class SimpleTestCase(_TestCase):
     """
     use_default_loop = True
 
-    def __init_loop(self):
+    def _init_loop(self):
         if self.use_default_loop:
             self.loop = _LOOP
             loop = None

--- a/tortoise/contrib/test/nose2.py
+++ b/tortoise/contrib/test/nose2.py
@@ -1,0 +1,42 @@
+import logging
+
+from nose2.events import Plugin
+
+from tortoise.contrib.test import finalizer, initializer
+
+log = logging.getLogger('nose2.plugins.tortoise')
+
+
+class TortoisePlugin(Plugin):
+    # pylint: disable=E1101
+    configSection = 'tortoise'
+    alwaysOn = True
+
+    def __init__(self):
+        self.db_url = (self.config.as_str('db-url', '').strip() or 'sqlite://:memory:')
+        self.db_modules = self.config.as_list('db-module', [])
+        if not self.db_modules:
+            self.alwaysOn = False
+
+        group = self.session.pluginargs
+        group.add_argument(
+            '--db-module', action='append', default=[], metavar='MODULE',
+            dest='db_modules',
+            help='Tortoise ORM modules to build models from (REQUIRED) (multi-allowed)'
+        )
+        group.add_argument(
+            '--db-url', action='store', default='', metavar='URI',
+            dest='db_url',
+            help='Tortoise ORM test DB-URL'
+        )
+
+    def handleArgs(self, event):
+        """Get our options in order command line, config file, hard coded."""
+        self.db_url = event.args.db_url or self.db_url
+        self.db_modules = event.args.db_modules or self.db_modules
+
+    def startTestRun(self, event):
+        initializer(self.db_modules, db_url=self.db_url)
+
+    def stopTestRun(self, event):
+        finalizer()

--- a/tortoise/fields.py
+++ b/tortoise/fields.py
@@ -87,9 +87,11 @@ class CharField(Field):
     ``max_length`` (int):
         Maximum length of the field in characters.
     """
-    def __init__(self, max_length: int = 0, **kwargs) -> None:
+    def __init__(self, max_length: int = -24816, **kwargs) -> None:
+        if int(max_length) == -24816:
+            raise ConfigurationError("missing 'max_length' parameter")
         if int(max_length) < 1:
-            raise ConfigurationError('max_digits must be >= 1')
+            raise ConfigurationError("'max_length' must be >= 1")
         self.max_length = int(max_length)
         super().__init__(str, **kwargs)
 
@@ -121,11 +123,15 @@ class DecimalField(Field):
     ``decimal_places`` (int):
         How many of those signifigant digits is after the decimal point.
     """
-    def __init__(self, max_digits: int = 0, decimal_places: int = -1, **kwargs) -> None:
+    def __init__(self, max_digits: int = -24816, decimal_places: int = -24816, **kwargs) -> None:
+        if int(max_digits) == -24816:
+            raise ConfigurationError("missing 'max_digits' parameter")
         if int(max_digits) < 1:
-            raise ConfigurationError('max_digits must be >= 1')
+            raise ConfigurationError("'max_digits' must be >= 1")
+        if int(decimal_places) == -24816:
+            raise ConfigurationError("missing 'decimal_places' parameter")
         if int(decimal_places) < 0:
-            raise ConfigurationError('decimal_places must be >= 0')
+            raise ConfigurationError("'decimal_places' must be >= 0")
         super().__init__(Decimal, **kwargs)
         self.max_digits = max_digits
         self.decimal_places = decimal_places
@@ -145,7 +151,7 @@ class DatetimeField(Field):
     """
     def __init__(self, auto_now: bool = False, auto_now_add: bool = False, **kwargs) -> None:
         if auto_now_add and auto_now:
-            raise ConfigurationError('You can choose only auto_now or auto_now_add')
+            raise ConfigurationError("You can choose only 'auto_now' or 'auto_now_add'")
         super().__init__(datetime.datetime, **kwargs)
         self.auto_now = auto_now
         self.auto_now_add = auto_now | auto_now_add

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -206,8 +206,8 @@ class QuerySet(AwaitableQuery):
             elif key in self._available_custom_filters:
                 queryset._having[key] = value
             else:
-                allowed = sorted(list(self.model._meta.fields | self.model._meta.fetch_fields |
-                                      set(self._available_custom_filters)))
+                allowed = sorted(list(self.model._meta.fields | self.model._meta.fetch_fields
+                                      | set(self._available_custom_filters)))
                 raise FieldError("Unknown filter param '{}'. Allowed base values are {}".format(
                     key, allowed))
         return queryset

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -206,7 +206,10 @@ class QuerySet(AwaitableQuery):
             elif key in self._available_custom_filters:
                 queryset._having[key] = value
             else:
-                raise FieldError('unknown filter param {}'.format(key))
+                allowed = sorted(list(self.model._meta.fields | self.model._meta.fetch_fields |
+                                      set(self._available_custom_filters)))
+                raise FieldError("Unknown filter param '{}'. Allowed base values are {}".format(
+                    key, allowed))
         return queryset
 
     def order_by(self, *orderings: str) -> 'QuerySet':

--- a/tortoise/tests/test_db_url.py
+++ b/tortoise/tests/test_db_url.py
@@ -27,6 +27,15 @@ class TestConfigGenerator(test.SimpleTestCase):
             }
         })
 
+    def test_sqlite_relative_with_subdir(self):
+        res = expand_db_url('sqlite://data/db.sqlite')
+        self.assertDictEqual(res, {
+            'engine': 'tortoise.backends.sqlite',
+            'credentials': {
+                'file_path': 'data/db.sqlite',
+            }
+        })
+
     def test_sqlite_testing(self):
         res = expand_db_url(
             db_url='sqlite:///some/test-{}.sqlite',

--- a/tortoise/tests/test_fields.py
+++ b/tortoise/tests/test_fields.py
@@ -210,18 +210,18 @@ class TestDatetimeFields(test.TestCase):
         obj = await testmodels.DatetimeFields.get(id=obj0.id)
         self.assertEqual(obj.datetime, now)
         self.assertEqual(obj.datetime_null, None)
-        self.assertLess(obj.datetime_auto - now, timedelta(seconds=1))
-        self.assertLess(obj.datetime_add - now, timedelta(seconds=1))
+        self.assertLess(obj.datetime_auto - now, timedelta(microseconds=10000))
+        self.assertLess(obj.datetime_add - now, timedelta(microseconds=10000))
         datetime_auto = obj.datetime_auto
-        sleep(1)
+        sleep(0.011)
         await obj.save()
         obj2 = await testmodels.DatetimeFields.get(id=obj.id)
         self.assertEqual(obj2.datetime, now)
         self.assertEqual(obj2.datetime_null, None)
         self.assertEqual(obj2.datetime_auto, obj.datetime_auto)
         self.assertNotEqual(obj2.datetime_auto, datetime_auto)
-        self.assertGreater(obj2.datetime_auto - now, timedelta(seconds=1))
-        self.assertLess(obj2.datetime_auto - now, timedelta(seconds=2))
+        self.assertGreater(obj2.datetime_auto - now, timedelta(microseconds=10000))
+        self.assertLess(obj2.datetime_auto - now, timedelta(microseconds=20000))
         self.assertEqual(obj2.datetime_add, obj.datetime_add)
 
     async def test_cast(self):

--- a/tortoise/tests/test_fields.py
+++ b/tortoise/tests/test_fields.py
@@ -8,33 +8,6 @@ from tortoise.exceptions import ConfigurationError, IntegrityError
 from tortoise.tests import testmodels
 
 
-class TestFieldErrors(test.SimpleTestCase):
-
-    def test_char_field_empty(self):
-        with self.assertRaises(ConfigurationError):
-            fields.CharField()
-
-    def test_char_field_zero(self):
-        with self.assertRaises(ConfigurationError):
-            fields.CharField(max_length=0)
-
-    def test_decimal_field_empty(self):
-        with self.assertRaises(ConfigurationError):
-            fields.DecimalField()
-
-    def test_decimal_field_neg_digits(self):
-        with self.assertRaises(ConfigurationError):
-            fields.DecimalField(max_digits=0, decimal_places=2)
-
-    def test_decimal_field_neg_decimal(self):
-        with self.assertRaises(ConfigurationError):
-            fields.DecimalField(max_digits=2, decimal_places=-1)
-
-    def test_datetime_field_auto_bad(self):
-        with self.assertRaises(ConfigurationError):
-            fields.DatetimeField(auto_now=True, auto_now_add=True)
-
-
 class TestIntFields(test.TestCase):
     async def test_empty(self):
         with self.assertRaises(IntegrityError):
@@ -92,6 +65,14 @@ class TestSmallIntFields(test.TestCase):
 
 
 class TestCharFields(test.TestCase):
+    def test_max_length_missing(self):
+        with self.assertRaisesRegex(ConfigurationError, "missing 'max_length' parameter"):
+            fields.CharField()
+
+    def test_max_length_bad(self):
+        with self.assertRaisesRegex(ConfigurationError, "'max_length' must be >= 1"):
+            fields.CharField(max_length=0)
+
     async def test_empty(self):
         with self.assertRaises(IntegrityError):
             await testmodels.CharFields.create()
@@ -172,6 +153,22 @@ class TestBooleanFields(test.TestCase):
 
 
 class TestDecimalFields(test.TestCase):
+    def test_max_digits_empty(self):
+        with self.assertRaisesRegex(ConfigurationError, "missing 'max_digits' parameter"):
+            fields.DecimalField()
+
+    def test_decimal_places_empty(self):
+        with self.assertRaisesRegex(ConfigurationError, "missing 'decimal_places' parameter"):
+            fields.DecimalField(max_digits=1)
+
+    def test_max_fields_bad(self):
+        with self.assertRaisesRegex(ConfigurationError, "'max_digits' must be >= 1"):
+            fields.DecimalField(max_digits=0, decimal_places=2)
+
+    def test_decimal_places_bad(self):
+        with self.assertRaisesRegex(ConfigurationError, "'decimal_places' must be >= 0"):
+            fields.DecimalField(max_digits=2, decimal_places=-1)
+
     async def test_empty(self):
         with self.assertRaises(IntegrityError):
             await testmodels.DecimalFields.create()
@@ -200,6 +197,11 @@ class TestDecimalFields(test.TestCase):
 
 
 class TestDatetimeFields(test.TestCase):
+    def test_both_auto_bad(self):
+        with self.assertRaisesRegex(ConfigurationError,
+                                    "You can choose only 'auto_now' or 'auto_now_add'"):
+            fields.DatetimeField(auto_now=True, auto_now_add=True)
+
     async def test_empty(self):
         with self.assertRaises(IntegrityError):
             await testmodels.DatetimeFields.create()

--- a/tortoise/tests/test_filters.py
+++ b/tortoise/tests/test_filters.py
@@ -1,4 +1,5 @@
 from tortoise.contrib import test
+from tortoise.exceptions import FieldError
 from tortoise.tests.testmodels import CharFields
 
 
@@ -7,6 +8,11 @@ class TestFieldFilters(test.TestCase):
         await CharFields.create(char='moo')
         await CharFields.create(char='baa', char_null='baa')
         await CharFields.create(char='oink')
+
+    async def test_bad_param(self):
+        with self.assertRaisesRegex(FieldError,
+                                    "Unknown filter param 'charup'. Allowed base values are"):
+            await CharFields.filter(charup='moo')
 
     async def test_equal(self):
         self.assertEqual(

--- a/tortoise/tests/test_init.py
+++ b/tortoise/tests/test_init.py
@@ -10,7 +10,9 @@ from tortoise.exceptions import ConfigurationError
 class TestInitErrors(test.SimpleTestCase):
     async def setUp(self):
         try:
-            await Tortoise._reset_connections()
+            Tortoise.apps = {}
+            Tortoise._connections = {}
+            Tortoise._inited = False
         except ConfigurationError:
             pass
         Tortoise._inited = False
@@ -20,10 +22,8 @@ class TestInitErrors(test.SimpleTestCase):
         )
 
     async def tearDown(self):
-        try:
-            await Tortoise._reset_connections()
-        except ConfigurationError:
-            pass
+        await Tortoise.close_connections()
+        await Tortoise._reset_apps()
 
     async def test_basic_init(self):
         await Tortoise.init({

--- a/tortoise/transactions.py
+++ b/tortoise/transactions.py
@@ -1,5 +1,5 @@
 from functools import wraps
-from typing import Callable, Optional, Dict  # noqa
+from typing import Callable, Dict, Optional  # noqa
 
 from tortoise.backends.base.client import BaseDBAsyncClient, BaseTransactionWrapper
 from tortoise.exceptions import ParamsError
@@ -15,7 +15,8 @@ def _get_connection(connection_name: Optional[str]) -> BaseDBAsyncClient:
         connection = list(Tortoise._connections.values())[0]
     else:
         raise ParamsError(
-            'You are running with multiple databases, so you should specify connection_name'
+            'You are running with multiple databases, so you should specify connection_name: {}'
+            .format(list(Tortoise._connections.keys()))
         )
     return connection
 
@@ -31,8 +32,7 @@ def in_transaction(connection_name: Optional[str] = None) -> BaseTransactionWrap
                             one db connection
     """
     connection = _get_connection(connection_name)
-    single_connection = connection._in_transaction()
-    return single_connection
+    return connection._in_transaction()
 
 
 def atomic(connection_name: Optional[str] = None) -> Callable:

--- a/tox.ini
+++ b/tox.ini
@@ -17,4 +17,4 @@ setenv=
 [flake8]
 max-line-length = 100
 exclude =
-ignore = W503,E126
+ignore = W503,E126,W606


### PR DESCRIPTION
* [x] Does not re-create connections per test, so now tests pass when using an SQLite in-memory database
* [x] Can pass event loop to test initializer function: `initializer(loop=loop)`
* [x] `nose2` plugin & docs
* [x] `py.test` usage docs
* [x] Fixed Test runner autodoc ignoring the test classes as it had `asynctest` blacklisted.
* [x] Minor doc cleanup

