### PR TITLE
Fix 'unique_together' for foreign keys

### DIFF
--- a/tortoise/backends/base/schema_generator.py
+++ b/tortoise/backends/base/schema_generator.py
@@ -123,12 +123,23 @@ class BaseSchemaGenerator:
             if field_object.index:
                 fields_with_index.append(field_name)
 
-        unique_togethers = model._meta.unique_together
-        if unique_togethers is not None:
-            unique_together_sqls = [
-                self._get_unique_constraint_sql(unique_together_list)
-                for unique_together_list in unique_togethers
-            ]
+        if model._meta.unique_together is not None:
+            unique_together_sqls = []
+
+            for unique_together_list in model._meta.unique_together:
+                unique_together_to_create = []
+
+                for field in unique_together_list:
+                    field_object = model._meta.fields_map[field]
+
+                    if field_object.source_field:
+                        unique_together_to_create.append(field_object.source_field)
+                    else:
+                        unique_together_to_create.append(field)
+
+                unique_together_sqls.append(
+                    self._get_unique_constraint_sql(unique_together_to_create))
+
             fields_to_create.extend(unique_together_sqls)
 
         table_fields_string = ', '.join(fields_to_create)

--- a/tortoise/tests/test_unique_together.py
+++ b/tortoise/tests/test_unique_together.py
@@ -1,9 +1,10 @@
 from tortoise.contrib import test
 from tortoise.exceptions import IntegrityError
-from tortoise.tests.testmodels import UniqueTogetherFields
+from tortoise.tests.testmodels import Tournament, UniqueTogetherFields, UniqueTogetherFieldsWithFK
 
 
 class TestUniqueTogether(test.TestCase):
+
     async def test_unique_together(self):
         first_name = 'first_name'
         last_name = 'last_name'
@@ -17,4 +18,23 @@ class TestUniqueTogether(test.TestCase):
             await UniqueTogetherFields.create(
                 first_name=first_name,
                 last_name=last_name
+            )
+
+    async def test_unique_together_with_foreign_keys(self):
+        tournament_name = 'tournament_name'
+        text = 'text'
+
+        tournament = await Tournament.create(
+            name=tournament_name
+        )
+
+        await UniqueTogetherFieldsWithFK.create(
+            text=text,
+            tournament=tournament
+        )
+
+        with self.assertRaises(IntegrityError):
+            await UniqueTogetherFieldsWithFK.create(
+                text=text,
+                tournament=tournament
             )

--- a/tortoise/tests/testmodels.py
+++ b/tortoise/tests/testmodels.py
@@ -200,3 +200,12 @@ class UniqueTogetherFields(Model):
 
     class Meta:
         unique_together = ('first_name', 'last_name')
+
+
+class UniqueTogetherFieldsWithFK(Model):
+    id = fields.IntField(pk=True)
+    text = fields.CharField(max_length=64)
+    tournament = fields.ForeignKeyField('models.Tournament')
+
+    class Meta:
+        unique_together = ('text', 'tournament')


### PR DESCRIPTION
## Description
Fixed 'unique_together' for foreign keys

## Motivation and Context
Adding 'unique_together' with FK field name was broken, there was only an ability to add it using a field name like '{foreign_key_name}_id'