### PR TITLE
Support field subclassing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+0.10.12
+-------
+- Support subclassing on existing fields
+
 0.10.11
 -------
 - Pre-build some query & filters statically, 15-30% speed up for smaller queries.

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -8,6 +8,7 @@ Contributors
 * Andrey Bondar ``@Zeliboba5``
 * Nickolas Grigoriadis ``@grigi``
 * ``@etzelwu``
+* Alexander Lyon ``@arlyon``
 
 Special Thanks
 ==============

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -20,6 +20,52 @@ Fields are defined as properties of a ``Model`` class object:
         name = fields.CharField(max_length=255)
 
 
+Extending A Field
+=================
+
+It is possible to subclass fields allowing use of arbitrary types as long as they can be represented in a
+database compatible format. An example of this would be a simple wrapper around the :class:`~tortoise.fields.CharField`
+to store and query Enum types.
+
+.. code-block:: python3
+
+    from enum import Enum
+    from typing import Type
+
+    from tortoise import ConfigurationError
+    from tortoise.fields import CharField
+
+
+    class EnumField(CharField):
+        """
+        An example extension to CharField that serializes Enums
+        to and from a str representation in the DB.
+        """
+
+        def __init__(self, enum_type: Type[Enum], **kwargs):
+            super().__init__(128, **kwargs)
+            if not issubclass(enum_type, Enum):
+                raise ConfigurationError("{} is not a subclass of Enum!".format(enum_type))
+            self._enum_type = enum_type
+
+        def to_db_value(self, value: Enum, instance) -> str:
+            return value.value
+
+        def to_python_value(self, value: str) -> Enum:
+            try:
+                return self._enum_type(value)
+            except Exception:
+                raise ValueError(
+                    "Database value {} does not exist on Enum {}.".format(value, self._enum_type)
+                )
+
+When subclassing, make sure that the ``to_db_value`` returns the same type as the superclass (in the case of CharField,
+that is a ``str``) and that, naturally, ``to_python_value`` accepts the same type in the value parameter (also ``str``).
+
+.. note:: Make sure to keep filtering in mind when subclassing. To support the filter ``field__isnull=True``,
+    for example, you must make sure that the function also accepts boolean values.
+
+
 Reference
 =========
 
@@ -75,4 +121,3 @@ Here is list of fields available at the moment with custom options of these fiel
 
 .. autoclass:: tortoise.fields.ManyToManyField
     :exclude-members: to_db_value, to_python_value
-

--- a/docs/query.rst
+++ b/docs/query.rst
@@ -86,7 +86,7 @@ When you need to make ``OR`` query or something a little more challenging you co
     )
 
 
-
+.. _filtering-queries:
 Filtering
 =========
 

--- a/tortoise/backends/base/schema_generator.py
+++ b/tortoise/backends/base/schema_generator.py
@@ -59,7 +59,12 @@ class BaseSchemaGenerator:
             nullable = 'NOT NULL' if not field_object.null else ''
             unique = 'UNIQUE' if field_object.unique else ''
 
-            field_type = self.FIELD_TYPE_MAP[field_object.__class__]
+            field_object_type = type(field_object)
+            while field_object_type.__bases__ and field_object_type not in self.FIELD_TYPE_MAP:
+                field_object_type = field_object_type.__bases__[0]
+
+            field_type = self.FIELD_TYPE_MAP[field_object_type]
+
             if isinstance(field_object, fields.DecimalField):
                 field_type = field_type.format(field_object.max_digits, field_object.decimal_places)
             elif isinstance(field_object, fields.CharField):

--- a/tortoise/tests/test_field_subclass.py
+++ b/tortoise/tests/test_field_subclass.py
@@ -4,16 +4,42 @@ from tortoise.tests import testmodels
 
 class TestEnumField(test.TestCase):
 
-    async def test_enum_field(self):
+    async def test_enum_field_create(self):
         """Tests the enumeration field."""
