### PR TITLE
Add "safe" schema generation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+0.11.2
+------
+- Added "safe" schema generation
+
 0.11.1
 ------
 - Test class isolation fixes & contextvars update

--- a/README.rst
+++ b/README.rst
@@ -136,7 +136,9 @@ Tortoise ORM currently supports the following databases:
 * PostgreSQL (requires ``asyncpg``)
 * MySQL (requires ``aiomysql``)
 
-``generate_schema`` generates schema on empty database, you shouldn't run it on every app init, run it just once, maybe out of your main code.
+``generate_schema`` generates the schema on an empty database. Tortoise generates schemas in safe mode by default which
+includes the `IF NOT EXISTS` clause, so you may include it in your main code.
+
 
 After that you can start using your models:
 

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -30,6 +30,8 @@ You can do it like this:
 Here we create connection to SQLite database client and then we discover & initialise models.
 
 ``generate_schema`` generates schema on empty database, you shouldn't run it on every app init, run it just once, maybe out of your main code.
+There is also the option when generating the schemas to set the ``safe`` parameter to ``True`` which will only insert the tables if they don't
+already exist.
 
 .. _cleaningup:
 

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -335,16 +335,21 @@ class Tortoise:
         current_transaction_map.clear()
 
     @classmethod
-    async def generate_schemas(cls) -> None:
+    async def generate_schemas(cls, safe=True) -> None:
         """
         Generate schemas according to models provided to ``.init()`` method.
         Will fail if schemas already exists, so it's not recommended to be used as part
         of application workflow
+
+        Parameters
+        ----------
+        safe:
+            When set to true, creates the table only when it does not already exist.
         """
         if not cls._inited:
             raise ConfigurationError('You have to call .init() first before generating schemas')
         for connection in cls._connections.values():
-            await generate_schema_for_client(connection)
+            await generate_schema_for_client(connection, safe)
 
     @classmethod
     async def _drop_databases(cls) -> None:

--- a/tortoise/backends/mysql/schema_generator.py
+++ b/tortoise/backends/mysql/schema_generator.py
@@ -6,7 +6,7 @@ class MySQLSchemaGenerator(BaseSchemaGenerator):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-        self.TABLE_CREATE_TEMPLATE = 'CREATE TABLE `{}` ({});'
+        self.TABLE_CREATE_TEMPLATE = 'CREATE TABLE {exists}`{table_name}` ({contents});'
         self.FIELD_TEMPLATE = '`{name}` {type} {nullable} {unique}'
         self.FK_TEMPLATE = ' REFERENCES `{table}` (`id`) ON DELETE {on_delete}'
         self.M2M_TABLE_TEMPLATE = (

--- a/tortoise/backends/mysql/schema_generator.py
+++ b/tortoise/backends/mysql/schema_generator.py
@@ -6,7 +6,7 @@ class MySQLSchemaGenerator(BaseSchemaGenerator):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-        self.TABLE_CREATE_TEMPLATE = 'CREATE TABLE {exists}`{table_name}` ({contents});'
+        self.TABLE_CREATE_TEMPLATE = 'CREATE TABLE {exists}`{table_name}` ({fields});'
         self.FIELD_TEMPLATE = '`{name}` {type} {nullable} {unique}'
         self.FK_TEMPLATE = ' REFERENCES `{table}` (`id`) ON DELETE {on_delete}'
         self.M2M_TABLE_TEMPLATE = (

--- a/tortoise/utils.py
+++ b/tortoise/utils.py
@@ -25,11 +25,11 @@ class QueryAsyncIterator:
             raise StopAsyncIteration
 
 
-def get_schema_sql(client) -> str:
+def get_schema_sql(client, safe=True) -> str:
     generator = client.schema_generator(client)
-    return generator.get_create_schema_sql()
+    return generator.get_create_schema_sql(safe)
 
 
-async def generate_schema_for_client(client) -> None:
+async def generate_schema_for_client(client, safe=True) -> None:
     generator = client.schema_generator(client)
-    await generator.generate_from_string(get_schema_sql(client))
+    await generator.generate_from_string(get_schema_sql(client, safe))


### PR DESCRIPTION
This PR adds a "safe" mode when creating the schemas (essentially identical to [the safe parameter on peewee's `create_table` function](http://docs.peewee-orm.com/en/latest/peewee/api.html#Model.create_table)).

## Description

Adds a safe parameter to the `generate_schemas` function that inserts the `IF NOT EXISTS` clause when creating the table.

## Motivation and Context

Peewee ORM has the option to generate schemas "safely" by inserting `if not exists` clause to the SQL. This feature is a nice quality of life, especially when deploying to heroku for example where maintaining some state about whether you've created the tables can be a problem. Currently the only way to emulate this is to catch the exception and pass, but this means that if you were to try to add a model to an existing database, it would except after trying to add the first, and fail on the others.

## Issues

Peewee defaults to True on this setting, so I have done the same. However, setting it to insert the clause by default could be seen as a breaking change. Maybe it's fit for version 0.11 in that case? Or should it instead default to False? Either is valid. On one hand, following peewee's example is probably a good idea, however it seems backward to explicitly state you *don't* want to include the clause.

## How Has This Been Tested?

All it does is add the `IF NOT EXISTS` clause. It's just a boolean and an if so there are two tests to check if the clause is inserted when set to True, and not otherwise.

To preserve the functionality of the tests, the safe parameter is [set to `False`](https://github.com/tortoise/tortoise-orm/pull/76/files#diff-2b8db23f3d3d9db1db66e77053e67911R21).

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
