### PR TITLE
Remove parameter hack now that PyPika support Parametrized queries

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,7 +17,7 @@ atomicwrites==1.2.1       # via pytest
 attrs==18.2.0             # via pytest
 babel==2.6.0              # via sphinx
 bandit==1.5.1
-bleach==3.0.2             # via readme-renderer
+bleach==3.1.0             # via readme-renderer
 certifi==2018.11.29       # via requests
 cffi==1.11.5              # via cryptography
 chardet==3.0.4            # via requests
@@ -52,8 +52,8 @@ nose2==0.8.0
 packaging==18.0           # via sphinx
 pbr==5.1.1                # via stevedore
 pip-tools==3.2.0
-pkginfo==1.4.2            # via twine
-pluggy==0.8.0             # via pytest, tox
+pkginfo==1.5.0.1          # via twine
+pluggy==0.8.1             # via pytest, tox
 py==1.7.0                 # via pytest, tox
 pycodestyle==2.4.0        # via flake8
 pycparser==2.19           # via cffi
@@ -61,10 +61,10 @@ pyflakes==2.0.0           # via flake8
 pygments==2.3.1
 pylint==2.2.2
 pymysql==0.9.2            # via aiomysql
-pyparsing==2.3.0          # via packaging
-pypika==0.19.0
-pytest==4.1.0
-pytz==2018.7              # via babel
+pyparsing==2.3.1          # via packaging
+pypika==0.21.0
+pytest==4.1.1
+pytz==2018.9              # via babel
 pyyaml==3.13
 readme-renderer==24.0     # via twine
 requests-toolbelt==0.8.0  # via twine
@@ -77,15 +77,15 @@ sphinx==1.8.3
 sphinxcontrib-websupport==1.1.0  # via sphinx
 stevedore==1.30.0         # via bandit
 termstyle==0.1.11         # via green
-testfixtures==6.4.1       # via flake8-isort
+testfixtures==6.4.3       # via flake8-isort
 toml==0.10.0              # via tox
-tox==3.6.1
-tqdm==4.28.1              # via twine
+tox==3.7.0
+tqdm==4.29.1              # via twine
 twine==1.12.1
-typed-ast==1.1.1          # via astroid, mypy
+typed-ast==1.1.2          # via astroid, mypy
 unidecode==1.0.23         # via green
 urllib3==1.24.1           # via requests
 virtualenv==16.2.0        # via tox
 webencodings==0.5.1       # via bleach
-wrapt==1.10.11            # via astroid
+wrapt==1.11.0             # via astroid
 yapf==0.25.0

--- a/requirements-pypy.txt
+++ b/requirements-pypy.txt
@@ -21,7 +21,7 @@ idna==2.8                 # via cryptography
 immutables==0.6           # via contextvars
 pycparser==2.19           # via cffi
 pymysql==0.9.2            # via aiomysql
-pypika==0.19.0
+pypika==0.21.0
 pyyaml==3.13
 six==1.12.0               # via cryptography
 termstyle==0.1.11         # via green

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pypika>=0.18.0
+pypika>=0.21.0
 ciso8601>=2.1
 aiocontextvars>=0.2;python_version<"3.7"
 aiosqlite>=0.8.0

--- a/tortoise/backends/asyncpg/executor.py
+++ b/tortoise/backends/asyncpg/executor.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from pypika import Table
+from pypika import Parameter, Table
 
 from tortoise.backends.base.executor import BaseExecutor
 
@@ -9,5 +9,5 @@ class AsyncpgExecutor(BaseExecutor):
     def _prepare_insert_statement(self, columns: List[str]) -> str:
         return str(
             self.db.query_class.into(Table(self.model._meta.table)).columns(*columns)
-            .insert('???').returning('id')
-        ).replace("'???'", ','.join(['$%d' % (i + 1, ) for i in range(len(columns))]))
+            .insert(*[Parameter('$%d' % (i + 1, )) for i in range(len(columns))]).returning('id')
+        )

--- a/tortoise/backends/base/executor.py
+++ b/tortoise/backends/base/executor.py
@@ -20,7 +20,7 @@ class BaseExecutor:
         self._prefetch_queries = prefetch_queries if prefetch_queries else {}
 
     async def execute_select(self, query, custom_fields: Optional[list] = None) -> list:
-        raw_results = await self.db.execute_query(str(query))
+        raw_results = await self.db.execute_query(query.get_sql())
         instance_list = []
         for row in raw_results:
             instance = self.model(**row)
@@ -83,13 +83,13 @@ class BaseExecutor:
                     self._field_to_db(field_object, getattr(instance, field), instance)
                 )
         query = query.where(table.id == instance.id)
-        await self.db.execute_query(str(query))
+        await self.db.execute_query(query.get_sql())
         return instance
 
     async def execute_delete(self, instance):
         table = Table(self.model._meta.table)
         query = self.model._meta.basequery.where(table.id == instance.id).delete()
-        await self.db.execute_query(str(query))
+        await self.db.execute_query(query.get_sql())
         return instance
 
     async def _prefetch_reverse_relation(self, instance_list: list, field: str,
@@ -160,7 +160,7 @@ class BaseExecutor:
             if having_criterion:
                 query = query.having(having_criterion)
 
-        raw_results = await self.db.execute_query(str(query))
+        raw_results = await self.db.execute_query(query.get_sql())
         relations = {(e['_backward_relation_key'], e['id']) for e in raw_results}
         related_object_list = [related_query.model(**e) for e in raw_results]
         await self.__class__(

--- a/tortoise/backends/mysql/executor.py
+++ b/tortoise/backends/mysql/executor.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from pypika import MySQLQuery, Table, functions
+from pypika import MySQLQuery, Parameter, Table, functions
 from pypika.enums import SqlTypes
 
 from tortoise.backends.base.executor import BaseExecutor
@@ -51,5 +51,5 @@ class MySQLExecutor(BaseExecutor):
     def _prepare_insert_statement(self, columns: List[str]) -> str:
         return str(
             MySQLQuery.into(Table(self.model._meta.table)).columns(*columns)
-            .insert('???')
-        ).replace("'???'", ','.join(['%s' for _ in range(len(columns))]))
+            .insert(*[Parameter('%s') for _ in range(len(columns))])
+        )

--- a/tortoise/backends/sqlite/executor.py
+++ b/tortoise/backends/sqlite/executor.py
@@ -1,7 +1,7 @@
 from decimal import Decimal
 from typing import List
 
-from pypika import Table
+from pypika import Parameter, Table
 
 from tortoise import fields
 from tortoise.backends.base.executor import BaseExecutor
@@ -32,5 +32,5 @@ class SqliteExecutor(BaseExecutor):
     def _prepare_insert_statement(self, columns: List[str]) -> str:
         return str(
             self.db.query_class.into(Table(self.model._meta.table)).columns(*columns)
-            .insert('???')
-        ).replace("'???'", ','.join(['?' for _ in range(len(columns))]))
+            .insert(*[Parameter('?') for _ in range(len(columns))])
+        )


### PR DESCRIPTION
This only removes the hack to generate a parametrized query. It now uses the PyPika `Parameter()` function from v0.21

This is only for inserts.


### This PR does not address the following:
* Adds proper parameter support for filtering and updating, so we become immune to SQL injection.
* Manage prepared statements for reasons of performance.
  * E.g. for a simple `.get()` operation, we spend about 40% of the time generating a SQL query, that will now be cacheable. But do we try and do this automatically, or expose a preparation API to the user?