### PR TITLE
Added some field types

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,12 @@ Changelog
 ------
 - Added "safe" schema generation
 - Correctly convert values to their db representation when using the "in" filter
+- Added some common missing field types:
+
+  - ``BigIntField``
+  - ``TimeDeltaField``
+
+- ``BigIntField`` can also be used as a primary key field.
 
 0.11.1
 ------

--- a/docs/databases.rst
+++ b/docs/databases.rst
@@ -51,4 +51,4 @@ MySQL/MariaDB
 =============
 
 .. todo::
-    Document PostgreSQL options and behaviour
+    Document MySQL/MariaDB options and behaviour

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -86,6 +86,9 @@ Here is list of fields available at the moment with custom options of these fiel
 .. autoclass:: tortoise.fields.IntField
     :exclude-members: to_db_value, to_python_value
 
+.. autoclass:: tortoise.fields.BigIntField
+    :exclude-members: to_db_value, to_python_value
+
 .. autoclass:: tortoise.fields.SmallIntField
     :exclude-members: to_db_value, to_python_value
 
@@ -105,6 +108,9 @@ Here is list of fields available at the moment with custom options of these fiel
     :exclude-members: to_db_value, to_python_value
 
 .. autoclass:: tortoise.fields.DateField
+    :exclude-members: to_db_value, to_python_value
+
+.. autoclass:: tortoise.fields.TimeDeltaField
     :exclude-members: to_db_value, to_python_value
 
 .. autoclass:: tortoise.fields.FloatField

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -1,4 +1,5 @@
 .. _getting_started:
+
 ===============
 Getting started
 ===============

--- a/docs/query.rst
+++ b/docs/query.rst
@@ -173,6 +173,7 @@ Also, Q objects support negated to generate `NOT` clause in your query
 
 
 .. _filtering-queries:
+
 Filtering
 =========
 

--- a/tortoise/backends/base/schema_generator.py
+++ b/tortoise/backends/base/schema_generator.py
@@ -18,13 +18,15 @@ class BaseSchemaGenerator:
         fields.BooleanField: 'BOOL',
         fields.IntField: 'INT',
         fields.SmallIntField: 'SMALLINT',
+        fields.BigIntField: 'BIGINT',
         fields.TextField: 'TEXT',
         fields.CharField: 'VARCHAR({})',
         fields.DatetimeField: 'TIMESTAMP',
         fields.DecimalField: 'DECIMAL({},{})',
+        fields.TimeDeltaField: 'BIGINT',
         fields.DateField: 'DATE',
         fields.FloatField: 'DOUBLE PRECISION',
-        fields.JSONField: 'TEXT'
+        fields.JSONField: 'TEXT',
     }
 
     def __init__(self, client) -> None:
@@ -54,7 +56,7 @@ class BaseSchemaGenerator:
         references = set()
         for field_name, db_field in model._meta.fields_db_projection.items():
             field_object = model._meta.fields_map[field_name]
-            if isinstance(field_object, fields.IntField) and field_object.pk:
+            if isinstance(field_object, (fields.IntField, fields.BigIntField)) and field_object.pk:
                 fields_to_create.append(self._get_primary_key_create_string(field_name))
                 continue
             nullable = 'NOT NULL' if not field_object.null else ''

--- a/tortoise/query_utils.py
+++ b/tortoise/query_utils.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Optional, List, Mapping, Any  # noqa
+from typing import Any, List, Mapping, Optional, Tuple  # noqa
 
 from pypika import Table
 from pypika.terms import Criterion

--- a/tortoise/tests/test_fields.py
+++ b/tortoise/tests/test_fields.py
@@ -14,9 +14,18 @@ class TestIntFields(test.TestCase):
             await testmodels.IntFields.create()
 
     async def test_create(self):
-        obj0 = await testmodels.IntFields.create(intnum=1)
+        obj0 = await testmodels.IntFields.create(intnum=2147483647)
         obj = await testmodels.IntFields.get(id=obj0.id)
-        self.assertEqual(obj.intnum, 1)
+        self.assertEqual(obj.intnum, 2147483647)
+        self.assertEqual(obj.intnum_null, None)
+        await obj.save()
+        obj2 = await testmodels.IntFields.get(id=obj.id)
+        self.assertEqual(obj, obj2)
+
+    async def test_min(self):
+        obj0 = await testmodels.IntFields.create(intnum=-2147483648)
+        obj = await testmodels.IntFields.get(id=obj0.id)
+        self.assertEqual(obj.intnum, -2147483648)
         self.assertEqual(obj.intnum_null, None)
         await obj.save()
         obj2 = await testmodels.IntFields.get(id=obj.id)
@@ -44,9 +53,18 @@ class TestSmallIntFields(test.TestCase):
             await testmodels.SmallIntFields.create()
 
     async def test_create(self):
-        obj0 = await testmodels.SmallIntFields.create(smallintnum=2)
+        obj0 = await testmodels.SmallIntFields.create(smallintnum=32767)
         obj = await testmodels.SmallIntFields.get(id=obj0.id)
-        self.assertEqual(obj.smallintnum, 2)
+        self.assertEqual(obj.smallintnum, 32767)
+        self.assertEqual(obj.smallintnum_null, None)
+        await obj.save()
+        obj2 = await testmodels.SmallIntFields.get(id=obj.id)
+        self.assertEqual(obj, obj2)
+
+    async def test_min(self):
+        obj0 = await testmodels.SmallIntFields.create(smallintnum=-32768)
+        obj = await testmodels.SmallIntFields.get(id=obj0.id)
+        self.assertEqual(obj.smallintnum, -32768)
         self.assertEqual(obj.smallintnum_null, None)
         await obj.save()
         obj2 = await testmodels.SmallIntFields.get(id=obj.id)
