### PR TITLE
In filter fix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+0.11.2
+------
+- Correctly convert values to their db representation when using the "in" filter
+
 0.11.1
 ------
 - Test class isolation fixes & contextvars update

--- a/docs/query.rst
+++ b/docs/query.rst
@@ -182,7 +182,7 @@ When using ``.filter()`` method you can use number of modifiers to field names t
 
     teams = await Team.filter(name__icontains='CON')
 
-
+- ``not``
 - ``in`` - checks if value of field is in passed list
 - ``not_in``
 - ``gte`` - greater or equals than passed value

--- a/tortoise/filters.py
+++ b/tortoise/filters.py
@@ -1,21 +1,23 @@
 import operator
-from typing import Dict, Optional  # noqa
+from typing import Dict, Iterable, Optional  # noqa
 
 from pypika import Table, functions
 from pypika.enums import SqlTypes
 
 from tortoise import fields
+from tortoise.fields import Field
 
 
-def list_encoder(value, instance):
-    return list(value)
+def list_encoder(values, instance, field: Field):
+    """Encodes an iterable of a given field into a database-compatible format."""
+    return [field.to_db_value(element, instance) for element in values]
 
 
-def bool_encoder(value, instance):
+def bool_encoder(value, *args):
     return bool(value)
 
 
-def string_encoder(value, instance):
+def string_encoder(value, *args):
     return str(value)
 
 

