### PR TITLE
Make use of pypika objects being immutable, and pre-build as much of the query as possible.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog
 -------
 - Pre-build some query & filters statically, 15-30% speed up for smaller queries.
 - Required field params are now positional, so Python and IDE linters will pick up on it easier.
+- Filtering also applies DB-specific transforms, Fixes #62
 
 0.10.10
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 0.10.11
 -------
 - Pre-build some query & filters statically, 15-30% speed up for smaller queries.
+- Required field params are now positional, so Python and IDE linters will pick up on it easier.
 
 0.10.10
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+0.10.11
+-------
+- Pre-build some query & filters statically, 15-30% speed up for smaller queries.
+
 0.10.10
 -------
 - Refactor ``Tortoise.init()`` and test runner to not re-create connections per test, so now tests pass when using an SQLite in-memory database

--- a/README.rst
+++ b/README.rst
@@ -115,18 +115,18 @@ You can do it like this:
     from tortoise import Tortoise
 
     async def init():
-        # Here we connect to a PostgresQL DB
+        # Here we connect to a SQLite DB file.
         # also specify the app name of "models"
         # which contain models from "app.models"
         await Tortoise.init(
-            db_url='postgres://postgres:qwerty123@localhost:5432/events',
+            db_url='sqlite://db.sqlite3',
             modules={'models': ['app.models']}
         )
         # Generate the schema
         await Tortoise.generate_schemas()
 
 
-Here we create connection to PostgresQL database with default ``asyncpg`` client and then we discover & initialise models.
+Here we create connection to SQLite database in the local directory called ``db.sqlite3``, and then we discover & initialise models.
 
 ``generate_schema`` generates schema on empty database, you shouldn't run it on every app init, run it just once, maybe out of your main code.
 

--- a/README.rst
+++ b/README.rst
@@ -128,6 +128,12 @@ You can do it like this:
 
 Here we create connection to SQLite database in the local directory called ``db.sqlite3``, and then we discover & initialise models.
 
+Tortoise ORM currently supports the following databases:
+
+* SQLite
+* PostgreSQL (requires ``asyncpg``)
+* MySQL (requires ``aiomysql``)
+
 ``generate_schema`` generates schema on empty database, you shouldn't run it on every app init, run it just once, maybe out of your main code.
 
 After that you can start using your models:

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -5,7 +5,6 @@
 ## Database Drivers
 asyncpg
 aiomysql
-aiosqlite
 
 # Dev Tools
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,11 +7,11 @@
 aenum==2.0.8              # via pypika
 aiocontextvars==0.1.2 ; python_version < "3.7"
 aiomysql==0.0.19
-aiosqlite==0.7.0
+aiosqlite==0.8.0
 alabaster==0.7.12         # via sphinx
 asn1crypto==0.24.0        # via cryptography
 astroid==2.0.4            # via pylint
-asyncpg==0.17.0
+asyncpg==0.18.1
 asynctest==0.12.2
 atomicwrites==1.2.1       # via pytest
 attrs==18.2.0             # via pytest
@@ -29,7 +29,7 @@ coveralls==1.5.1
 cryptography==2.3.1       # via pymysql
 docopt==0.6.2             # via coveralls
 docutils==0.14
-filelock==3.0.9           # via tox
+filelock==3.0.10          # via tox
 flake8-isort==2.5
 flake8==3.6.0             # via flake8-isort
 gitdb2==2.0.5             # via gitpython
@@ -40,14 +40,14 @@ imagesize==1.1.0          # via sphinx
 isort==4.3.4              # via flake8-isort, pylint
 jinja2==2.10              # via sphinx
 lazy-object-proxy==1.3.1  # via astroid
-markupsafe==1.0           # via jinja2
+markupsafe==1.1.0         # via jinja2
 mccabe==0.6.1             # via flake8, pylint
 more-itertools==4.3.0     # via pytest
 mypy-extensions==0.4.1    # via mypy
 mypy==0.641
 nose2==0.8.0
 packaging==18.0           # via sphinx
-pbr==5.1.0                # via stevedore
+pbr==5.1.1                # via stevedore
 pip-tools==3.1.0
 pluggy==0.8.0             # via pytest, tox
 py==1.7.0                 # via pytest, tox
@@ -57,12 +57,12 @@ pyflakes==2.0.0           # via flake8
 pygments==2.2.0
 pylint==2.1.1
 pymysql==0.9.2            # via aiomysql
-pyparsing==2.2.2          # via packaging
-pypika==0.15.8
-pytest==3.9.3
-pytz==2018.6              # via babel
+pyparsing==2.3.0          # via packaging
+pypika==0.16.1
+pytest==3.10.0
+pytz==2018.7              # via babel
 pyyaml==3.13              # via bandit
