### PR TITLE
New pool (WIP)

### DIFF
--- a/tortoise/backends/base/client.py
+++ b/tortoise/backends/base/client.py
@@ -87,8 +87,8 @@ class BaseDBAsyncClient:
     async def execute_script(self, query: str) -> None:
         raise NotImplementedError()  # pragma: nocoverage
 
-    async def execute_explain(self, query: str) -> Sequence[dict]:
-        raise NotImplementedError()  # pragma: nocoverage
+    # async def execute_explain(self, query: str) -> Sequence[dict]:
+    #     raise NotImplementedError()  # pragma: nocoverage
 
 
 class ConnectionWrapper:

--- a/tortoise/backends/base/config_generator.py
+++ b/tortoise/backends/base/config_generator.py
@@ -47,6 +47,8 @@ DB_LOOKUP = {
         },
         'defaults': {
             'port': 3306,
+            'minsize': 1,
+            'maxsize': 5,
         },
         'cast': {
             'minsize': int,

--- a/tortoise/contrib/test/__init__.py
+++ b/tortoise/contrib/test/__init__.py
@@ -148,6 +148,7 @@ class SimpleTestCase(_TestCase):
     use_default_loop = True
 
     def _init_loop(self) -> None:
+        # pylint: disable=W0201
         if self.use_default_loop:
             self.loop = _LOOP
             loop = None
@@ -217,7 +218,7 @@ class IsolatedTestCase(SimpleTestCase):
             modules=_MODULES,
         )
         await Tortoise.init(config, _create_db=True)
-        await Tortoise.generate_schemas()
+        await Tortoise.generate_schemas(safe=False)
         self._connections = Tortoise._connections.copy()
 
     async def _tearDownDB(self) -> None:

--- a/tortoise/exceptions.py
+++ b/tortoise/exceptions.py
@@ -7,56 +7,48 @@ class BaseORMException(Exception):
     """
     Base ORM Exception.
     """
-    pass
 
 
 class FieldError(BaseORMException):
     """
     The FieldError exception is raised when there is a problem with a model field.
     """
-    pass
 
 
 class ParamsError(BaseORMException):
     """
     The ParamsError is raised when function can not be run with given parameters
     """
-    pass
 
 
 class ConfigurationError(BaseORMException):
     """
     The ConfigurationError exception is raised when the configuration of the ORM is invalid.
     """
-    pass
 
 
 class TransactionManagementError(BaseORMException):
     """
     The TransactionManagementError is raised when any transaction error occurs.
     """
-    pass
 
 
 class OperationalError(BaseORMException):
     """
     The OperationalError exception is raised when an operational error occurs.
     """
-    pass
 
 
 class IntegrityError(OperationalError):
     """
     The IntegrityError exception is raised when there is an integrity error.
     """
-    pass
 
 
 class NoValuesFetched(OperationalError):
     """
     The NoValuesFetched exception is raised when the related model was never fetched.
     """
-    pass
 
 
 class MultipleObjectsReturned(OperationalError):
@@ -64,18 +56,15 @@ class MultipleObjectsReturned(OperationalError):
     The MultipleObjectsReturned exception is raised when doing a ``.get()`` operation,
     and more than one object is returned.
     """
-    pass
 
 
 class DoesNotExist(OperationalError):
     """
     The DoesNotExist exception is raised when expecting data, such as a ``.get()`` operation.
     """
-    pass
 
 
 class DBConnectionError(BaseORMException):
     """
     The DBConnectionError is raised when problems with connecting to db occurs
     """
-    pass

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -238,7 +238,7 @@ class QuerySet(AwaitableQuery):
             queryset._custom_filters.update(get_filters_for_field(key, None, key))
         return queryset
 
-    def values_list(self, *fields: str, flat: bool = False
+    def values_list(self, *fields_: str, flat: bool = False
                     ) -> 'ValuesListQuery':  # pylint: disable=W0621
         """
         Make QuerySet returns list of tuples for given args instead of objects.
@@ -249,7 +249,7 @@ class QuerySet(AwaitableQuery):
             model=self.model,
             q_objects=self._q_objects,
             flat=flat,
