### PR TITLE
Fix typos in JSONField docstring

### DIFF
--- a/tortoise/fields.py
+++ b/tortoise/fields.py
@@ -252,9 +252,9 @@ class JSONField(Field):
     This field can store dictionaries or lists of any JSON-compliant structure.
 
     ``encoder``:
-        The JSON encoder. The default is recommemded.
+        The JSON encoder. The default is recommended.
     ``decoder``:
-        The JSON decoder. The default is recommemded.
+        The JSON decoder. The default is recommended.
     """
     __slots__ = ('encoder', 'decoder')
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix "recommemded" typo in `JSONField` in `fields.py`

## Motivation and Context
This change is required for the sake of correct spelling. :)

## How Has This Been Tested?
- Ran `make deps`
- Ran `make test`
- Ran `make docs`
- Opened `index.html` in my browser and navigated to the fields page, with corrected typo.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

