### PR TITLE
Remove generate_schema import from documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,7 +113,6 @@ You can do it like this:
 .. code-block:: python3
 
     from tortoise import Tortoise
-    from tortoise.utils import generate_schema
 
     async def init():
         # Here we connect to a PostgresQL DB

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -68,7 +68,6 @@ You can do it like this:
 .. code-block:: python3
 
     from tortoise import Tortoise
-    from tortoise.utils import generate_schema
 
     async def init():
         # Here we connect to a PostgresQL DB

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -14,7 +14,6 @@ You can do it like this:
 .. code-block:: python3
 
     from tortoise import Tortoise
-    from tortoise.utils import generate_schema
 
     async def init():
         # Here we connect to a PostgresQL DB


### PR DESCRIPTION
## Description

I removed all occurrences in documentation of obsolete import:

```python
from tortoise.utils import generate_schema
```
As we know directly use:

```python
Tortoise.generate_schemas()
```

## Motivation and Context

Remove this avoid an error when copy pasting example code from documentation, it's more serious ;-)

## How Has This Been Tested?

I've just copy-pasted the documentation and know it's working well

## Checklist:

- [ ] My code follows the code style of this project. **Not applicable**
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes. **Not applicable**
- [ ] All new and existing tests passed. **Not applicable**

