### PR TITLE
WIP: Basic serializers framework

### DIFF
--- a/tortoise/contrib/pydantic/__init__.py
+++ b/tortoise/contrib/pydantic/__init__.py
@@ -1,19 +1,19 @@
 import datetime
 import decimal
 import json
-from typing import Any, Dict, Optional, Set, TypeVar, Tuple, Type, Union  # noqa
+from typing import Any, Dict, Optional, Set, Tuple, Type, TypeVar, Union  # noqa
 
 from tortoise import fields
 from tortoise.fields import Field
 from tortoise.serializers.backends import SerializationBackend
 from tortoise.serializers.datatypes import Data
-from tortoise.serializers.exceptions import ValidationError
+from tortoise.serializers.exceptions import MissingDependencies, ValidationError
 from tortoise.serializers.field_utils import is_read_only
 
 try:
     from pydantic import BaseModel, ValidationError as PydanticValidationError, create_model
 except ImportError as exc:
-    raise exc from None
+    raise MissingDependencies('pydantic') from exc
 
 T = TypeVar('T')
 Definition = Union[Any, Tuple[Type, Any]]

--- a/tortoise/contrib/pydantic/__init__.py
+++ b/tortoise/contrib/pydantic/__init__.py
@@ -1,0 +1,121 @@
+import datetime
+import decimal
+import json
+from typing import Any, Dict, Optional, Set, TypeVar, Tuple, Type, Union  # noqa
+
+from tortoise import fields
+from tortoise.fields import Field
+from tortoise.serializers.backends import SerializationBackend
+from tortoise.serializers.datatypes import Data
+from tortoise.serializers.field_utils import is_read_only
+
+try:
+    from pydantic import BaseModel, ValidationError, create_model
+except ImportError as exc:
+    raise exc from None
+
+T = TypeVar('T')
+Definition = Union[Any, Tuple[Type, Any]]
+
+
+_FIELD_TO_PYDANTIC_TYPE = {
+    fields.IntField: int,
+    fields.BigIntField: int,
+    fields.SmallIntField: int,
+    fields.CharField: str,
+    fields.TextField: str,
+    fields.BooleanField: bool,
+    fields.DecimalField: decimal.Decimal,
+    fields.DatetimeField: datetime.datetime,
+    fields.DateField: datetime.date,
+    fields.TimeDeltaField: datetime.timedelta,
+    fields.FloatField: float,
+    fields.JSONField: Union[dict, list],
+}
+
+_REQUIRED = ...
+
+
+class Ignore(Exception):
+    pass
+
+
+class PydanticSerializationBackend(SerializationBackend):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._read_schema: Optional[Type[BaseModel]] = None
+        self._write_schema: Optional[Type[BaseModel]] = None
+
+    def _get_schema(self, operation: str, instance: Optional[T] = None) -> Type[BaseModel]:
+        """Create a Pydantic model for the given serialization operation."""
+        definitions: Dict[str, Definition] = {}
+
+        for field_name in self.get_field_names():
+            try:
+                definition = self.build_field(field_name, operation, instance=instance)
+            except Ignore:
+                pass
+            else:
+                definitions[field_name] = definition
+
+        return create_model(self.config.model.__name__, **definitions)
+
+    def get_field_names(self) -> Set[str]:
+        return (
+            super().get_field_names()
+            .union(set(getattr(self, "__annotations__", [])))
+        )
+
+    def build_field(
+        self, field_name: str, operation: str, instance: Optional[T] = None
+    ) -> Optional[Definition]:
+        try:
+            field: Field = self.config.model._meta.fields_map[field_name]
+        except KeyError:
+            # Treat as a read-only property.
+            if operation == "write":
+                raise Ignore
+            return getattr(instance, field_name)
+        else:
+            # Tortoise field
+            if operation == "write" and is_read_only(field):
+                raise Ignore
+
+            write_only = False  # Not implemented yet
+            if operation == "read" and write_only:
+                raise Ignore
+
+            type_ = _FIELD_TO_PYDANTIC_TYPE[field.__class__]
+            value = _REQUIRED  # type: Union[None, ellipsis, Any]
+
+            if field.default is None and field.null:
+                value = None
+            elif field.default is not None:
+                if callable(field.default):
+                    raise AssertionError('Callable default values are not supported yet.')
+                value = field.default
+
+            return (type_, value)
+
+    def to_internal_value(self, data: Data) -> Data:
+        """Convert a native dict of values to a Python dict of values."""
+        schema = self._get_schema("write")
+        try:
+            obj = schema(**data)
+        except ValidationError as exc:
+            raise exc from None
+        else:
+            return obj.dict()
+
+    def to_representation(self, instance: T) -> Data:
+        """Convert a Python object to a native dict of values."""
+        schema = self._get_schema("read", instance=instance)
+        data = {
+            attr: getattr(instance, attr)
+            for attr in schema.__fields__.keys()
+        }
+        return json.loads(schema(**data).json())
+
+
+backend = PydanticSerializationBackend

