### PR TITLE
Reconnect: catch connection error before query execution

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -11,6 +11,7 @@ Contributors
 * Alexander Lyon ``@arlyon``
 * Florimond Manca ``@florimondmanca``
 * Vitali Rebkavets ``@REVIMI``
+* Shlomy Balulu ``@shaloba``
 
 Special Thanks
 ==============

--- a/tortoise/backends/asyncpg/client.py
+++ b/tortoise/backends/asyncpg/client.py
@@ -28,7 +28,11 @@ def retry_connection(func):
     async def wrapped(self, *args):
         try:
             return await func(self, *args)
-        except (asyncpg.PostgresConnectionError, asyncpg.ConnectionDoesNotExistError, asyncpg.ConnectionFailureError):
+        except (
+            asyncpg.PostgresConnectionError,
+            asyncpg.ConnectionDoesNotExistError,
+            asyncpg.ConnectionFailureError,
+        ):
             # Here we assume that a connection error has happened
             # Re-create connection and re-try the function call once only.
             await self._lock.acquire()

--- a/tortoise/backends/asyncpg/client.py
+++ b/tortoise/backends/asyncpg/client.py
@@ -28,7 +28,7 @@ def retry_connection(func):
     async def wrapped(self, *args):
         try:
             return await func(self, *args)
-        except (asyncpg.InterfaceError):
+        except (asyncpg.PostgresConnectionError, asyncpg.ConnectionDoesNotExistError, asyncpg.ConnectionFailureError):
             # Here we assume that a connection error has happened
             # Re-create connection and re-try the function call once only.
             await self._lock.acquire()


### PR DESCRIPTION
HI @grigi , 

I'm using this repository and reported about bug #134 , you manage to set a reconnect function that's working fine but there was a issue with the error type when the query operation failed due to connection issue.
I have change the exception handling to the once mention in asyncpg exception code that will be raised when a connection failed. 

I have tested it and it works.

Thanks!