-requests==2.20.0          # via coveralls, sphinx
+requests==2.20.1          # via coveralls, sphinx
 six==1.11.0               # via astroid, bandit, cryptography, more-itertools, nose2, packaging, pip-tools, pytest, sphinx, stevedore, tox
 smmap2==2.0.5             # via gitdb2
 snowballstemmer==1.2.1    # via sphinx
@@ -73,10 +73,10 @@ stevedore==1.30.0         # via bandit
 termstyle==0.1.11         # via green
 testfixtures==6.3.0       # via flake8-isort
 toml==0.10.0              # via tox
-tox==3.5.2
+tox==3.5.3
 typed-ast==1.1.0          # via astroid, mypy
 unidecode==1.0.22         # via green
-urllib3==1.24             # via requests
-virtualenv==16.0.0        # via tox
+urllib3==1.24.1           # via requests
+virtualenv==16.1.0        # via tox
 wrapt==1.10.11            # via astroid
 yapf==0.24.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pypika>=0.15.6,<1.0
+pypika>=0.16.0
 ciso8601>=2.0
 aiocontextvars==0.1.2;python_version<"3.7"
 aiosqlite>=0.7.0

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -214,7 +214,10 @@ class Tortoise:
     def _build_initial_querysets(cls):
         for app in cls.apps.values():
             for model in app.values():
+                model._meta.override_filters()
                 model._meta.basequery = model._meta.db.query_class.from_(model._meta.table)