--- a/tortoise/contrib/pydantic/__init__.py
+++ b/tortoise/contrib/pydantic/__init__.py
@@ -1,10 +1,9 @@
 import datetime
 import decimal
 import json
-from typing import Any, Dict, Optional, Set, Tuple, Type, TypeVar, Union  # noqa
+from typing import Any, Dict, Optional, Set, Tuple, Type, TypeVar, Union, Callable  # noqa
 
 from tortoise import fields
-from tortoise.fields import Field
 from tortoise.serializers.backends import SerializationBackend
 from tortoise.serializers.datatypes import Data
 from tortoise.serializers.exceptions import MissingDependencies, ValidationError
@@ -45,12 +44,12 @@ class PydanticSerializationBackend(SerializationBackend):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._read_schema: Optional[Type[BaseModel]] = None
-        self._write_schema: Optional[Type[BaseModel]] = None
+        self._read_schema = None  # type: Optional[Type[BaseModel]]
+        self._write_schema = None  # type: Optional[Type[BaseModel]]
 
     def _get_schema(self, operation: str, instance: Optional[T] = None) -> Type[BaseModel]:
         """Create a Pydantic model for the given serialization operation."""
-        definitions: Dict[str, Definition] = {}
+        definitions = {}  # type: Dict[str, Definition]
 
         for field_name in self.get_field_names():
             try:
@@ -72,7 +71,7 @@ class PydanticSerializationBackend(SerializationBackend):
         self, field_name: str, operation: str, instance: Optional[T] = None
     ) -> Optional[Definition]:
         try:
-            field: Field = self.config.model._meta.fields_map[field_name]
+            field = self.config.model._meta.fields_map[field_name]  # type: fields.Field
         except KeyError:
             # Treat as a read-only property.
             if operation == 'write':
@@ -88,7 +87,7 @@ class PydanticSerializationBackend(SerializationBackend):
                 raise Ignore
 
             type_ = _FIELD_TO_PYDANTIC_TYPE[field.__class__]
-            value = _REQUIRED  # type: Union[None, ellipsis, Any]
+            value = _REQUIRED  # type: Union[None, ellipsis, Any, Callable]
 
             if field.default is None and field.null:
                 value = None

--- a/tortoise/serializers/__init__.py
+++ b/tortoise/serializers/__init__.py
@@ -1,0 +1,2 @@
+from .base import BaseSerializer  # noqa
+from .impl import ModelSerializer, Serializer  # noqa

--- a/tortoise/serializers/backends.py
+++ b/tortoise/serializers/backends.py
@@ -1,0 +1,40 @@
+from importlib import import_module
+from typing import Any, Set
+
+from .datatypes import Data
+from .meta import MetaInfo
+
+
+class SerializationBackend:
+    """Base serialization backend class."""
+
+    def __init__(self, config: MetaInfo):
+        self.config = config
+
+    def get_declared_fields(self) -> Set[str]:
+        return self.config.fields
+
+    def get_excluded_fields(self) -> Set[str]:
+        return self.config.exclude
+
+    def get_field_names(self) -> Set[str]:
+        return self.get_declared_fields().difference(self.get_excluded_fields())
+
+    def to_internal_value(self, data: Data) -> Data:
+        raise NotImplementedError
+
+    def to_representation(self, instance: Any) -> Data:
+        raise NotImplementedError
+
+
+def load_serialization_backend(name: str) -> SerializationBackend:
+    try:
+        module = import_module("tortoise.contrib.{}".format(name))  # type: Any
+    except ModuleNotFoundError as exc:
+        raise ImportError("Backend '{}' does not exist.".format(name)) from exc
+    except ImportError as exc:
+        raise ImportError(
+            "Backend '{}' found, but some dependencies need to be installed."
+        ) from exc
+
+    return module.backend