-            fields_for_select_list=fields,
+            fields_for_select_list=fields_,
             distinct=self._distinct,
             limit=self._limit,
             offset=self._offset,

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -13,13 +13,14 @@ from tortoise.utils import QueryAsyncIterator
 
 
 class AwaitableQuery:
-    __slots__ = ('_joined_tables', 'query', 'model', '_db')
+    __slots__ = ('_joined_tables', 'query', 'model', '_db', 'capabilities')
 
-    def __init__(self, model, db: Optional[BaseDBAsyncClient]) -> None:
+    def __init__(self, model) -> None:
         self._joined_tables = []  # type: List[Table]
         self.model = model
         self.query = model._meta.basequery  # type: Query
-        self._db = db if db else model._meta.db  # type: BaseDBAsyncClient
+        self._db = None  # type: Optional[BaseDBAsyncClient]
+        self.capabilities = model._meta.db.capabilities
 
     def resolve_filters(self, model, q_objects, annotations, custom_filters) -> None:
         modifier = QueryModifier()
@@ -74,7 +75,13 @@ class AwaitableQuery:
                     )
                 self.query = self.query.orderby(getattr(table, ordering[0]), order=ordering[1])
 
+    def _make_query(self):
+        raise NotImplementedError()  # pragma: nocoverage
+
     def __await__(self):
+        if self._db is None:
+            self._db = self.model._meta.db
+        self._make_query()
         return self._execute().__await__()
 
     async def _execute(self):
@@ -88,7 +95,7 @@ class QuerySet(AwaitableQuery):
                  '_annotations', '_having', '_custom_filters')
 
     def __init__(self, model) -> None:
-        super().__init__(model, None)
+        super().__init__(model)
         self.fields = model._meta.db_fields
 
         self._prefetch_map = {}  # type: Dict[str, Set[str]]
@@ -111,6 +118,7 @@ class QuerySet(AwaitableQuery):
         queryset.fields = self.fields
         queryset.model = self.model
         queryset.query = self.query
+        queryset.capabilities = self.capabilities
         queryset._prefetch_map = copy(self._prefetch_map)
         queryset._prefetch_queries = copy(self._prefetch_queries)
         queryset._single = self._single
@@ -213,7 +221,7 @@ class QuerySet(AwaitableQuery):
         """
         queryset = self._clone()
         queryset._offset = offset
-        if self._db.capabilities.requires_limit and queryset._limit is None:
+        if self.capabilities.requires_limit and queryset._limit is None:
             queryset._limit = 1000000
         return queryset
 
@@ -389,9 +397,13 @@ class QuerySet(AwaitableQuery):
             and query optimization.
             **The output format may (and will) vary greatly depending on the database backend.**
         """