-        test1 = await testmodels.RaceParticipant.create(first_name="Alex", place=testmodels.RacePlacingEnum.FIRST)
-        self.assertEquals(test1.place, testmodels.RacePlacingEnum.FIRST)
+        test1 = await testmodels.RaceParticipant.create(
+            first_name="Alex",
+            place=testmodels.RacePlacingEnum.FIRST)
+        self.assertEqual(test1.place, testmodels.RacePlacingEnum.FIRST)
+
+    async def test_enum_field_update(self):
+        test1 = await testmodels.RaceParticipant.create(
+            first_name="Alex",
+            place=testmodels.RacePlacingEnum.FIRST)
 
         test1.place = testmodels.RacePlacingEnum.SECOND
         await test1.save()
 
         test2 = await testmodels.RaceParticipant.first()
-        self.assertEquals(test1.place, test2.place)
+        self.assertEqual(test1.place, test2.place)
 
-        test3 = await testmodels.RaceParticipant.filter(place=testmodels.RacePlacingEnum.SECOND).first()
-        self.assertEquals(test1.place, test3.place)
+    async def test_enum_field_filter(self):
+        await testmodels.RaceParticipant.create(
+            first_name="Alex",
+            place=testmodels.RacePlacingEnum.FIRST)
+        await testmodels.RaceParticipant.create(
+            first_name="Ben",
+            place=testmodels.RacePlacingEnum.SECOND)
+        await testmodels.RaceParticipant.create(
+            first_name="Chris",
+            place=testmodels.RacePlacingEnum.THIRD)
+
+        first_place = await testmodels.RaceParticipant \
+            .filter(place=testmodels.RacePlacingEnum.FIRST) \
+            .first()
+
+        second_place = await testmodels.RaceParticipant \
+            .filter(place=testmodels.RacePlacingEnum.SECOND) \
+            .first()
+
+        self.assertEqual(first_place.place, testmodels.RacePlacingEnum.FIRST)
+        self.assertEqual(second_place.place, testmodels.RacePlacingEnum.SECOND)

--- a/tortoise/tests/test_field_subclass.py
+++ b/tortoise/tests/test_field_subclass.py
@@ -1,0 +1,19 @@
+from tortoise.contrib import test
+from tortoise.tests import testmodels
+
+
+class TestEnumField(test.TestCase):
+
+    async def test_enum_field(self):
+        """Tests the enumeration field."""
+        test1 = await testmodels.RaceParticipant.create(first_name="Alex", place=testmodels.RacePlacingEnum.FIRST)
+        self.assertEquals(test1.place, testmodels.RacePlacingEnum.FIRST)
+
+        test1.place = testmodels.RacePlacingEnum.SECOND
+        await test1.save()
+
+        test2 = await testmodels.RaceParticipant.first()
+        self.assertEquals(test1.place, test2.place)
+
+        test3 = await testmodels.RaceParticipant.filter(place=testmodels.RacePlacingEnum.SECOND).first()
+        self.assertEquals(test1.place, test3.place)

--- a/tortoise/tests/test_field_subclass.py
+++ b/tortoise/tests/test_field_subclass.py
@@ -2,36 +2,52 @@ from tortoise.contrib import test
 from tortoise.tests import testmodels
 
 
+async def create_participants():
+    test1 = await testmodels.RaceParticipant.create(
+        first_name="Alex",
+        place=testmodels.RacePlacingEnum.FIRST,
+        predicted_place=testmodels.RacePlacingEnum.THIRD
+    )
+    test2 = await testmodels.RaceParticipant.create(
+        first_name="Ben",
+        place=testmodels.RacePlacingEnum.SECOND,
+        predicted_place=testmodels.RacePlacingEnum.FIRST
+    )
+    test3 = await testmodels.RaceParticipant.create(
+        first_name="Chris",
+        place=testmodels.RacePlacingEnum.THIRD
+    )
+    test4 = await testmodels.RaceParticipant.create(
+        first_name="Bill"
+    )
+
+    return test1, test2, test3, test4
+
+
 class TestEnumField(test.TestCase):