--- a/tortoise/query_utils.py
+++ b/tortoise/query_utils.py
@@ -23,7 +23,7 @@ def _process_filter_kwarg(model, key, value) -> Tuple[Criterion, Optional[Tuple[
     else:
         field_object = model._meta.fields_map[param['field']]
         encoded_value = (
-            param['value_encoder'](value, model)
+            param['value_encoder'](value, model, field_object)
             if param.get('value_encoder')
             else model._meta.db.executor_class._field_to_db(field_object, value, model)
         )

--- a/tortoise/tests/test_filters.py
+++ b/tortoise/tests/test_filters.py
@@ -2,7 +2,8 @@ from decimal import Decimal
 
 from tortoise.contrib import test
 from tortoise.exceptions import FieldError
-from tortoise.tests.testmodels import BooleanFields, CharFields, DecimalFields
+from tortoise.tests.testmodels import (BooleanFields, CharFields, DecimalFields, RaceParticipant,
+                                       RacePlacingEnum)
 
 
 class TestCharFieldFilters(test.TestCase):
@@ -211,4 +212,79 @@ class TestDecimalFieldFilters(test.TestCase):
             await DecimalFields.filter(decimal__gt=Decimal('1.2345')).order_by('decimal')
             .values_list('decimal', flat=True),
             [Decimal('2.3'), Decimal('2.3457'), Decimal('23')]
+        )
+
+
+class TestCustomFieldFilters(test.TestCase):
+
+    async def setUp(self):
+        await RaceParticipant.create(
+            first_name="George", place=RacePlacingEnum.FIRST, predicted_place=RacePlacingEnum.SECOND
+        )
+        await RaceParticipant.create(
+            first_name="John", place=RacePlacingEnum.SECOND, predicted_place=RacePlacingEnum.THIRD
+        )
+        await RaceParticipant.create(first_name="Paul", place=RacePlacingEnum.THIRD)
+        await RaceParticipant.create(first_name="Ringo", place=RacePlacingEnum.RUNNER_UP)
+        await RaceParticipant.create(first_name="Stuart", predicted_place=RacePlacingEnum.FIRST)
+
+    async def test_equal(self):
+        self.assertEqual(
+            set(await RaceParticipant
+                .filter(place=RacePlacingEnum.FIRST)
+                .values_list('place', flat=True)),
+            {RacePlacingEnum.FIRST}
+        )
+
+    async def test_not(self):
+        self.assertEqual(
+            set(await RaceParticipant
+                .filter(place__not=RacePlacingEnum.FIRST)
+                .values_list('place', flat=True)),
+            {RacePlacingEnum.SECOND, RacePlacingEnum.THIRD, RacePlacingEnum.RUNNER_UP,
+             RacePlacingEnum.DNF}
+        )
+
+    async def test_in(self):
+        self.assertSetEqual(
+            set(await RaceParticipant
+                .filter(place__in=[RacePlacingEnum.DNF, RacePlacingEnum.RUNNER_UP])
+                .values_list('place', flat=True)),
+            {RacePlacingEnum.DNF, RacePlacingEnum.RUNNER_UP}
+        )
+
+    async def test_not_in(self):
+        self.assertSetEqual(
+            set(await RaceParticipant
+                .filter(place__not_in=[RacePlacingEnum.DNF, RacePlacingEnum.RUNNER_UP])
+                .values_list('place', flat=True)),
+            {RacePlacingEnum.FIRST, RacePlacingEnum.SECOND, RacePlacingEnum.THIRD}
+        )
+
+    async def test_isnull(self):
+        self.assertSetEqual(
+            set(await RaceParticipant
+                .filter(predicted_place__isnull=True)
+                .values_list('first_name', flat=True)),
+            {'Paul', 'Ringo'}
+        )
+        self.assertSetEqual(
+            set(await RaceParticipant
+                .filter(predicted_place__isnull=False)
+                .values_list('first_name', flat=True)),
+            {'George', 'John', 'Stuart'}
+        )
+
+    async def test_not_isnull(self):
+        self.assertSetEqual(
+            set(await RaceParticipant
+                .filter(predicted_place__not_isnull=False)
+                .values_list('first_name', flat=True)),
+            {'Paul', 'Ringo'}
+        )
+        self.assertSetEqual(
+            set(await RaceParticipant
+                .filter(predicted_place__not_isnull=True)
+                .values_list('first_name', flat=True)),
+            {'George', 'John', 'Stuart'}
         )

--- a/tortoise/tests/testfields.py
+++ b/tortoise/tests/testfields.py
@@ -18,10 +18,13 @@ class EnumField(CharField):
         self._enum_type = enum_type
 
     def to_db_value(self, value, instance):
-        if isinstance(value, self._enum_type):
-            return value.value
+        if value is None:
+            return None
 
-        return value
+        if not isinstance(value, self._enum_type):
+            raise TypeError("Expected type {}, got {}".format(self._enum_type, value))
+
+        return value.value
 
     def to_python_value(self, value):
         try:

--- a/tortoise/tests/testmodels.py
+++ b/tortoise/tests/testmodels.py
@@ -162,6 +162,7 @@ class RacePlacingEnum(Enum):
     FIRST = "first"
     SECOND = "second"
     THIRD = "third"
+    RUNNER_UP = "runner_up"
     DNF = "dnf"
 
 


### PR DESCRIPTION
Changes the `list_encoder` to also map the values using the `to_db_value` function defined on the field. Previously it didn't convert them at all meaning that when you extended a field such as the example `EnumField` it would just pass the names of the Enum straight to the database, instead of converting to a string as expected. This means you have to do it yourself, which can be a pain.

```python3
# before
await RaceParticipant.filter(place__in=[RacePlacingEnum.DNF.value, RacePlacingEnum.RUNNER_UP.value])

# fix
await RaceParticipant.filter(place__in=[RacePlacingEnum.DNF, RacePlacingEnum.RUNNER_UP])
```

I also added the `not` clause to the filtering docs which wasn't there for some reason, and cleaned up the EnumField.

## How Has This Been Tested?

I added some tests to make sure that filtering worked properly on custom fields, after finding that the `in` and `not_in` clauses weren't converting my `Enum` into its string representation. Now all the fields that make sense for any field (`equal`, `not`, `in`, `not_in`, `isnull`, `not_isnull`) are tested and working, and the fix has been administered.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

