### PR TITLE
Add `QuerySet.explain()`

### DIFF
--- a/tortoise/backends/asyncpg/client.py
+++ b/tortoise/backends/asyncpg/client.py
@@ -117,6 +117,15 @@ class AsyncpgDBClient(BaseDBAsyncClient):
             self.log.debug(query)
             await connection.execute(query)
 
+    @translate_exceptions
+    async def execute_explain(self, query: str) -> str:
+        async with self.acquire_connection() as connection:
+            self.log.debug("%s %s", "EXPLAIN", query)
+            prepared = await connection.prepare(query)
+            plan = await prepared.explain()  # type: dict
+            # TODO properly convert to string
+            return str(plan)
+
 
 class TransactionWrapper(AsyncpgDBClient, BaseTransactionWrapper):
     def __init__(self, connection_name: str, connection) -> None:

--- a/tortoise/backends/base/client.py
+++ b/tortoise/backends/base/client.py
@@ -43,6 +43,9 @@ class BaseDBAsyncClient:
     async def execute_script(self, query: str) -> None:
         raise NotImplementedError()  # pragma: nocoverage
 
+    async def execute_explain(self, query: str) -> Sequence[dict]:
+        raise NotImplementedError()
+
 
 class ConnectionWrapper:
     __slots__ = ('connection', )

--- a/tortoise/backends/base/executor.py
+++ b/tortoise/backends/base/executor.py
@@ -19,6 +19,9 @@ class BaseExecutor:
         self.prefetch_map = prefetch_map if prefetch_map else {}
         self._prefetch_queries = prefetch_queries if prefetch_queries else {}
 
+    async def execute_explain(self, query, format: Optional[str] = None, **options) -> str:
+        return await self.db.execute_explain(query.get_sql())
+
     async def execute_select(self, query, custom_fields: Optional[list] = None) -> list:
         raw_results = await self.db.execute_query(query.get_sql())
         instance_list = []

--- a/tortoise/backends/sqlite/executor.py
+++ b/tortoise/backends/sqlite/executor.py
@@ -28,6 +28,7 @@ class SqliteExecutor(BaseExecutor):
         fields.BooleanField: to_db_bool,
         fields.DecimalField: to_db_decimal,
     }
+    EXPLAIN_PREFIX = 'EXPLAIN QUERY PLAN'
 
     def _prepare_insert_statement(self, columns: List[str]) -> str:
         return str(

--- a/tortoise/backends/sqlite/executor.py
+++ b/tortoise/backends/sqlite/executor.py
@@ -28,7 +28,6 @@ class SqliteExecutor(BaseExecutor):
         fields.BooleanField: to_db_bool,
         fields.DecimalField: to_db_decimal,
     }
-    EXPLAIN_PREFIX = 'EXPLAIN QUERY PLAN'
 
     def _prepare_insert_statement(self, columns: List[str]) -> str:
         return str(

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -85,7 +85,7 @@ class QuerySet(AwaitableQuery):
     __slots__ = ('fields', '_prefetch_map', '_prefetch_queries',
                  '_single', '_get', '_count', '_db', '_limit', '_offset', '_filter_kwargs',
                  '_orderings', '_q_objects', '_distinct',
-                 '_annotations', '_having', '_custom_filters')
+                 '_annotations', '_having', '_custom_filters', '_explain')
 
     def __init__(self, model) -> None:
         super().__init__(model, None)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds support for executing an `EXPLAIN` statement against the query represented by a `QuerySet`.

## Motivation and Context
Fixes #90 

## How Has This Been Tested?
> TODO

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## TODO:

- [x] Implement the base explain API (`QuerySet`, `Executor`, `AsyncDBClient`)
- [x] Implement for PostgreSQL
- [ ] Better format the PostgreSQL output
- [ ] Implement for MySQL
- [ ] Implement for SQLite
- [ ] Add tests
- [ ] Add docs