+    """Tests the enumeration field."""
 
     async def test_enum_field_create(self):
-        """Tests the enumeration field."""
-        test1 = await testmodels.RaceParticipant.create(
-            first_name="Alex",
-            place=testmodels.RacePlacingEnum.FIRST)
+        """Asserts that the new field is saved properly."""
+        test1, _, _, _ = await create_participants()
+        self.assertIn(test1, await testmodels.RaceParticipant.all())
         self.assertEqual(test1.place, testmodels.RacePlacingEnum.FIRST)
 
     async def test_enum_field_update(self):
-        test1 = await testmodels.RaceParticipant.create(
-            first_name="Alex",
-            place=testmodels.RacePlacingEnum.FIRST)
-
+        """Asserts that the new field can be updated correctly."""
+        test1, _, _, _ = await create_participants()
         test1.place = testmodels.RacePlacingEnum.SECOND
         await test1.save()
 
-        test2 = await testmodels.RaceParticipant.first()
-        self.assertEqual(test1.place, test2.place)
+        tied_second = await testmodels.RaceParticipant \
+            .filter(place=testmodels.RacePlacingEnum.SECOND)
+
+        self.assertIn(test1, tied_second)
+        self.assertEqual(len(tied_second), 2)
 
     async def test_enum_field_filter(self):
-        await testmodels.RaceParticipant.create(
-            first_name="Alex",
-            place=testmodels.RacePlacingEnum.FIRST)
-        await testmodels.RaceParticipant.create(
-            first_name="Ben",
-            place=testmodels.RacePlacingEnum.SECOND)
-        await testmodels.RaceParticipant.create(
-            first_name="Chris",
-            place=testmodels.RacePlacingEnum.THIRD)
+        """Assert that filters correctly select the enums."""
+        await create_participants()
 
         first_place = await testmodels.RaceParticipant \
             .filter(place=testmodels.RacePlacingEnum.FIRST) \
@@ -43,3 +59,22 @@ class TestEnumField(test.TestCase):
 
         self.assertEqual(first_place.place, testmodels.RacePlacingEnum.FIRST)
         self.assertEqual(second_place.place, testmodels.RacePlacingEnum.SECOND)
+
+    async def test_enum_field_delete(self):
+        """Assert that delete correctly removes the right participant by their place."""
+        await create_participants()
+        await testmodels.RaceParticipant.filter(place=testmodels.RacePlacingEnum.FIRST).delete()
+        self.assertEqual(await testmodels.RaceParticipant.all().count(), 3)
+
+    async def test_enum_field_default(self):
+        _, _, _, test4 = await create_participants()
+        self.assertEqual(test4.place, testmodels.RacePlacingEnum.DNF)
+
+    async def test_enum_field_null(self):
+        """Assert that filtering by None selects the records which are null."""
+        _, _, test3, test4 = await create_participants()
+
+        no_predictions = await testmodels.RaceParticipant.filter(predicted_place__isnull=True)
+
+        self.assertIn(test3, no_predictions)
+        self.assertIn(test4, no_predictions)

--- a/tortoise/tests/testfields.py
+++ b/tortoise/tests/testfields.py
@@ -9,7 +9,8 @@ T = TypeVar("T")
 
 class EnumField(CharField):
     """
-    An example extension to CharField that serializes Enums to and from a Text representation in the DB.
+    An example extension to CharField that serializes Enums
+    to and from a Text representation in the DB.
     """
 
     def __init__(self, enum_type: T, *args, **kwargs):
@@ -25,4 +26,6 @@ class EnumField(CharField):
         try:
             return self._enum_type(value)
         except Exception:
-            raise ValueError("Database value {} does not exist on Enum {}.".format(value, self._enum_type))
+            raise ValueError(
+                "Database value {} does not exist on Enum {}.".format(value, self._enum_type)
+            )