--- a/tortoise/serializers/backends.py
+++ b/tortoise/serializers/backends.py
@@ -8,7 +8,8 @@ from .meta import MetaInfo
 class SerializationBackend:
     """Base serialization backend class."""
 
-    def __init__(self, config: MetaInfo):
+    def __init__(self, serializer, config: MetaInfo):
+        self.serializer = serializer
         self.config = config
 
     def get_declared_fields(self) -> Set[str]:
@@ -29,12 +30,13 @@ class SerializationBackend:
 
 def load_serialization_backend(name: str) -> SerializationBackend:
     try:
-        module = import_module("tortoise.contrib.{}".format(name))  # type: Any
+        module = import_module('tortoise.contrib.{}'.format(name))  # type: Any
     except ModuleNotFoundError as exc:
-        raise ImportError("Backend '{}' does not exist.".format(name)) from exc
+        raise ImportError('Backend "{}" does not exist.'.format(name)) from exc
     except ImportError as exc:
         raise ImportError(
-            "Backend '{}' found, but some dependencies need to be installed."
+            'Backend "{}" found, but dependency "{}" is not installed.'
+            .format(name, exc.name)
         ) from exc
 
     return module.backend

--- a/tortoise/serializers/base.py
+++ b/tortoise/serializers/base.py
@@ -10,7 +10,7 @@ T = TypeVar('T')
 class BaseSerializerMeta(type):
 
     def __new__(mcs, name: str, bases: tuple, attrs: dict):
-        attrs["_meta"] = MetaInfo(attrs.get("Meta"))
+        attrs['_meta'] = MetaInfo(attrs.get('Meta'))
         return super().__new__(mcs, name, bases, attrs)
 
 
@@ -20,9 +20,15 @@ class BaseSerializer(Generic[T], metaclass=BaseSerializerMeta):
     _meta = MetaInfo(None)
 
     def to_internal_value(self, data: Data) -> Data:
+        """Convert a native dict of values to a Python dict of values.
+
+        Concrete implementations should validate the given data and return
+        its validated version, or raise a `ValidationError` if validation has failed.
+        """
         raise NotImplementedError
 
     def to_representation(self, instance: T) -> Data:
+        """Convert a Python object to a native dict of values."""
         raise NotImplementedError
 
     def validate(self, data: Data) -> Data:
@@ -34,6 +40,7 @@ class BaseSerializer(Generic[T], metaclass=BaseSerializerMeta):
             return validated_data
 
     def dump(self, instance: T) -> Data:
+        # Simple alias: `to_representation()` is a very long name!
         return self.to_representation(instance)
 
     async def perform_create(self, validated_data: Data) -> T:

--- a/tortoise/serializers/base.py
+++ b/tortoise/serializers/base.py
@@ -1,0 +1,51 @@
+from typing import Generic, TypeVar
+
+from .datatypes import Data
+from .exceptions import ValidationError
+from .meta import MetaInfo
+
+T = TypeVar('T')
+
+
+class BaseSerializerMeta(type):
+
+    def __new__(mcs, name: str, bases: tuple, attrs: dict):
+        attrs["_meta"] = MetaInfo(attrs.get("Meta"))
+        return super().__new__(mcs, name, bases, attrs)
+
+
+class BaseSerializer(Generic[T], metaclass=BaseSerializerMeta):
+
+    # Fix for autocompletion / static analysis.
+    _meta = MetaInfo(None)
+
+    def to_internal_value(self, data: Data) -> Data:
+        raise NotImplementedError
+
+    def to_representation(self, instance: T) -> Data:
+        raise NotImplementedError
+
+    def validate(self, data: Data) -> Data:
+        try:
+            validated_data = self.to_internal_value(data)
+        except ValidationError as exc:
+            raise exc from None
+        else:
+            return validated_data
+
+    def dump(self, instance: T) -> Data:
+        return self.to_representation(instance)
+
+    async def perform_create(self, validated_data: Data) -> T:
+        raise NotImplementedError
+
+    async def perform_update(self, instance: T, validated_data: Data) -> T:
+        raise NotImplementedError
+
+    async def create(self, data: Data) -> T:
+        validated_data = self.validate(data)
+        return await self.perform_create(validated_data)
+
+    async def update(self, instance: T, data: Data) -> T:
+        validated_data = self.validate(data)
+        return await self.perform_update(instance, validated_data)