@@ -62,6 +80,45 @@ class TestSmallIntFields(test.TestCase):
         values = await testmodels.SmallIntFields.get(
             id=obj0.id).values_list('smallintnum', flat=True)
         self.assertEqual(values[0], 2)
+
+
+class TestBigIntFields(test.TestCase):
+    async def test_empty(self):
+        with self.assertRaises(IntegrityError):
+            await testmodels.BigIntFields.create()
+
+    async def test_create(self):
+        obj0 = await testmodels.BigIntFields.create(intnum=9223372036854775807)
+        obj = await testmodels.BigIntFields.get(id=obj0.id)
+        self.assertEqual(obj.intnum, 9223372036854775807)
+        self.assertEqual(obj.intnum_null, None)
+        await obj.save()
+        obj2 = await testmodels.BigIntFields.get(id=obj.id)
+        self.assertEqual(obj, obj2)
+
+    async def test_min(self):
+        obj0 = await testmodels.BigIntFields.create(intnum=-9223372036854775808)
+        obj = await testmodels.BigIntFields.get(id=obj0.id)
+        self.assertEqual(obj.intnum, -9223372036854775808)
+        self.assertEqual(obj.intnum_null, None)
+        await obj.save()
+        obj2 = await testmodels.BigIntFields.get(id=obj.id)
+        self.assertEqual(obj, obj2)
+
+    async def test_cast(self):
+        obj0 = await testmodels.BigIntFields.create(intnum='3')
+        obj = await testmodels.BigIntFields.get(id=obj0.id)
+        self.assertEqual(obj.intnum, 3)
+
+    async def test_values(self):
+        obj0 = await testmodels.BigIntFields.create(intnum=1)
+        values = await testmodels.BigIntFields.get(id=obj0.id).values('intnum')
+        self.assertEqual(values[0]['intnum'], 1)
+
+    async def test_values_list(self):
+        obj0 = await testmodels.BigIntFields.create(intnum=1)
+        values = await testmodels.BigIntFields.get(id=obj0.id).values_list('intnum', flat=True)
+        self.assertEqual(values[0], 1)
 
 
 class TestCharFields(test.TestCase):
@@ -281,6 +338,35 @@ class TestDateFields(test.TestCase):
         obj0 = await testmodels.DateFields.create(date=today)
         values = await testmodels.DateFields.get(id=obj0.id).values_list('date', flat=True)
         self.assertEqual(values[0], today)
+
+
+class TestTimeDeltaFields(test.TestCase):
+    async def test_empty(self):
+        with self.assertRaises(IntegrityError):
+            await testmodels.TimeDeltaFields.create()
+
+    async def test_create(self):
+        obj0 = await testmodels.TimeDeltaFields.create(
+            timedelta=timedelta(days=35, seconds=8, microseconds=1))
+        obj = await testmodels.TimeDeltaFields.get(id=obj0.id)
+        self.assertEqual(obj.timedelta, timedelta(days=35, seconds=8, microseconds=1))
+        self.assertEqual(obj.timedelta_null, None)
+        await obj.save()
+        obj2 = await testmodels.TimeDeltaFields.get(id=obj.id)
+        self.assertEqual(obj, obj2)
+
+    async def test_values(self):
+        obj0 = await testmodels.TimeDeltaFields.create(
+            timedelta=timedelta(days=35, seconds=8, microseconds=1))
+        values = await testmodels.TimeDeltaFields.get(id=obj0.id).values('timedelta')
+        self.assertEqual(values[0]['timedelta'], timedelta(days=35, seconds=8, microseconds=1))
+
+    async def test_values_list(self):
+        obj0 = await testmodels.TimeDeltaFields.create(
+            timedelta=timedelta(days=35, seconds=8, microseconds=1))
+        values = await testmodels.TimeDeltaFields.get(id=obj0.id).values_list(
+            'timedelta', flat=True)
+        self.assertEqual(values[0], timedelta(days=35, seconds=8, microseconds=1))
 
 
 class TestFloatFields(test.TestCase):

--- a/tortoise/tests/testmodels.py
+++ b/tortoise/tests/testmodels.py
@@ -88,6 +88,12 @@ class IntFields(Model):
     intnum_null = fields.IntField(null=True)
 
 
+class BigIntFields(Model):
+    id = fields.BigIntField(pk=True)
+    intnum = fields.BigIntField()
+    intnum_null = fields.BigIntField(null=True)
+
+
 class SmallIntFields(Model):
     id = fields.IntField(pk=True)
     smallintnum = fields.SmallIntField()
@@ -125,6 +131,12 @@ class DatetimeFields(Model):
     datetime_null = fields.DatetimeField(null=True)
     datetime_auto = fields.DatetimeField(auto_now=True)
     datetime_add = fields.DatetimeField(auto_now_add=True)
+
+
+class TimeDeltaFields(Model):
+    id = fields.IntField(pk=True)
+    timedelta = fields.TimeDeltaField()
+    timedelta_null = fields.TimeDeltaField(null=True)
 
 
 class DateFields(Model):


### PR DESCRIPTION
New fields:
- `BigIntField`
- `TimeDeltaField`

`BigIntField` can also be used as a primary key field.
Also extended the int tests to check that max/min values are stored.
Updated docs.
bumped version to v0.11.2

**Extra notes:**
I wanted to also add the following but didn't:
* `BinaryField` → Limitation of pypika. Only supports string-represented types, we need full parametrised queries functionality.
* `TinyInt`, `Unsigned*Int` → Not supported in PostgreSQL (not part of the SQL standard apparently)
  Django only supports uint2 and unit4 and seems to cast them to larger integer values in postgres with a check limit. This violates the least surprise principle, so I'm uncomfortable doing that.