--- a/tortoise/tests/testfields.py
+++ b/tortoise/tests/testfields.py
@@ -1,0 +1,28 @@
+from enum import Enum
+from typing import TypeVar
+
+from tortoise import ConfigurationError
+from tortoise.fields import CharField
+
+T = TypeVar("T")
+
+
+class EnumField(CharField):
+    """
+    An example extension to CharField that serializes Enums to and from a Text representation in the DB.
+    """
+
+    def __init__(self, enum_type: T, *args, **kwargs):
+        super().__init__(128, *args, **kwargs)
+        if not issubclass(enum_type, Enum):
+            raise ConfigurationError("{} is not a subclass of Enum!".format(enum_type))
+        self._enum_type = enum_type
+
+    def to_db_value(self, value: T, instance) -> str:
+        return value.value
+
+    def to_python_value(self, value: str) -> T:
+        try:
+            return self._enum_type(value)
+        except Exception:
+            raise ValueError("Database value {} does not exist on Enum {}.".format(value, self._enum_type))

--- a/tortoise/tests/testfields.py
+++ b/tortoise/tests/testfields.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import TypeVar
+from typing import TypeVar, Type
 
 from tortoise import ConfigurationError
 from tortoise.fields import CharField
@@ -13,7 +13,7 @@ class EnumField(CharField):
     to and from a Text representation in the DB.
     """
 
-    def __init__(self, enum_type: T, *args, **kwargs):
+    def __init__(self, enum_type: Type[T], *args, **kwargs):
         super().__init__(128, *args, **kwargs)
         if not issubclass(enum_type, Enum):
             raise ConfigurationError("{} is not a subclass of Enum!".format(enum_type))

--- a/tortoise/tests/testmodels.py
+++ b/tortoise/tests/testmodels.py
@@ -3,9 +3,11 @@ This is the testing Models
 """
 import binascii
 import os
+from enum import Enum
 
 from tortoise import fields
 from tortoise.models import Model
+from tortoise.tests.testfields import EnumField
 
 
 def generate_token():
@@ -154,3 +156,15 @@ class MinRelation(Model):
 
 class NoID(Model):
     name = fields.CharField(max_length=255, null=True)
+
+
+class RacePlacingEnum(Enum):
+    FIRST = "first"
+    SECOND = "second"
+    THIRD = "third"
+
+
+class RaceParticipant(Model):
+    id = fields.IntField(pk=True)
+    first_name = fields.CharField(max_length=64)
+    place = EnumField(RacePlacingEnum, default=RacePlacingEnum.SECOND)

--- a/tortoise/tests/testmodels.py
+++ b/tortoise/tests/testmodels.py
@@ -162,9 +162,11 @@ class RacePlacingEnum(Enum):
     FIRST = "first"
     SECOND = "second"
     THIRD = "third"
+    DNF = "dnf"
 
 
 class RaceParticipant(Model):
     id = fields.IntField(pk=True)
     first_name = fields.CharField(max_length=64)
-    place = EnumField(RacePlacingEnum, default=RacePlacingEnum.SECOND)
+    place = EnumField(RacePlacingEnum, default=RacePlacingEnum.DNF)
+    predicted_place = EnumField(RacePlacingEnum, null=True)


### PR DESCRIPTION
This PR adds support for subclassing the already existing fields, as long as the signatures of the `to_db_value` and `to_python_value` functions are the same. It also includes an example implementation of an enum field that extends the string field, and uses it when serializing and de-serializing with the database. 

Currently, the `schema_generator` looks up the type in the `FIELD_TYPE_MAP` which makes subclassing impossible (and throw a KeyError). Now, it will continue looking up the chain (looking only at the "first" parent) until it finds a parent that is a supported `Field`, and use that.

### Some things to consider

- Currently the only way to subclass is to completely override the serialization function. Maybe, instead of overriding, having a hook that the parent calls would be a better approach?
- This could pave the way for data validation (such as only even numbers for example) but it really depends on where you want to draw the line
- Wasn't quite sure where to put the tests, so let me know where they need to go
- The GIS stuff is coming along, but as with most things, it's taking a while...