--- a/tortoise/serializers/datatypes.py
+++ b/tortoise/serializers/datatypes.py
@@ -1,0 +1,3 @@
+# from typing import Union
+
+Data = dict

--- a/tortoise/serializers/exceptions.py
+++ b/tortoise/serializers/exceptions.py
@@ -1,5 +1,8 @@
+from typing import List
+
+
 class ValidationError(Exception):
 
-    def __init__(self, errors):
+    def __init__(self, errors: List[str]):
         super().__init__()
         self.errors = errors

--- a/tortoise/serializers/exceptions.py
+++ b/tortoise/serializers/exceptions.py
@@ -1,0 +1,5 @@
+class ValidationError(Exception):
+
+    def __init__(self, errors):
+        super().__init__()
+        self.errors = errors

--- a/tortoise/serializers/exceptions.py
+++ b/tortoise/serializers/exceptions.py
@@ -2,7 +2,16 @@ from typing import List
 
 
 class ValidationError(Exception):
+    """Raised when inbound data has failed validation."""
 
     def __init__(self, errors: List[str]):
         super().__init__()
         self.errors = errors
+
+
+class MissingDependencies(Exception):
+    """Raised when one or more of a backend's dependencies are not installed."""
+
+    def __init__(self, *dependencies: str):
+        super().__init__()
+        self.dependencies = dependencies

--- a/tortoise/serializers/field_utils.py
+++ b/tortoise/serializers/field_utils.py
@@ -1,0 +1,9 @@
+from tortoise.fields import Field
+
+
+def is_read_only(field: Field) -> bool:
+    return (
+        field.pk
+        or getattr(field, "auto_now", False)
+        or getattr(field, "auto_now_add", False)
+    )

--- a/tortoise/serializers/field_utils.py
+++ b/tortoise/serializers/field_utils.py
@@ -4,6 +4,6 @@ from tortoise.fields import Field
 def is_read_only(field: Field) -> bool:
     return (
         field.pk
-        or getattr(field, "auto_now", False)
-        or getattr(field, "auto_now_add", False)
+        or getattr(field, 'auto_now', False)
+        or getattr(field, 'auto_now_add', False)
     )

--- a/tortoise/serializers/impl.py
+++ b/tortoise/serializers/impl.py
@@ -12,22 +12,20 @@ T = TypeVar('T')
 class Serializer(BaseSerializer[T]):  # pylint: disable=unsubscriptable-object
     """A concrete serializer class backed by a serialization backend."""
 
-    serialization_backend: Union[None, str, Type[SerializationBackend]] = None
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.backend = self._get_backend()
 
     def _get_backend(self) -> SerializationBackend:
-        backend = getattr(self, "serialization_backend")
+        backend = self._meta.options.get('backend')
 
         if backend is None:
-            raise AssertionError("`serialization_backend` class attribute should be set.")
+            raise AssertionError('A value for `backend` should be set in `Meta.options`.')
 
         if isinstance(backend, str):
             backend = load_serialization_backend(backend)
 
-        return backend(config=self._meta)
+        return backend(serializer=self, config=self._meta)
 
     def to_internal_value(self, data: Data) -> Data:
         return self.backend.to_internal_value(data)

