### PR TITLE
Fixed Field.to_db_value method (#113)

### DIFF
--- a/tortoise/fields.py
+++ b/tortoise/fields.py
@@ -53,7 +53,9 @@ class Field:
         self.model_field_name = ''  # Type: str
 
     def to_db_value(self, value: Any, instance) -> Any:
-        return value
+        if value is None or type(value) == self.type:
+            return value
+        return self.type(value)
 
     def to_python_value(self, value: Any) -> Any:
         if value is None or isinstance(value, self.type):

--- a/tortoise/fields.py
+++ b/tortoise/fields.py
@@ -53,7 +53,7 @@ class Field:
         self.model_field_name = ''  # Type: str
 
     def to_db_value(self, value: Any, instance) -> Any:
-        if value is None or type(value) == self.type:
+        if value is None or type(value) == self.type:  # pylint: disable=C0123
             return value
         return self.type(value)
 

--- a/tortoise/tests/test_update.py
+++ b/tortoise/tests/test_update.py
@@ -24,3 +24,11 @@ class TestUpdate(test.TestCase):
         contact = await Contact.get(id=1)
         contact.type = ContactTypeEnum.home
         await contact.save()
+
+    async def test_exception_on_invalid_data_type_in_int_field(self):
+        await Contact.create()
+        contact = await Contact.get(id=1)
+
+        contact.type = 'not_int'
+        with self.assertRaises((TypeError, ValueError)):
+            await contact.save()

--- a/tortoise/tests/test_update.py
+++ b/tortoise/tests/test_update.py
@@ -20,14 +20,12 @@ class TestUpdate(test.TestCase):
         self.assertEqual(event.tournament_id, tournament_second.id)
 
     async def test_update_with_int_enum_value(self):
-        await Contact.create()
-        contact = await Contact.get(id=1)
+        contact = await Contact.create()
         contact.type = ContactTypeEnum.home
         await contact.save()
 
     async def test_exception_on_invalid_data_type_in_int_field(self):
-        await Contact.create()
-        contact = await Contact.get(id=1)
+        contact = await Contact.create()
 
         contact.type = 'not_int'
         with self.assertRaises((TypeError, ValueError)):

--- a/tortoise/tests/test_update.py
+++ b/tortoise/tests/test_update.py
@@ -19,7 +19,6 @@ class TestUpdate(test.TestCase):
         event = await Event.first()
         self.assertEqual(event.tournament_id, tournament_second.id)
 
-    @test.expectedFailure
     async def test_update_with_int_enum_value(self):
         await Contact.create()
         contact = await Contact.get(id=1)


### PR DESCRIPTION
## Description
Fixed Field.to_db_value method
Added converting field's value to the field's type

## Motivation and Context
As for now, using inappropriate field type leads to hardly readable OperationalError.

As a side effect, setting enum as a value for IntField will be fixed. (#113)