-        query = self._make_query()
-        executor = self._db.executor_class(model=self.model, db=self._db)
-        return await executor.execute_explain(query)
+        if self._db is None:
+            self._db = self.model._meta.db
+
+        return await self._db.executor_class(
+            model=self.model,
+            db=self._db
+        ).execute_explain(self._make_query())
 
     def using_db(self, _db: BaseDBAsyncClient) -> 'QuerySet':
         """
@@ -432,7 +444,6 @@ class QuerySet(AwaitableQuery):
         return self.query
 
     async def _execute(self):
-        self.query = self._make_query()
         instance_list = await self._db.executor_class(
             model=self.model,
             db=self._db,
@@ -457,6 +468,9 @@ class QuerySet(AwaitableQuery):
 
     def __await__(self):
         clone = self._clone()
+        if clone._db is None:
+            clone._db = self.model._meta.db
+        clone._make_query()
         return clone._execute().__await__()
 
     def __aiter__(self) -> QueryAsyncIterator:
@@ -464,30 +478,37 @@ class QuerySet(AwaitableQuery):
 
 
 class UpdateQuery(AwaitableQuery):
-    __slots__ = ()
+    __slots__ = ('update_kwargs', 'q_objects', 'annotations', 'custom_filters')
 
     def __init__(self, model, update_kwargs, db, q_objects, annotations, custom_filters) -> None:
-        super().__init__(model, db)
-        table = Table(model._meta.table)
+        super().__init__(model)
+        self.update_kwargs = update_kwargs
+        self.q_objects = q_objects
+        self.annotations = annotations
+        self.custom_filters = custom_filters
+        self._db = db
+
+    def _make_query(self):
+        table = Table(self.model._meta.table)
         self.query = self._db.query_class.update(table)
         self.resolve_filters(
-            model=model,
-            q_objects=q_objects,
-            annotations=annotations,
-            custom_filters=custom_filters
+            model=self.model,
+            q_objects=self.q_objects,
+            annotations=self.annotations,
+            custom_filters=self.custom_filters
         )
 
-        for key, value in update_kwargs.items():
-            field_object = model._meta.fields_map.get(key)
+        for key, value in self.update_kwargs.items():
+            field_object = self.model._meta.fields_map.get(key)
             if not field_object:
-                raise FieldError('Unknown keyword argument {} for model {}'.format(key, model))
+                raise FieldError('Unknown keyword argument {} for model {}'.format(key, self.model))
             if field_object.generated:
                 raise IntegrityError('Field {} is generated and can not be updated')
             if isinstance(field_object, fields.ForeignKeyField):
                 db_field = '{}_id'.format(key)
                 value = value.id
             else:
-                db_field = model._meta.fields_db_projection[key]
+                db_field = self.model._meta.fields_db_projection[key]
             self.query = self.query.set(db_field, value)
 
     async def _execute(self):
@@ -495,16 +516,22 @@ class UpdateQuery(AwaitableQuery):
 
 
 class DeleteQuery(AwaitableQuery):
-    __slots__ = ()
+    __slots__ = ('q_objects', 'annotations', 'custom_filters')
 
     def __init__(self, model, db, q_objects, annotations, custom_filters) -> None:
-        super().__init__(model, db)
-        self.query = model._meta.basequery
+        super().__init__(model)
+        self.q_objects = q_objects
+        self.annotations = annotations
+        self.custom_filters = custom_filters
+        self._db = db
+
+    def _make_query(self):
+        self.query = self.model._meta.basequery
         self.resolve_filters(
-            model=model,
-            q_objects=q_objects,
-            annotations=annotations,
-            custom_filters=custom_filters
+            model=self.model,
+            q_objects=self.q_objects,
+            annotations=self.annotations,
+            custom_filters=self.custom_filters
         )
         self.query = self.query.delete()
 
@@ -513,18 +540,23 @@ class DeleteQuery(AwaitableQuery):
 
 
 class CountQuery(AwaitableQuery):
-    __slots__ = ()
+    __slots__ = ('q_objects', 'annotations', 'custom_filters')
 
-    def __init__(self, model, db, q_objects, annotations, custom_filters
-                 ) -> None:
-        super().__init__(model, db)
-        table = Table(model._meta.table)
-        self.query = model._meta.basequery
+    def __init__(self, model, db, q_objects, annotations, custom_filters) -> None:
+        super().__init__(model)
+        self.q_objects = q_objects
+        self.annotations = annotations
+        self.custom_filters = custom_filters
+        self._db = db
+
+    def _make_query(self):
+        table = Table(self.model._meta.table)
+        self.query = self.model._meta.basequery
         self.resolve_filters(
-            model=model,
-            q_objects=q_objects,
-            annotations=annotations,
-            custom_filters=custom_filters,
+            model=self.model,
+            q_objects=self.q_objects,
+            annotations=self.annotations,
+            custom_filters=self.custom_filters,
         )
         self.query = self.query.select(Count(table.star))
 
@@ -619,35 +651,49 @@ class FieldSelectQuery(AwaitableQuery):
 
 
 class ValuesListQuery(FieldSelectQuery):
-    __slots__ = ('flat', 'fields')
+    __slots__ = (
+        'flat', 'fields', 'limit', 'offset', 'distinct', 'orderings', 'annotations',
+        'custom_filters', 'q_objects', 'fields_for_select_list',
+    )
 
     def __init__(self, model, db, q_objects, fields_for_select_list, limit, offset,
                  distinct, orderings, flat, annotations, custom_filters) -> None:
-        super().__init__(model, db)
+        super().__init__(model)
         if flat and (len(fields_for_select_list) != 1):
             raise TypeError('You can flat value_list only if contains one field')
 
-        self.query = model._meta.basequery
         fields_for_select = {str(i): field for i, field in enumerate(fields_for_select_list)}
+        self.fields = fields_for_select
+        self.limit = limit
+        self.offset = offset
+        self.distinct = distinct
+        self.orderings = orderings
+        self.annotations = annotations
+        self.custom_filters = custom_filters
+        self.q_objects = q_objects
+        self.fields_for_select_list = fields_for_select_list
+        self.flat = flat
+        self._db = db
 
-        for positional_number, field in fields_for_select.items():
+    def _make_query(self):
+        self.query = self.model._meta.basequery
+
+        for positional_number, field in self.fields.items():
             self.add_field_to_select_query(field, positional_number)
 
         self.resolve_filters(
-            model=model,
-            q_objects=q_objects,
-            annotations=annotations,
-            custom_filters=custom_filters,
+            model=self.model,
+            q_objects=self.q_objects,
+            annotations=self.annotations,
+            custom_filters=self.custom_filters,
         )
-        if limit:
-            self.query = self.query.limit(limit)
-        if offset:
-            self.query = self.query.offset(offset)
-        if distinct:
+        if self.limit:
+            self.query = self.query.limit(self.limit)
+        if self.offset:
+            self.query = self.query.offset(self.offset)
+        if self.distinct:
             self.query = self.query.distinct()
-        self.resolve_ordering(model, orderings, annotations)
-        self.flat = flat
-        self.fields = fields_for_select
+        self.resolve_ordering(self.model, self.orderings, self.annotations)
 
     async def _execute(self):
         result = await self._db.execute_query(str(self.query))
@@ -662,31 +708,44 @@ class ValuesListQuery(FieldSelectQuery):
 
 
 class ValuesQuery(FieldSelectQuery):
-    __slots__ = ('fields_for_select',)
+    __slots__ = (
+        'fields_for_select', 'limit', 'offset', 'distinct', 'orderings', 'annotations',
+        'custom_filters', 'q_objects',
+    )
 
     def __init__(self, model, db, q_objects, fields_for_select, limit, offset, distinct, orderings,
                  annotations, custom_filters) -> None:
-        super().__init__(model, db)
-        self.query = model._meta.basequery
-        for return_as, field in fields_for_select.items():
+        super().__init__(model)
+        self.fields_for_select = fields_for_select
+        self.limit = limit
+        self.offset = offset
+        self.distinct = distinct
+        self.orderings = orderings
+        self.annotations = annotations
+        self.custom_filters = custom_filters
+        self.q_objects = q_objects
+        self._db = db
+
+    def _make_query(self):
+        self.query = self.model._meta.basequery
+        for return_as, field in self.fields_for_select.items():
             self.add_field_to_select_query(field, return_as)
 
         self.resolve_filters(
-            model=model,
-            q_objects=q_objects,
-            annotations=annotations,
-            custom_filters=custom_filters,
+            model=self.model,
+            q_objects=self.q_objects,
+            annotations=self.annotations,
+            custom_filters=self.custom_filters,
         )
-        if limit:
-            self.query = self.query.limit(limit)
-        if offset:
-            self.query = self.query.offset(offset)
-        if distinct:
+        if self.limit:
+            self.query = self.query.limit(self.limit)
+        if self.offset:
+            self.query = self.query.offset(self.offset)
+        if self.distinct:
             self.query = self.query.distinct()
-        for ordering in orderings:
+        for ordering in self.orderings:
             self.query = self.query.orderby(ordering[0], order=ordering[1])
-        self.resolve_ordering(model, orderings, annotations)
-        self.fields_for_select = fields_for_select
+        self.resolve_ordering(self.model, self.orderings, self.annotations)
 
     async def _execute(self):
         result = await self._db.execute_query(str(self.query))

--- a/tortoise/tests/test_basic.py
+++ b/tortoise/tests/test_basic.py
@@ -4,16 +4,19 @@ from tortoise.tests.testmodels import Tournament
 
 class TestBasic(test.TestCase):
     async def test_basic(self):
-        event = await Tournament.create(name='Test')
-        await Tournament.filter(id=event.id).update(name='Updated name')
+        tournament = await Tournament.create(name='Test')
+        await Tournament.filter(id=tournament.id).update(name='Updated name')
         saved_event = await Tournament.filter(name='Updated name').first()
-        self.assertEqual(saved_event.id, event.id)
+        self.assertEqual(saved_event.id, tournament.id)
         await Tournament(name='Test 2').save()
         self.assertEqual(
             await Tournament.all().values_list('id', flat=True),
-            [event.id, event.id + 1]
+            [tournament.id, tournament.id + 1]
         )
         self.assertEqual(
             await Tournament.all().values('id', 'name'),
-            [{'id': event.id, 'name': 'Updated name'}, {'id': event.id + 1, 'name': 'Test 2'}]
+            [
+                {'id': tournament.id, 'name': 'Updated name'},
+                {'id': tournament.id + 1, 'name': 'Test 2'},
+            ],
         )

--- a/tortoise/tests/test_capabilities.py
+++ b/tortoise/tests/test_capabilities.py
@@ -26,7 +26,7 @@ class TestCapabilities(test.TestCase):
     @test.requireCapability(dialect='sqlite')
     @test.expectedFailure
     def test_actually_runs(self):
-        self.assertTrue(False)
+        self.assertTrue(False)  # pylint: disable=W1503
 
     def test_attribute_error(self):
         with self.assertRaises(AttributeError):
@@ -34,12 +34,12 @@ class TestCapabilities(test.TestCase):
 
     @test.requireCapability(dialect='sqlite')
     def test_dialect_sqlite(self):
-        self.assertEquals(self.caps.dialect, 'sqlite')
+        self.assertEqual(self.caps.dialect, 'sqlite')
 
     @test.requireCapability(dialect='mysql')
     def test_dialect_mysql(self):
-        self.assertEquals(self.caps.dialect, 'mysql')
+        self.assertEqual(self.caps.dialect, 'mysql')
 
     @test.requireCapability(dialect='postgres')
     def test_dialect_postgres(self):
-        self.assertEquals(self.caps.dialect, 'postgres')
+        self.assertEqual(self.caps.dialect, 'postgres')

--- a/tortoise/tests/test_db_url.py
+++ b/tortoise/tests/test_db_url.py
@@ -141,6 +141,8 @@ class TestConfigGenerator(test.SimpleTestCase):
                 'password': '',
                 'port': 33060,
                 'user': 'root',
+                'minsize': 1,
+                'maxsize': 5,
             }
         })
 
@@ -154,6 +156,8 @@ class TestConfigGenerator(test.SimpleTestCase):
                 'password': '',
                 'port': 3306,
                 'user': 'root',
+                'minsize': 1,
+                'maxsize': 5,
             }
         })
 
@@ -173,6 +177,8 @@ class TestConfigGenerator(test.SimpleTestCase):
                 'password': '',
                 'port': 3306,
                 'user': 'root',
+                'minsize': 1,
+                'maxsize': 5,
             }
         })
 

--- a/tortoise/tests/test_generate_schema.py
+++ b/tortoise/tests/test_generate_schema.py
@@ -15,6 +15,7 @@ class TestGenerateSchema(test.SimpleTestCase):
         except ConfigurationError:
             pass
         Tortoise._inited = False
+        self.sqls = ''
 
     async def tearDown(self):
         await Tortoise.close_connections()

--- a/tortoise/tests/test_transactions.py
+++ b/tortoise/tests/test_transactions.py
@@ -8,7 +8,6 @@ class SomeException(Exception):
     """
     A very specific exception so s to not accidentally catch another exception.
     """
-    pass
 
 
 @atomic()


### PR DESCRIPTION
Now that code base is simpler, and test runner should be more sane, attempt to add connection pooling for the third time.

The plan is to change to connection pooling ONLY, as we currently implement persistent connections, but only one persistent connection.
A connection pool should:
* add robustness (if connection dies, then reconnect)
* Allow multiple DB clients to operate at the same time (up to maxsize)
* Allow more conflicts, so we need to handle rollback/retries explicitly.

Things done:
* [x] Change to a connection pooling system for MySQL.
* [ ] Add tests for concurrency
* [ ] Add tests for robustness (hackery allowed)
* [ ] Add tests for handling conflicts.

Concerns:
* Can SQLite be concurrent at all? If difficult, should we limit it?
* We need to add concurrency to the benchmarks, to manage performance