--- a/tortoise/serializers/impl.py
+++ b/tortoise/serializers/impl.py
@@ -1,0 +1,49 @@
+from typing import Generic, TypeVar, Type, Union  # noqa
+
+from tortoise.models import Model
+
+from .backends import SerializationBackend, load_serialization_backend
+from .base import BaseSerializer
+from .datatypes import Data
+
+T = TypeVar('T')
+
+
+class Serializer(BaseSerializer[T]):  # pylint: disable=unsubscriptable-object
+    """A concrete serializer class backed by a serialization backend."""
+
+    serialization_backend: Union[None, str, Type[SerializationBackend]] = None
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.backend = self._get_backend()
+
+    def _get_backend(self) -> SerializationBackend:
+        backend = getattr(self, "serialization_backend")
+
+        if backend is None:
+            raise AssertionError("`serialization_backend` class attribute should be set.")
+
+        if isinstance(backend, str):
+            backend = load_serialization_backend(backend)
+
+        return backend(config=self._meta)
+
+    def to_internal_value(self, data: Data) -> Data:
+        return self.backend.to_internal_value(data)
+
+    def to_representation(self, instance: T) -> Data:
+        return self.backend.to_representation(instance)
+
+
+class ModelSerializer(Serializer[Model]):
+    """A concrete model serializer class."""
+
+    async def perform_create(self, validated_data: Data) -> Model:
+        return await self._meta.model.create(**validated_data)
+
+    async def perform_update(self, instance: Model, validated_data: Data) -> Model:
+        for attr, value in validated_data.items():
+            setattr(instance, attr, value)
+        await instance.save()
+        return instance

--- a/tortoise/serializers/meta.py
+++ b/tortoise/serializers/meta.py
@@ -5,6 +5,7 @@ from tortoise.models import Model  # noqa
 class MetaInfo:
 
     def __init__(self, meta: Any):
-        self.model = getattr(meta, "model", None)  # type: Type[Model]
-        self.fields = getattr(meta, "fields", set())  # type: Set[str]
-        self.exclude = getattr(meta, "exclude", set())  # type: Set[str]
+        self.model = getattr(meta, 'model', None)  # type: Type[Model]
+        self.fields = getattr(meta, 'fields', set())  # type: Set[str]
+        self.exclude = getattr(meta, 'exclude', set())  # type: Set[str]
+        self.options = getattr(meta, 'options', {})  # type: dict

--- a/tortoise/serializers/meta.py
+++ b/tortoise/serializers/meta.py
@@ -1,0 +1,10 @@
+from typing import Any, Set, Type  # noqa
+from tortoise.models import Model  # noqa
+
+
+class MetaInfo:
+
+    def __init__(self, meta: Any):
+        self.model = getattr(meta, "model", None)  # type: Type[Model]
+        self.fields = getattr(meta, "fields", set())  # type: Set[str]
+        self.exclude = getattr(meta, "exclude", set())  # type: Set[str]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This is a basic implementation of a serializers "framework" which would allow to perform the following operations:

```python
from tortoise.models import Model
from tortoise import fields
from tortoise.serializers import ModelSerializer


class Book(Model):
    title = fields.CharField(max_length=200)
    content = fields.TextField()


class BookSerializer(ModelSerializer):

    class Meta:
        model = Book
        options = {"backend": "pydantic"}


async def main():
    serializer = BookSerializer()

    # Serialization:
    data = serializer.dump(book)

    # Deserialization:
    data = {"title": "foo", "content": "bar"}
    book = await serializer.create(data)
    updated_book = await serializer.update(book, data)

    # Validation only:
    data = {"title": "foo", "content": "bar"}
    validated_data = serializer.validate(data)
```

We have a base class, `BaseSerializer`, which defines anything that can be defined without making further assumptions on the implementation, i.e. the basic API and workflow.

Then, two concrete serializers:
- `Serializer` performs serialization, deserialization and validation as provided by third-party libraries. This is implemented by the concept of "serialization backend", which are used to implement `.to_internal_value()` and `.to_representation()`. It can be defined on the 
- `ModelSerializer` ties everything up and defines how deserialized objects should be saved to the DB by implementing `.create()` and `.update()`.

This is flexible enough to allow using serializers outside the scope of models.

This PR also comes with a serialization backend based on Pydantic. It works by generating Pydantic schemas based on the `Meta.model` attribute.

I'm pretty sure there will be many subtleties and API tweaks to figure out (e.g. how to allow to make the most out of the library behind the serialization backend?), but at least this would provide basic ser/de capabilities.

## Motivation and Context
Fixes #13?

## How Has This Been Tested?
Not tested yet.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Other TODOs

- [ ] Add support for dealing with a list of objects, e.g. using a `many=True` option.
- [ ] How can we define a default serialization backend? We wouldn't want to have to specify it everytime. Or should it be auto-detected based on what's installed?
