### PR TITLE
Initial MySQL param passthrough

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,6 +6,7 @@ omit =
     tortoise/contrib/pylint/*
     tortoise/contrib/test/nose2.py
     tortoise/tests/*
+    tortoise/contrib/quart/*
 [report]
 show_missing = True
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+0.11.11
+-------
+- Extra parameters now get passed through to the MySQL & PostgreSQL drivers
+
 0.11.10
 -------
 - Fixed SQLite handling of DatetimeField
@@ -16,22 +20,18 @@ Changelog
 ------
 - Fixed ``.count()`` when a join happens (#109)
 
-
 0.11.7
 ------
 - Fixed 'unique_together' for foreign keys (#114)
 - Fixed Field.to_db_value method to handle Enum (#113 #115 #116)
 
-
 0.11.6
 ------
 - Added ability to use "unique_together" meta Model option
 
-
 0.11.5
 ------
 - Fixed concurrency isolation when attempting to do multiple concurrent operations on a single connection.
-
 
 0.11.4
 ------
@@ -43,7 +43,6 @@ Changelog
 - Some DB's don't support OFFSET without Limit, added caps to signal workaround, which is to automatically add limit of 1000000
 - Pylint plugin to know about default `related_name` for ForeignKey fields.
 - Simplified capabilities to be static, and defined at class level.
-
 
 0.11.3
 ------

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -404,4 +404,4 @@ def run_async(coro: Coroutine) -> None:
         loop.run_until_complete(Tortoise.close_connections())
 
 
-__version__ = "0.11.10"
+__version__ = "0.11.11"

--- a/tortoise/backends/base/config_generator.py
+++ b/tortoise/backends/base/config_generator.py
@@ -48,6 +48,7 @@ DB_LOOKUP = {
             "connect_timeout": float,
             "echo": bool,
             "no_delay": bool,
+            "use_unicode": bool,
         },
     },
 }  # type: Dict[str, Dict[str, Any]]

--- a/tortoise/backends/base/config_generator.py
+++ b/tortoise/backends/base/config_generator.py
@@ -23,6 +23,11 @@ DB_LOOKUP = {
             "max_size": int,
             "max_queries": int,
             "max_inactive_connection_lifetime": float,
+            "timeout": int,
+            "statement_cache_size": int,
+            "max_cached_statement_lifetime": int,
+            "max_cacheable_statement_size": int,
+            "ssl": bool,
         },
     },
     "sqlite": {

--- a/tortoise/tests/test_connection_params.py
+++ b/tortoise/tests/test_connection_params.py
@@ -37,32 +37,35 @@ class TestConnectionParams(test.TestCase):
             )
 
     async def test_postres_connection_params(self):
-        with patch("asyncpg.connect", new=CoroutineMock()) as asyncpg_connect:
-            await Tortoise._init_connections(
-                {
-                    "models": {
-                        "engine": "tortoise.backends.asyncpg",
-                        "credentials": {
-                            "database": "test",
-                            "host": "127.0.0.1",
-                            "password": "foomip",
-                            "port": 5432,
-                            "user": "root",
-                            "timeout": 30,
-                            "ssl": True,
-                        },
-                    }
-                },
-                False,
-            )
+        try:
+            with patch("asyncpg.connect", new=CoroutineMock()) as asyncpg_connect:
+                await Tortoise._init_connections(
+                    {
+                        "models": {
+                            "engine": "tortoise.backends.asyncpg",
+                            "credentials": {
+                                "database": "test",
+                                "host": "127.0.0.1",
+                                "password": "foomip",
+                                "port": 5432,
+                                "user": "root",
+                                "timeout": 30,
+                                "ssl": True,
+                            },
+                        }
+                    },
+                    False,
+                )
 
-            asyncpg_connect.assert_awaited_once_with(  # nosec
-                None,
-                database="test",
-                host="127.0.0.1",
-                password="foomip",
-                port=5432,
-                ssl=True,
-                timeout=30,
-                user="root",
-            )
+                asyncpg_connect.assert_awaited_once_with(  # nosec
+                    None,
+                    database="test",
+                    host="127.0.0.1",
+                    password="foomip",
+                    port=5432,
+                    ssl=True,
+                    timeout=30,
+                    user="root",
+                )
+        except ImportError:
+            self.skipTest("asyncpg not installed")

--- a/tortoise/tests/test_connection_params.py
+++ b/tortoise/tests/test_connection_params.py
@@ -1,0 +1,68 @@
+from asynctest.mock import CoroutineMock, patch
+
+from tortoise import Tortoise
+from tortoise.contrib import test
+
+
+class TestConnectionParams(test.TestCase):
+    async def test_mysql_connection_params(self):
+        with patch("aiomysql.connect", new=CoroutineMock()) as mysql_connect:
+            await Tortoise._init_connections(
+                {
+                    "models": {
+                        "engine": "tortoise.backends.mysql",
+                        "credentials": {
+                            "database": "test",
+                            "host": "127.0.0.1",
+                            "password": "foomip",
+                            "port": 3306,
+                            "user": "root",
+                            "connect_timeout": 1.5,
+                            "charset": "utf-8",
+                        },
+                    }
+                },
+                False,
+            )
+
+            mysql_connect.assert_awaited_once_with(  # nosec
+                autocommit=True,
+                charset="utf-8",
+                connect_timeout=1.5,
+                db="test",
+                host="127.0.0.1",
+                password="foomip",
+                port=3306,
+                user="root",
+            )
+
+    async def test_postres_connection_params(self):
+        with patch("asyncpg.connect", new=CoroutineMock()) as asyncpg_connect:
+            await Tortoise._init_connections(
+                {
+                    "models": {
+                        "engine": "tortoise.backends.asyncpg",
+                        "credentials": {
+                            "database": "test",
+                            "host": "127.0.0.1",
+                            "password": "foomip",
+                            "port": 5432,
+                            "user": "root",
+                            "timeout": 30,
+                            "ssl": True,
+                        },
+                    }
+                },
+                False,
+            )
+
+            asyncpg_connect.assert_awaited_once_with(  # nosec
+                None,
+                database="test",
+                host="127.0.0.1",
+                password="foomip",
+                port=5432,
+                ssl=True,
+                timeout=30,
+                user="root",
+            )


### PR DESCRIPTION
Custom DB parameters needs to be passed through to the relevant drivers.

* [x] MySQL
* [x] PostgreSQL
* ~SQLite~ Not needed
* [x] Tests to ensure passthrough works, and stays working.

Should fix question 1 in #132 