+                model._meta.basequery_all_fields = model._meta.basequery.select(
+                    *model._meta.db_fields)
 
     @classmethod
     async def init(

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -214,7 +214,7 @@ class Tortoise:
     def _build_initial_querysets(cls):
         for app in cls.apps.values():
             for model in app.values():
-                model._meta.override_filters()
+                model._meta.generate_filters()
                 model._meta.basequery = model._meta.db.query_class.from_(model._meta.table)
                 model._meta.basequery_all_fields = model._meta.basequery.select(
                     *model._meta.db_fields)

--- a/tortoise/aggregation.py
+++ b/tortoise/aggregation.py
@@ -10,6 +10,8 @@ from tortoise.exceptions import ConfigurationError
 
 
 class Aggregate:
+    __slots__ = ('field', )
+
     aggregation_func = AggregateFunction
 
     def __init__(self, field) -> None:

--- a/tortoise/backends/asyncpg/client.py
+++ b/tortoise/backends/asyncpg/client.py
@@ -204,13 +204,3 @@ class TransactionWrapper(AsyncpgDBClient, BaseTransactionWrapper):
             await self._pool.release(self._connection)
             self._connection = None
         current_transaction_map[self.connection_name].set(self._old_context_value)
-
-    async def __aenter__(self):
-        await self.start()
-        return self
-
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
-        if exc_type:
-            await self.rollback()
-        else:
-            await self.commit()

--- a/tortoise/backends/base/client.py
+++ b/tortoise/backends/base/client.py
@@ -55,6 +55,8 @@ class BaseDBAsyncClient:
 
 
 class ConnectionWrapper:
+    __slots__ = ('connection', )
+
     def __init__(self, connection):
         self.connection = connection
 
@@ -105,7 +107,11 @@ class BaseTransactionWrapper:
         raise NotImplementedError()  # pragma: nocoverage
 
     async def __aenter__(self):
-        raise NotImplementedError()  # pragma: nocoverage
+        await self.start()
+        return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
-        raise NotImplementedError()  # pragma: nocoverage
+        if exc_type:
+            await self.rollback()
+        else:
+            await self.commit()

--- a/tortoise/backends/base/executor.py
+++ b/tortoise/backends/base/executor.py
@@ -96,7 +96,7 @@ class BaseExecutor:
 
     async def execute_delete(self, instance):
         table = Table(self.model._meta.table)
-        query = self.db.query_class.from_(table).where(table.id == instance.id).delete()
+        query = self.model._meta.basequery.where(table.id == instance.id).delete()
         await self.db.execute_query(str(query))
         return instance
 

--- a/tortoise/backends/base/executor.py
+++ b/tortoise/backends/base/executor.py
@@ -43,9 +43,10 @@ class BaseExecutor:
         result_columns = [self.model._meta.fields_db_projection[c] for c in regular_columns]
         return regular_columns, result_columns
 
-    def _field_to_db(self, field_object, attr, instance):
-        if field_object.__class__ in self.TO_DB_OVERRIDE:
-            return self.TO_DB_OVERRIDE[field_object.__class__](field_object, attr, instance)
+    @classmethod
+    def _field_to_db(cls, field_object, attr, instance):
+        if field_object.__class__ in cls.TO_DB_OVERRIDE:
+            return cls.TO_DB_OVERRIDE[field_object.__class__](field_object, attr, instance)
         return field_object.to_db_value(attr, instance)
 
     def _prepare_insert_values(self, instance, regular_columns):

--- a/tortoise/backends/mysql/client.py
+++ b/tortoise/backends/mysql/client.py
@@ -6,8 +6,8 @@ import aiomysql
 import pymysql
 from pypika import MySQLQuery
 
-from tortoise.backends.base.client import (BaseDBAsyncClient, ConnectionWrapper,
-                                           SingleConnectionWrapper)
+from tortoise.backends.base.client import (BaseDBAsyncClient, BaseTransactionWrapper,
+                                           ConnectionWrapper, SingleConnectionWrapper)
 from tortoise.backends.mysql.executor import MySQLExecutor
 from tortoise.backends.mysql.schema_generator import MySQLSchemaGenerator
 from tortoise.exceptions import (ConfigurationError, DBConnectionError, IntegrityError,
@@ -155,7 +155,7 @@ class MySQLClient(BaseDBAsyncClient):
             await self._db_pool.release(single_connection.connection)
 
 
-class TransactionWrapper(MySQLClient):
+class TransactionWrapper(MySQLClient, BaseTransactionWrapper):
     def __init__(self, connection_name, pool=None, connection=None):
         if pool and connection:
             raise ConfigurationError('You must pass either connection or pool')
@@ -204,13 +204,3 @@ class TransactionWrapper(MySQLClient):
             await self._pool.release(self._connection)
             self._connection = None
         current_transaction_map[self.connection_name].set(self._old_context_value)
-
-    async def __aenter__(self):
-        await self.start()
-        return self
-
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
-        if exc_type:
-            await self.rollback()
-        else:
-            await self.commit()

--- a/tortoise/backends/sqlite/client.py
+++ b/tortoise/backends/sqlite/client.py
@@ -123,13 +123,3 @@ class TransactionWrapper(SqliteClient, BaseTransactionWrapper):
         self._finalized = True
         await self._connection.commit()
         current_transaction_map[self.connection_name].set(self._old_context_value)
-
-    async def __aenter__(self):
-        await self.start()
-        return self
-
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
-        if exc_type:
-            await self.rollback()
-        else:
-            await self.commit()

--- a/tortoise/fields.py
+++ b/tortoise/fields.py
@@ -27,6 +27,9 @@ class Field:
     """
     Base Field type.
     """
+    __slots__ = ('type', 'source_field', 'generated', 'pk', 'default', 'null', 'unique',
+                 'model_field_name')
+
     def __init__(
         self,
         type=None,  # pylint: disable=W0622
@@ -63,6 +66,8 @@ class IntField(Field):
     ``pk`` (bool):
         True if field is Primary Key.
     """
+    __slots__ = ('reference', )
+
     def __init__(self, pk: bool = False, **kwargs) -> None:
         kwargs['generated'] = bool(kwargs.get('generated')) | pk
         super().__init__(int, **kwargs)
@@ -74,6 +79,8 @@ class SmallIntField(Field):
     """
     Small integer field.
     """
+    __slots__ = ()
+
     def __init__(self, **kwargs) -> None:
         super().__init__(int, **kwargs)
 
@@ -87,6 +94,8 @@ class CharField(Field):
     ``max_length`` (int):
         Maximum length of the field in characters.
     """
+    __slots__ = ('max_length', )
+
     def __init__(self, max_length: int, **kwargs) -> None:
         if int(max_length) < 1:
             raise ConfigurationError("'max_length' must be >= 1")
@@ -98,6 +107,8 @@ class TextField(Field):
     """
     Large Text field.
     """
+    __slots__ = ()
+
     def __init__(self, **kwargs) -> None:
         super().__init__(str, **kwargs)
 
@@ -106,6 +117,8 @@ class BooleanField(Field):
     """
     Boolean field.
     """
+    __slots__ = ()
+
     def __init__(self, **kwargs) -> None:
         super().__init__(bool, **kwargs)
 
@@ -121,6 +134,8 @@ class DecimalField(Field):
     ``decimal_places`` (int):
         How many of those signifigant digits is after the decimal point.
     """
+    __slots__ = ('max_digits', 'decimal_places')
+
     def __init__(self, max_digits: int, decimal_places: int, **kwargs) -> None:
         if int(max_digits) < 1:
             raise ConfigurationError("'max_digits' must be >= 1")
@@ -143,6 +158,8 @@ class DatetimeField(Field):
     ``auto_now_add`` (bool):
         Set to ``datetime.utcnow()`` on first save only.
     """
+    __slots__ = ('auto_now', 'auto_now_add')
+
     def __init__(self, auto_now: bool = False, auto_now_add: bool = False, **kwargs) -> None:
         if auto_now_add and auto_now:
             raise ConfigurationError("You can choose only 'auto_now' or 'auto_now_add'")
@@ -171,6 +188,8 @@ class DateField(Field):
     """
     Date field.
     """
+    __slots__ = ()
+
     def __init__(self, **kwargs) -> None:
         super().__init__(datetime.date, **kwargs)
 
@@ -184,6 +203,8 @@ class FloatField(Field):
     """
     Float (double) field.
     """
+    __slots__ = ()
+
     def __init__(self, **kwargs) -> None:
         super().__init__(float, **kwargs)
 
@@ -199,6 +220,8 @@ class JSONField(Field):
     ``decoder``:
         The JSON decoder. The default is recommemded.
     """
+    __slots__ = ('encoder', 'decoder')
+
     def __init__(self, encoder=JSON_DUMPS, decoder=JSON_LOADS, **kwargs) -> None:
         super().__init__((dict, list), **kwargs)
         self.encoder = encoder
@@ -244,6 +267,8 @@ class ForeignKeyField(Field):
                 Resets the field to ``default`` value in case the related model gets deleted.
                 Can only be set is field has a ``default`` set.
     """
+    __slots__ = ('model_name', 'related_name', 'on_delete')
+
     def __init__(
         self,
         model_name: str,
@@ -288,6 +313,9 @@ class ManyToManyField(Field):
     ``related_name``:
         The attribute name on the related model to reverse resolve the many to many.
     """
+    __slots__ = ('model_name', 'related_name', 'forward_key', 'backward_key', 'through',
+                 '_generated')
+
     def __init__(
         self,
         model_name: str,
@@ -311,12 +339,17 @@ class ManyToManyField(Field):
 
 
 class BackwardFKRelation:
+    __slots__ = ('type', 'relation_field')
+
     def __init__(self, type, relation_field, **kwargs):  # pylint: disable=W0622
         self.type = type
         self.relation_field = relation_field
 
 
 class RelationQueryContainer:
+    __slots__ = ('model', 'relation_field', 'instance', '_fetched', '_custom_query',
+                 'related_objects')
+
     def __init__(self, model, relation_field, instance, is_new):
         self.model = model
         self.relation_field = relation_field
@@ -403,6 +436,8 @@ class RelationQueryContainer:
 
 
 class ManyToManyRelationManager(RelationQueryContainer):
+    __slots__ = ('field', 'model', 'instance')
+
     def __init__(self, model, instance, m2m_field, is_new):
         super().__init__(model, m2m_field.related_name, instance, is_new)
         self.field = m2m_field

--- a/tortoise/fields.py
+++ b/tortoise/fields.py
@@ -87,9 +87,7 @@ class CharField(Field):
     ``max_length`` (int):
         Maximum length of the field in characters.
     """
-    def __init__(self, max_length: int = -24816, **kwargs) -> None:
-        if int(max_length) == -24816:
-            raise ConfigurationError("missing 'max_length' parameter")
+    def __init__(self, max_length: int, **kwargs) -> None:
         if int(max_length) < 1:
             raise ConfigurationError("'max_length' must be >= 1")
         self.max_length = int(max_length)
@@ -123,13 +121,9 @@ class DecimalField(Field):
     ``decimal_places`` (int):
         How many of those signifigant digits is after the decimal point.
     """
-    def __init__(self, max_digits: int = -24816, decimal_places: int = -24816, **kwargs) -> None:
-        if int(max_digits) == -24816:
-            raise ConfigurationError("missing 'max_digits' parameter")
+    def __init__(self, max_digits: int, decimal_places: int, **kwargs) -> None:
         if int(max_digits) < 1:
             raise ConfigurationError("'max_digits' must be >= 1")
-        if int(decimal_places) == -24816:
-            raise ConfigurationError("missing 'decimal_places' parameter")
         if int(decimal_places) < 0:
             raise ConfigurationError("'decimal_places' must be >= 0")
         super().__init__(Decimal, **kwargs)

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -254,7 +254,7 @@ class MetaInfo:
     def get_filter(self, key):
         return self.filters[key]
 
-    def override_filters(self):
+    def generate_filters(self):
         get_overridden_filter_func = self.db.executor_class.get_overridden_filter_func
         for key, filter_info in self._filters.items():
             overridden_operator = get_overridden_filter_func(
@@ -267,6 +267,8 @@ class MetaInfo:
 
 
 class ModelMeta(type):
+    __slots__ = ()
+
     def __new__(mcs, name, bases, attrs, *args, **kwargs):
         fields_db_projection = {}  # type: Dict[str,str]
         fields_map = {}  # type: Dict[str, fields.Field]

--- a/tortoise/query_utils.py
+++ b/tortoise/query_utils.py
@@ -5,6 +5,8 @@ from tortoise.exceptions import OperationalError
 
 
 class Q:  # pylint: disable=C0103
+    __slots__ = ('children', 'filters', 'join_type')
+
     AND = 'AND'
     OR = 'OR'
 
@@ -121,6 +123,8 @@ class Q:  # pylint: disable=C0103
 
 
 class Prefetch:
+    __slots__ = ('relation', 'queryset')
+
     def __init__(self, relation, queryset):
         self.relation = relation
         self.queryset = queryset

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -1,4 +1,4 @@
-from copy import deepcopy
+from copy import copy
 from typing import Any, Dict, List, Optional, Set, Tuple  # noqa
 
 from pypika import JoinType, Order, Table
@@ -161,23 +161,26 @@ class QuerySet(AwaitableQuery):
         self._available_custom_filters = {}  # type: Dict[str, dict]
 
     def _clone(self) -> 'QuerySet':
-        queryset = self.__class__(self.model)
-        queryset._prefetch_map = deepcopy(self._prefetch_map)
-        queryset._prefetch_queries = deepcopy(self._prefetch_queries)
+        queryset = QuerySet.__new__(QuerySet)
+        queryset.fields = self.fields
+        queryset.model = self.model
+        queryset.query = self.query
+        queryset._prefetch_map = copy(self._prefetch_map)
+        queryset._prefetch_queries = copy(self._prefetch_queries)
         queryset._single = self._single
         queryset._get = self._get
         queryset._count = self._count
         queryset._db = self._db
         queryset._limit = self._limit
         queryset._offset = self._offset
-        queryset._filter_kwargs = deepcopy(self._filter_kwargs)
-        queryset._orderings = deepcopy(self._orderings)
-        queryset._joined_tables = deepcopy(self._joined_tables)
-        queryset._q_objects_for_resolve = deepcopy(self._q_objects_for_resolve)
+        queryset._filter_kwargs = copy(self._filter_kwargs)
+        queryset._orderings = copy(self._orderings)
+        queryset._joined_tables = copy(self._joined_tables)
+        queryset._q_objects_for_resolve = copy(self._q_objects_for_resolve)
         queryset._distinct = self._distinct
-        queryset._annotations = deepcopy(self._annotations)
-        queryset._having = deepcopy(self._having)
-        queryset._available_custom_filters = deepcopy(self._available_custom_filters)
+        queryset._annotations = copy(self._annotations)
+        queryset._having = copy(self._having)
+        queryset._available_custom_filters = copy(self._available_custom_filters)
         return queryset
 
     def filter(self, *args, **kwargs) -> 'QuerySet':

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -449,9 +449,7 @@ class QuerySet(AwaitableQuery):
             self.query = self.query.select(aggregation_info['field'].as_(key))
 
     def _make_query(self):
-        db = self._db if self._db else self.model._meta.db
-        table = Table(self.model._meta.table)
-        self.query = db.query_class.from_(table).select(*self.fields)
+        self.query = self.model._meta.basequery.select(*self.fields)
         self._resolve_annotate()
         self.resolve_filters(
             model=self.model,
@@ -542,8 +540,7 @@ class DeleteQuery(AwaitableQuery):
     def __init__(self, model, filter_kwargs, db, q_objects, annotations, having, custom_filters):
         super().__init__()
         self._db = db if db else model._meta.db
-        table = Table(model._meta.table)
-        self.query = self._db.query_class.from_(table)
+        self.query = model._meta.basequery
         self.resolve_filters(
             model=model,
             filter_kwargs=filter_kwargs,
@@ -563,7 +560,7 @@ class CountQuery(AwaitableQuery):
         super().__init__()
         self._db = db if db else model._meta.db
         table = Table(model._meta.table)
-        self.query = self._db.query_class.from_(table)
+        self.query = model._meta.basequery
         self.resolve_filters(
             model=model,
             filter_kwargs=filter_kwargs,
@@ -673,9 +670,8 @@ class ValuesListQuery(FieldSelectQuery):
             raise TypeError('You can flat value_list only if contains one field')
 
         self.model = model
-        table = Table(model._meta.table)
         self._db = db if db else model._meta.db
-        self.query = self._db.query_class.from_(table)
+        self.query = model._meta.basequery
         fields_for_select = {str(i): field for i, field in enumerate(fields_for_select_list)}
 
         for positional_number, field in fields_for_select.items():
@@ -718,9 +714,8 @@ class ValuesQuery(FieldSelectQuery):
     ):
         super().__init__()
         self.model = model
-        table = Table(model._meta.table)
         self._db = db if db else model._meta.db
-        self.query = self._db.query_class.from_(table)
+        self.query = model._meta.basequery
         for returns_as, field in fields_for_select.items():
             self.add_field_to_select_query(field, returns_as)
 

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -716,7 +716,7 @@ class ValuesListQuery(FieldSelectQuery):
         if self.flat:
             func = columns[0][1]
             return [func(entry['0']) for entry in result]
-        return [(func(entry[column]) for column, func in columns) for entry in result]
+        return [tuple(func(entry[column]) for column, func in columns) for entry in result]
 
 
 class ValuesQuery(FieldSelectQuery):

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -449,7 +449,7 @@ class QuerySet(AwaitableQuery):
             self.query = self.query.select(aggregation_info['field'].as_(key))
 
     def _make_query(self):
-        self.query = self.model._meta.basequery.select(*self.fields)
+        self.query = self.model._meta.basequery_all_fields
         self._resolve_annotate()
         self.resolve_filters(
             model=self.model,

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -132,7 +132,7 @@ class AwaitableQuery:
 
 
 class QuerySet(AwaitableQuery):
-    __slots__ = ('_joined_tables', 'query', 'model', 'fields', '_prefetch_map', '_prefetch_queries',
+    __slots__ = ('fields', '_prefetch_map', '_prefetch_queries',
                  '_single', '_get', '_count', '_db', '_limit', '_offset', '_filter_kwargs',
                  '_orderings', '_q_objects_for_resolve', '_distinct',
                  '_annotations', '_having', '_available_custom_filters')
@@ -505,6 +505,8 @@ class QuerySet(AwaitableQuery):
 
 
 class UpdateQuery(AwaitableQuery):
+    __slots__ = ('_db', )
+
     def __init__(
         self, model, filter_kwargs, update_kwargs, db, q_objects, annotations, having,
         custom_filters
@@ -540,6 +542,8 @@ class UpdateQuery(AwaitableQuery):
 
 
 class DeleteQuery(AwaitableQuery):
+    __slots__ = ('_db', )
+
     def __init__(self, model, filter_kwargs, db, q_objects, annotations, having, custom_filters):
         super().__init__()
         self._db = db if db else model._meta.db
@@ -559,6 +563,8 @@ class DeleteQuery(AwaitableQuery):
 
 
 class CountQuery(AwaitableQuery):
+    __slots__ = ('_db', )
+
     def __init__(self, model, filter_kwargs, db, q_objects, annotations, having, custom_filters):
         super().__init__()
         self._db = db if db else model._meta.db
@@ -581,6 +587,7 @@ class CountQuery(AwaitableQuery):
 
 class FieldSelectQuery(AwaitableQuery):
     # pylint: disable=W0223
+    __slots__ = ()
 
     def _join_table_with_forwarded_fields(self, model, field, forwarded_fields):
         table = Table(model._meta.table)
@@ -664,6 +671,8 @@ class FieldSelectQuery(AwaitableQuery):
 
 
 class ValuesListQuery(FieldSelectQuery):
+    __slots__ = ('_db', 'flat', 'fields')
+
     def __init__(
         self, model, filter_kwargs, db, q_objects, fields_for_select_list, limit, offset, distinct,
         orderings, flat, annotations, having, custom_filters
@@ -711,6 +720,8 @@ class ValuesListQuery(FieldSelectQuery):
 
 
 class ValuesQuery(FieldSelectQuery):
+    __slots__ = ('_db', 'fields_for_select')
+
     def __init__(
         self, model, filter_kwargs, db, q_objects, fields_for_select, limit, offset, distinct,
         orderings, annotations, having, custom_filters

--- a/tortoise/tests/test_fields.py
+++ b/tortoise/tests/test_fields.py
@@ -66,7 +66,8 @@ class TestSmallIntFields(test.TestCase):
 
 class TestCharFields(test.TestCase):
     def test_max_length_missing(self):
-        with self.assertRaisesRegex(ConfigurationError, "missing 'max_length' parameter"):
+        with self.assertRaisesRegex(TypeError,
+                                    "missing 1 required positional argument: 'max_length'"):
             fields.CharField()
 
     def test_max_length_bad(self):
@@ -154,11 +155,14 @@ class TestBooleanFields(test.TestCase):
 
 class TestDecimalFields(test.TestCase):
     def test_max_digits_empty(self):
-        with self.assertRaisesRegex(ConfigurationError, "missing 'max_digits' parameter"):
+        with self.assertRaisesRegex(TypeError,
+                                    "missing 2 required positional arguments: 'max_digits' and"
+                                    " 'decimal_places'"):
             fields.DecimalField()
 
     def test_decimal_places_empty(self):
-        with self.assertRaisesRegex(ConfigurationError, "missing 'decimal_places' parameter"):
+        with self.assertRaisesRegex(TypeError,
+                                    "missing 1 required positional argument: 'decimal_places'"):
             fields.DecimalField(max_digits=1)
 
     def test_max_fields_bad(self):

--- a/tortoise/tests/test_fields.py
+++ b/tortoise/tests/test_fields.py
@@ -227,7 +227,7 @@ class TestDatetimeFields(test.TestCase):
         self.assertEqual(obj2.datetime_auto, obj.datetime_auto)
         self.assertNotEqual(obj2.datetime_auto, datetime_auto)
         self.assertGreater(obj2.datetime_auto - now, timedelta(microseconds=10000))
-        self.assertLess(obj2.datetime_auto - now, timedelta(microseconds=20000))
+        self.assertLess(obj2.datetime_auto - now, timedelta(microseconds=30000))
         self.assertEqual(obj2.datetime_add, obj.datetime_add)
 
     async def test_cast(self):

--- a/tortoise/tests/test_filters.py
+++ b/tortoise/tests/test_filters.py
@@ -209,7 +209,7 @@ class TestDecimalFieldFilters(test.TestCase):
 
     async def test_gt(self):
         self.assertEqual(
-            await DecimalFields.filter(decimal__gt='1.2345').order_by('decimal')
+            await DecimalFields.filter(decimal__gt=Decimal('1.2345')).order_by('decimal')
             .values_list('decimal', flat=True),
             [Decimal('2.3'), Decimal('2.3457'), Decimal('23')]
         )

--- a/tortoise/tests/test_filters.py
+++ b/tortoise/tests/test_filters.py
@@ -1,9 +1,11 @@
+from decimal import Decimal
+
 from tortoise.contrib import test
 from tortoise.exceptions import FieldError
-from tortoise.tests.testmodels import CharFields
+from tortoise.tests.testmodels import BooleanFields, CharFields, DecimalFields
 
 
-class TestFieldFilters(test.TestCase):
+class TestCharFieldFilters(test.TestCase):
     async def setUp(self):
         await CharFields.create(char='moo')
         await CharFields.create(char='baa', char_null='baa')
@@ -138,4 +140,76 @@ class TestFieldFilters(test.TestCase):
         self.assertSetEqual(
             set(await CharFields.filter(char__iendswith='Oo').values_list('char', flat=True)),
             {'moo'}
+        )
+
+    async def test_sorting(self):
+        self.assertEqual(
+            await CharFields.all().order_by('char').values_list('char', flat=True),
+            ['baa', 'moo', 'oink']
+        )
+
+
+class TestBooleanFieldFilters(test.TestCase):
+    async def setUp(self):
+        await BooleanFields.create(boolean=True)
+        await BooleanFields.create(boolean=False)
+        await BooleanFields.create(boolean=True, boolean_null=True)
+        await BooleanFields.create(boolean=False, boolean_null=True)
+        await BooleanFields.create(boolean=True, boolean_null=False)
+        await BooleanFields.create(boolean=False, boolean_null=False)
+
+    async def test_equal_true(self):
+        self.assertEqual(
+            set(await BooleanFields.filter(boolean=True).values_list('boolean', 'boolean_null')),
+            {(True, None), (True, True), (True, False)}
+        )
+
+    async def test_equal_false(self):
+        self.assertEqual(
+            set(await BooleanFields.filter(boolean=False).values_list('boolean', 'boolean_null')),
+            {(False, None), (False, True), (False, False)}
+        )
+
+    async def test_equal_true2(self):
+        self.assertEqual(
+            set(await BooleanFields.filter(boolean_null=True)
+                .values_list('boolean', 'boolean_null')),
+            {(False, True), (True, True)}
+        )
+
+    async def test_equal_false2(self):
+        self.assertEqual(
+            set(await BooleanFields.filter(boolean_null=False)
+                .values_list('boolean', 'boolean_null')),
+            {(False, False), (True, False)}
+        )
+
+    @test.expectedFailure
+    async def test_equal_null(self):
+        self.assertEqual(
+            set(await BooleanFields.filter(boolean_null=None)
+                .values_list('boolean', 'boolean_null')),
+            {(False, None), (True, None)}
+        )
+
+
+class TestDecimalFieldFilters(test.TestCase):
+    async def setUp(self):
+        await DecimalFields.create(decimal='1.2345', decimal_nodec=1)
+        await DecimalFields.create(decimal='2.34567', decimal_nodec=1)
+        await DecimalFields.create(decimal='2.300', decimal_nodec=1)
+        await DecimalFields.create(decimal='023.0', decimal_nodec=1)
+        await DecimalFields.create(decimal='0.230', decimal_nodec=1)
+
+    async def test_sorting(self):
+        self.assertEqual(
+            await DecimalFields.all().order_by('decimal').values_list('decimal', flat=True),
+            [Decimal('0.23'), Decimal('1.2345'), Decimal('2.3'), Decimal('2.3457'), Decimal('23')]
+        )
+
+    async def test_gt(self):
+        self.assertEqual(
+            await DecimalFields.filter(decimal__gt='1.2345').order_by('decimal')
+            .values_list('decimal', flat=True),
+            [Decimal('2.3'), Decimal('2.3457'), Decimal('23')]
         )

--- a/tortoise/tests/test_transactions.py
+++ b/tortoise/tests/test_transactions.py
@@ -143,25 +143,90 @@ class TestTransactions(test.IsolatedTestCase):
             async with in_transaction() as connection:
                 await connection.commit()
 
-    async def test_await_across_transaction_fail(self):
+    async def test_insert_await_across_transaction_fail(self):
         tournament = Tournament(name='Test')
-        query = tournament.save()
+        query = tournament.save()  # pylint: disable=E1111
 
         try:
-            async with in_transaction() as connection:
-                result = await query
-                raise Exception('moo')
-        except Exception:
+            async with in_transaction():
+                await query
+                raise KeyError('moo')
+        except KeyError:
             pass
 
         self.assertEqual(await Tournament.all(), [])
 
-    async def test_await_across_transaction_success(self):
+    async def test_insert_await_across_transaction_success(self):
         tournament = Tournament(name='Test')
-        query = tournament.save()
+        query = tournament.save()  # pylint: disable=E1111
 
-        async with in_transaction() as connection:
-            result = await query
+        async with in_transaction():
+            await query
 
         self.assertEqual(await Tournament.all(), [tournament])
 
+    async def test_update_await_across_transaction_fail(self):
+        await Tournament.create(name='Test1')
+
+        query = Tournament.filter(id=1).update(name='Test2')
+        try:
+            async with in_transaction():
+                await query
+                raise KeyError('moo')
+        except KeyError:
+            pass
+
+        self.assertEqual(await Tournament.all().values('id', 'name'), [{'id': 1, 'name': 'Test1'}])
+
+    async def test_update_await_across_transaction_success(self):
+        await Tournament.create(name='Test1')
+
+        query = Tournament.filter(id=1).update(name='Test2')
+        async with in_transaction():
+            await query
+
+        self.assertEqual(await Tournament.all().values('id', 'name'), [{'id': 1, 'name': 'Test2'}])
+
+    async def test_delete_await_across_transaction_fail(self):
+        await Tournament.create(name='Test1')
+
+        query = Tournament.filter(id=1).delete()
+        try:
+            async with in_transaction():
+                await query
+                raise KeyError('moo')
+        except KeyError:
+            pass
+
+        self.assertEqual(await Tournament.all().values('id', 'name'), [{'id': 1, 'name': 'Test1'}])
+
+    async def test_delete_await_across_transaction_success(self):
+        await Tournament.create(name='Test1')
+
+        query = Tournament.filter(id=1).delete()
+        async with in_transaction():
+            await query
+
+        self.assertEqual(await Tournament.all(), [])
+
+    async def test_select_await_across_transaction_fail(self):
+        query = Tournament.all().values('id', 'name')
+        try:
+            async with in_transaction():
+                await Tournament.create(name='Test1')
+                result = await query
+                raise KeyError('moo')
+        except KeyError:
+            pass
+
+        self.assertEqual(result, [{'id': 1, 'name': 'Test1'}])
+        self.assertEqual(await Tournament.all(), [])
+
+    async def test_select_await_across_transaction_success(self):
+        query = Tournament.all().values('id', 'name')
+        async with in_transaction():
+            await Tournament.create(name='Test1')
+            result = await query
+
+        self.assertEqual(result, [{'id': 1, 'name': 'Test1'}])
+        self.assertEqual(await Tournament.all().values('id', 'name'), [{'id': 1, 'name': 'Test1'}])

--- a/tortoise/utils.py
+++ b/tortoise/utils.py
@@ -2,6 +2,8 @@ from typing import Awaitable, Callable, Iterator, Optional
 
 
 class QueryAsyncIterator:
+    __slots__ = ('query', 'sequence', '_sequence_iterator', '_callback')
+
     def __init__(self, query: Awaitable[Iterator], callback: Optional[Callable] = None) -> None:
         self.query = query
         self.sequence = None  # type: Optional[Iterator]


### PR DESCRIPTION
Make use of pypika objects being immutable, and pre-build as much of the query as possible.
Also pre-build DB-specific filter override list. (avoids a transaction lookup which is quite expensive)
Also optimised queryset cloning.,

This gives us a further 21-48% speed up for small queries. :grin:

This actually slowed down tests marginally, as in the tests we re-build all the query caches for each test. :man_shrugging: