### PR TITLE
Fixed ``.count()`` when a join happens (#109)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.11.8
+------
+- Fixed ``.count()`` when a join happens (#109)
+
+
 0.11.7
 ------
 - Fixed 'unique_together' for foreign keys (#114)

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -392,4 +392,4 @@ def run_async(coro: Coroutine) -> None:
         loop.run_until_complete(Tortoise.close_connections())
 
 
-__version__ = "0.11.7"
+__version__ = "0.11.8"

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -518,7 +518,6 @@ class CountQuery(AwaitableQuery):
     def __init__(self, model, db, q_objects, annotations, custom_filters
                  ) -> None:
         super().__init__(model, db)
-        table = Table(model._meta.table)
         self.query = model._meta.basequery
         self.resolve_filters(
             model=model,
@@ -526,7 +525,7 @@ class CountQuery(AwaitableQuery):
             annotations=annotations,
             custom_filters=custom_filters,
         )
-        self.query = self.query.select(Count(table.star))
+        self.query = self.query.select(Count("*"))
 
     async def _execute(self):
         result = await self._db.execute_query(str(self.query))

--- a/tortoise/tests/test_queryset.py
+++ b/tortoise/tests/test_queryset.py
@@ -1,6 +1,6 @@
 from tortoise.contrib import test
 from tortoise.exceptions import DoesNotExist, MultipleObjectsReturned
-from tortoise.tests.testmodels import IntFields
+from tortoise.tests.testmodels import IntFields, MinRelation, Tournament
 
 # TODO: Test the many exceptions in QuerySet
 # TODO: .filter(intnum_null=None) does not work as expected
@@ -14,8 +14,14 @@ class TestQueryset(test.TestCase):
 
     async def test_all_count(self):
         self.assertEqual(await IntFields.all().count(), 30)
-
         self.assertEqual(await IntFields.filter(intnum_null=80).count(), 0)
+
+    async def test_join_count(self):
+        tour = await Tournament.create(name="moo")
+        await MinRelation.create(tournament=tour)
+
+        self.assertEqual(await MinRelation.all().count(), 1)
+        self.assertEqual(await MinRelation.filter(tournament__id=tour.id).count(), 1)
 
     async def test_modify_dataset(self):
         # Modify dataset


### PR DESCRIPTION
Fixes #109


