### PR TITLE
Differentiate between timezone aware and timezone naive datetimes

### DIFF
--- a/tortoise/fields.py
+++ b/tortoise/fields.py
@@ -223,7 +223,9 @@ class DatetimeField(Field):
             if self.in_timezone is not None:
                 value = value.astimezone(self.in_timezone).replace(tzinfo=None)
             else:
-                raise ValueError(f"Timezone aware datetime {value} supplied to DatetimeField")
+                raise ValueError(
+                    "Timezone aware datetime {} supplied to DatetimeField".format(value)
+                )
         return value
 
 

--- a/tortoise/tests/test_fields.py
+++ b/tortoise/tests/test_fields.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 from time import sleep
 
@@ -322,6 +322,20 @@ class TestDatetimeFields(test.TestCase):
         obj0 = await testmodels.DatetimeFields.create(datetime=now)
         values = await testmodels.DatetimeFields.get(id=obj0.id).values_list('datetime', flat=True)
         self.assertEqual(values[0], now)
+
+    async def test_timezone_aware(self):
+        now = datetime.now(timezone.utc)
+        with self.assertRaises(ValueError):
+            await testmodels.DatetimeFields.create(datetime=now)
+
+    async def test_timezone_aware_conversion(self):
+        now = datetime.now(timezone.utc)
+        obj0 = await testmodels.DatetimeFields.create(
+            datetime=now.replace(tzinfo=None),
+            datetime_aware=now
+        )
+        obj = await testmodels.DatetimeFields.get(id=obj0.id)
+        self.assertIsNot(obj.datetime_aware.tzinfo, None)
 
 
 class TestDateFields(test.TestCase):

--- a/tortoise/tests/testmodels.py
+++ b/tortoise/tests/testmodels.py
@@ -3,6 +3,7 @@ This is the testing Models
 """
 import binascii
 import os
+from datetime import timezone
 from enum import Enum
 
 from tortoise import fields
@@ -131,6 +132,7 @@ class DatetimeFields(Model):
     datetime_null = fields.DatetimeField(null=True)
     datetime_auto = fields.DatetimeField(auto_now=True)
     datetime_add = fields.DatetimeField(auto_now_add=True)
+    datetime_aware = fields.DatetimeField(null=True, in_timezone=timezone.utc)
 
 
 class TimeDeltaFields(Model):


### PR DESCRIPTION
SQLite supports any valid ISO8601 datetime string when defining dates (amongst others) which may or may not include the timezone. This means that a field may have a mixture of timezone aware and timezone naive values. Postgres differentiates between timezone aware and timezone naive fields and so code that is valid when using the ORM with sqlite may cause errors in other engines.

Ideally, the DatetimeField, since it is not timezone aware, would catch any timezone aware datetimes and provide a descriptive error instead trying (and failing) to insert them. Another option is to provide the desired timezone that the datetime should be stored in, so that the field can convert a timezone-aware datetime into the timezone-naive datetime for the supplied timezone.

```python
class Event(Model):
    ...
    start_time = fields.DatetimeField(in_timezone=timezone.utc)
```

In the example above, any timezone-aware datetime is converted to a timezone-naive utc time before it is saved. If the timezone is supplied, datetimes retrieved from the model are timezone aware.

Is this reasonable? Or should we remove the `in_timezone` flag and create a separate timezone aware field? For some context, I am receiving strings that may or may not be timezone-aware and it is a pain having to manually guard and convert them over. So if I were able to define on the model that all datetimes once they hit the database are guaranteed UTC then it would vastly simplify the logic.
