### PR TITLE
Bulk insert support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,28 @@
 Changelog
 =========
 
+0.12.1
+------
+* Notable efficiency improvement for regular inserts
+* Bulk insert operation:
+
+  .. note::
+     The bulk insert operation will do the minimum to ensure that the object
+     created in the DB has all the defaults and generated fields set,
+     but may be incomplete reference in Python.
+
+     e.g. ``IntField`` primary keys will not be poplulated.
+
+  This is recommend only for throw away inserts where you want to ensure optimal
+  insert performance.
+
+  .. code-block:: python3
+
+      User.bulk_create([
+          User(name="...", email="..."),
+          User(name="...", email="...")
+      ])
+
 0.12.0
 ------
 * Tortoise ORM now supports non-autonumber primary keys.
@@ -36,8 +58,6 @@ Changelog
 
       guid = fields.UUIDField(pk=True)
 
-  For more info, please have a look at :ref:`init_app`
-
 
 0.11.13
 -------
@@ -69,12 +89,12 @@ Changelog
 
 0.11.7
 ------
-- Fixed 'unique_together' for foreign keys (#114)
+- Fixed ``unique_together`` for foreign keys (#114)
 - Fixed Field.to_db_value method to handle Enum (#113 #115 #116)
 
 0.11.6
 ------
-- Added ability to use "unique_together" meta Model option
+- Added ability to use ``unique_together`` meta Model option
 
 0.11.5
 ------

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -99,6 +99,33 @@ Any of these are valid primary key definitions in a Model:
 
     guid = fields.UUIDField(pk=True)
 
+The ``Meta`` class
+------------------
+
+.. autoclass:: tortoise.models.Model.Meta
+
+    .. attribute:: abstract
+        :annotation: = False
+
+        Set to ``True`` to indicate this is an abstract class
+
+    .. attribute:: table
+        :annotation: = ""
+
+        Set this to configure a manual table name, instead of a generated one
+
+    .. attribute:: unique_together
+        :annotation: = None
+
+        Specify ``unique_together`` to set up compound unique indexes for sets of columns.
+
+        It should be a tuple of tuples (lists are fine) in the format of:
+
+        .. code-block:: python3
+
+            unique_together=("field_a", "field_b")
+            unique_together=(("field_a", "field_b"), )
+            unique_together=(("field_a", "field_b"), ("field_c", "field_d", "field_e")
 
 ``ForeignKeyField``
 -------------------
@@ -195,7 +222,6 @@ The reverse lookup of ``team.event_team`` works exactly the same way.
 Reference
 =========
 
-.. autoclass:: tortoise.models.Model
-    :members:
+.. automodule:: tortoise.models
+    :members: Model
     :undoc-members:
-

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -401,4 +401,4 @@ def run_async(coro: Coroutine) -> None:
         loop.run_until_complete(Tortoise.close_connections())
 
 
-__version__ = "0.12.0"
+__version__ = "0.12.1"

--- a/tortoise/backends/asyncpg/client.py
+++ b/tortoise/backends/asyncpg/client.py
@@ -160,6 +160,14 @@ class AsyncpgDBClient(BaseDBAsyncClient):
 
     @translate_exceptions
     @retry_connection
+    async def execute_many(self, query: str, values: list) -> None:
+        async with self.acquire_connection() as connection:
+            self.log.debug("%s: %s", query, values)
+            # TODO: Consider using copy_records_to_table instead
+            await connection.executemany(query, values)
+
+    @translate_exceptions
+    @retry_connection
     async def execute_query(self, query: str) -> List[dict]:
         async with self.acquire_connection() as connection:
             self.log.debug(query)

--- a/tortoise/backends/base/config_generator.py
+++ b/tortoise/backends/base/config_generator.py
@@ -34,8 +34,8 @@ DB_LOOKUP = {
         "engine": "tortoise.backends.sqlite",
         "skip_first_char": False,
         "vmap": {"path": "file_path"},
-        "defaults": {},
-        "cast": {},
+        "defaults": {"journal_mode": "WAL", "journal_size_limit": 16384},
+        "cast": {"journal_size_limit": int},
     },
     "mysql": {
         "engine": "tortoise.backends.mysql",

--- a/tortoise/backends/base/executor.py
+++ b/tortoise/backends/base/executor.py
@@ -1,3 +1,4 @@
+from functools import partial
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple, Type  # noqa
 
 from pypika import JoinType, Table
@@ -9,7 +10,7 @@ from tortoise.query_utils import QueryModifier
 if TYPE_CHECKING:  # pragma: nocoverage
     from tortoise.models import Model
 
-INSERT_CACHE = {}  # type: Dict[str, Tuple[list, list, str]]
+INSERT_CACHE = {}  # type: Dict[str, Tuple[list, str, Dict[str, Callable]]]
 
 
 class BaseExecutor:
@@ -22,6 +23,24 @@ class BaseExecutor:
         self.db = db
         self.prefetch_map = prefetch_map if prefetch_map else {}
         self._prefetch_queries = prefetch_queries if prefetch_queries else {}
+
+        key = "{}:{}".format(self.db.connection_name, self.model._meta.table)
+        if key not in INSERT_CACHE:
+            self.regular_columns, columns = self._prepare_insert_columns()
+            self.query = self._prepare_insert_statement(columns)
+
+            self.column_map = {}  # type: Dict[str, Callable]
+            for column in self.regular_columns:
+                field_object = self.model._meta.fields_map[column]
+                if field_object.__class__ in self.TO_DB_OVERRIDE:
+                    func = partial(self.TO_DB_OVERRIDE[field_object.__class__], field_object)
+                else:
+                    func = field_object.to_db_value
+                self.column_map[column] = func
+
+            INSERT_CACHE[key] = self.regular_columns, self.query, self.column_map
+        else:
+            self.regular_columns, self.query, self.column_map = INSERT_CACHE[key]
 
     async def execute_explain(self, query) -> Any:
         sql = " ".join(((self.EXPLAIN_PREFIX, query.get_sql())))
@@ -54,14 +73,6 @@ class BaseExecutor:
             return cls.TO_DB_OVERRIDE[field_object.__class__](field_object, attr, instance)
         return field_object.to_db_value(attr, instance)
 
-    def _prepare_insert_values(self, instance, regular_columns: List[str]) -> list:
-        return [
-            self._field_to_db(
-                self.model._meta.fields_map[column], getattr(instance, column), instance
-            )
-            for column in regular_columns
-        ]
-
     def _prepare_insert_statement(self, columns: List[str]) -> str:
         # Insert should implement returning new id to saved object
         # Each db has it's own methods for it, so each implementation should
@@ -72,33 +83,23 @@ class BaseExecutor:
         raise NotImplementedError()  # pragma: nocoverage
 
     async def execute_insert(self, instance):
-        key = "{}:{}".format(self.db.connection_name, self.model._meta.table)
-        if key not in INSERT_CACHE:
-            regular_columns, columns = self._prepare_insert_columns()
-            query = self._prepare_insert_statement(columns)
-            INSERT_CACHE[key] = regular_columns, columns, query
-        else:
-            regular_columns, columns, query = INSERT_CACHE[key]
-
-        values = self._prepare_insert_values(instance=instance, regular_columns=regular_columns)
-        insert_result = await self.db.execute_insert(query, values)
+        values = [
+            self.column_map[column](getattr(instance, column), instance)
+            for column in self.regular_columns
+        ]
+        insert_result = await self.db.execute_insert(self.query, values)
         await self._process_insert_result(instance, insert_result)
         return instance
 
     async def execute_bulk_insert(self, instances):
-        key = "{}:{}".format(self.db.connection_name, self.model._meta.table)
-        if key not in INSERT_CACHE:
-            regular_columns, columns = self._prepare_insert_columns()
-            query = self._prepare_insert_statement(columns)
-            INSERT_CACHE[key] = regular_columns, columns, query
-        else:
-            regular_columns, columns, query = INSERT_CACHE[key]
-
         valueses = [
-            self._prepare_insert_values(instance=instance, regular_columns=regular_columns)
+            [
+                self.column_map[column](getattr(instance, column), instance)
+                for column in self.regular_columns
+            ]
             for instance in instances
         ]
-        await self.db.execute_many(query, valueses)
+        await self.db.execute_many(self.query, valueses)
 
     async def execute_update(self, instance):
         table = Table(self.model._meta.table)
@@ -107,7 +108,7 @@ class BaseExecutor:
             field_object = self.model._meta.fields_map[field]
             if not field_object.generated:
                 query = query.set(
-                    db_field, self._field_to_db(field_object, getattr(instance, field), instance)
+                    db_field, self.column_map[field](getattr(instance, field), instance)
                 )
         query = query.where(
             getattr(table, self.model._meta.db_pk_field)

--- a/tortoise/backends/base/executor.py
+++ b/tortoise/backends/base/executor.py
@@ -92,14 +92,14 @@ class BaseExecutor:
         return instance
 
     async def execute_bulk_insert(self, instances):
-        valueses = [
+        values_lists = [
             [
                 self.column_map[column](getattr(instance, column), instance)
                 for column in self.regular_columns
             ]
             for instance in instances
         ]
-        await self.db.execute_many(self.query, valueses)
+        await self.db.execute_many(self.query, values_lists)
 
     async def execute_update(self, instance):
         table = Table(self.model._meta.table)

--- a/tortoise/backends/mysql/client.py
+++ b/tortoise/backends/mysql/client.py
@@ -159,9 +159,16 @@ class MySQLClient(BaseDBAsyncClient):
         async with self.acquire_connection() as connection:
             self.log.debug("%s: %s", query, values)
             async with connection.cursor() as cursor:
-                # TODO: Use prepared statement, and cache it
                 await cursor.execute(query, values)
                 return cursor.lastrowid  # return auto-generated id
+
+    @translate_exceptions
+    @retry_connection
+    async def execute_many(self, query: str, values: list) -> None:
+        async with self.acquire_connection() as connection:
+            self.log.debug("%s: %s", query, values)
+            async with connection.cursor() as cursor:
+                await cursor.executemany(query, values)
 
     @translate_exceptions
     @retry_connection

--- a/tortoise/backends/sqlite/client.py
+++ b/tortoise/backends/sqlite/client.py
@@ -40,6 +40,11 @@ class SqliteClient(BaseDBAsyncClient):
     def __init__(self, file_path: str, **kwargs) -> None:
         super().__init__(**kwargs)
         self.filename = file_path
+
+        self.pragmas = kwargs.copy()
+        self.pragmas.pop("connection_name", None)
+        self.pragmas.pop("fetch_inserted", None)
+
         self._transaction_class = type(
             "TransactionWrapper", (TransactionWrapper, self.__class__), {}
         )
@@ -52,15 +57,24 @@ class SqliteClient(BaseDBAsyncClient):
             self._connection.start()
             await self._connection._connect()
             self._connection._conn.row_factory = sqlite3.Row
+            for pragma, val in self.pragmas.items():
+                cursor = await self._connection.execute("PRAGMA {}={}".format(pragma, val))
+                await cursor.close()
             self.log.debug(
-                "Created connection %s with params: filename=%s", self._connection, self.filename
+                "Created connection %s with params: filename=%s %s",
+                self._connection,
+                self.filename,
+                " ".join(["{}={}".format(k, v) for k, v in self.pragmas.items()]),
             )
 
     async def close(self) -> None:
         if self._connection:
             await self._connection.close()
             self.log.debug(
-                "Closed connection %s with params: filename=%s", self._connection, self.filename
+                "Closed connection %s with params: filename=%s %s",
+                self._connection,
+                self.filename,
+                " ".join(["{}={}".format(k, v) for k, v in self.pragmas.items()]),
             )
             self._connection = None
 
@@ -95,6 +109,7 @@ class SqliteClient(BaseDBAsyncClient):
     async def execute_many(self, query: str, values: List[list]) -> None:
         async with self.acquire_connection() as connection:
             self.log.debug("%s: %s", query, values)
+            # TODO: Ensure that this is wrapped by a transaction, will provide a big speedup
             await connection.executemany(query, values)
 
     @translate_exceptions

--- a/tortoise/backends/sqlite/client.py
+++ b/tortoise/backends/sqlite/client.py
@@ -92,6 +92,12 @@ class SqliteClient(BaseDBAsyncClient):
             return (await connection.execute_insert(query, values))[0]
 
     @translate_exceptions
+    async def execute_many(self, query: str, values: List[list]) -> int:
+        async with self.acquire_connection() as connection:
+            self.log.debug("%s: %s", query, values)
+            return (await connection.executemany(query, values))[0]
+
+    @translate_exceptions
     async def execute_query(self, query: str) -> List[dict]:
         async with self.acquire_connection() as connection:
             self.log.debug(query)

--- a/tortoise/backends/sqlite/client.py
+++ b/tortoise/backends/sqlite/client.py
@@ -92,10 +92,10 @@ class SqliteClient(BaseDBAsyncClient):
             return (await connection.execute_insert(query, values))[0]
 
     @translate_exceptions
-    async def execute_many(self, query: str, values: List[list]) -> int:
+    async def execute_many(self, query: str, values: List[list]) -> None:
         async with self.acquire_connection() as connection:
             self.log.debug("%s: %s", query, values)
-            return (await connection.executemany(query, values))[0]
+            await connection.executemany(query, values)
 
     @translate_exceptions
     async def execute_query(self, query: str) -> List[dict]:

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -306,7 +306,7 @@ class Model(metaclass=ModelMeta):
         # Assign values and do type conversions
         passed_fields = set(kwargs.keys())
         passed_fields.update(meta.fetch_fields)
-        passed_fields |= self.set_field_values(kwargs)
+        passed_fields |= self._set_field_values(kwargs)
 
         # Assign defaults for missing fields
         for key in meta.fields.difference(passed_fields):
@@ -316,7 +316,7 @@ class Model(metaclass=ModelMeta):
             else:
                 setattr(self, key, field_object.default)
 
-    def set_field_values(self, values_map: Dict[str, Any]) -> Set[str]:
+    def _set_field_values(self, values_map: Dict[str, Any]) -> Set[str]:
         """
         Sets values for fields honoring type transformations and
         return list of fields that were set additionally
@@ -354,33 +354,6 @@ class Model(metaclass=ModelMeta):
 
         return passed_fields
 
-    def _get_pk_val(self):
-        return getattr(self, self._meta.pk_attr)
-
-    def _set_pk_val(self, value):
-        setattr(self, self._meta.pk_attr, value)
-
-    pk = property(_get_pk_val, _set_pk_val)
-
-    async def save(self, *args, **kwargs) -> None:
-        db = kwargs.get("using_db") or self._meta.db
-        executor = db.executor_class(model=self.__class__, db=db)
-        if self._saved_in_db:
-            await executor.execute_update(self)
-        else:
-            await executor.execute_insert(self)
-            self._saved_in_db = True
-
-    async def delete(self, using_db=None) -> None:
-        db = using_db or self._meta.db
-        if not self._saved_in_db:
-            raise OperationalError("Can't delete unpersisted record")
-        await db.executor_class(model=self.__class__, db=db).execute_delete(self)
-
-    async def fetch_related(self, *args, using_db=None):
-        db = using_db or self._meta.db
-        await db.executor_class(model=self.__class__, db=db).fetch_for_list([self], *args)
-
     def __str__(self) -> str:
         return "<{}>".format(self.__class__.__name__)
 
@@ -399,6 +372,37 @@ class Model(metaclass=ModelMeta):
         if type(self) == type(other) and self.pk == other.pk:
             return True
         return False
+
+    def _get_pk_val(self):
+        return getattr(self, self._meta.pk_attr)
+
+    def _set_pk_val(self, value):
+        setattr(self, self._meta.pk_attr, value)
+
+    pk = property(_get_pk_val, _set_pk_val)
+    """
+    Alias to the models Primary Key.
+    Can be used as a field name when doing filtering e.g. ``.filter(pk=...)`` etc...
+    """
+
+    async def save(self, using_db=None) -> None:
+        db = using_db or self._meta.db
+        executor = db.executor_class(model=self.__class__, db=db)
+        if self._saved_in_db:
+            await executor.execute_update(self)
+        else:
+            await executor.execute_insert(self)
+            self._saved_in_db = True
+
+    async def delete(self, using_db=None) -> None:
+        db = using_db or self._meta.db
+        if not self._saved_in_db:
+            raise OperationalError("Can't delete unpersisted record")
+        await db.executor_class(model=self.__class__, db=db).execute_delete(self)
+
+    async def fetch_related(self, *args, using_db=None):
+        db = using_db or self._meta.db
+        await db.executor_class(model=self.__class__, db=db).fetch_for_list([self], *args)
 
     @classmethod
     async def get_or_create(
@@ -421,6 +425,28 @@ class Model(metaclass=ModelMeta):
 
     @classmethod
     async def bulk_create(cls: Type[MODEL_TYPE], objects: List[MODEL_TYPE], using_db=None) -> None:
+        """
+        Bulk insert operation:
+
+        .. note::
+            The bulk insert operation will do the minimum to ensure that the object
+            created in the DB has all the defaults and generated fields set,
+            but may be incomplete reference in Python.
+
+            e.g. ``IntField`` primary keys will not be poplulated.
+
+        This is recommend only for throw away inserts where you want to ensure optimal
+        insert performance.
+
+        .. code-block:: python3
+
+            User.bulk_create([
+                User(name="...", email="..."),
+                User(name="...", email="...")
+            ])
+
+        :param objects: List of objects to bulk create
+        """
         db = using_db or cls._meta.db
         await db.executor_class(model=cls, db=db).execute_bulk_insert(objects)
 
@@ -494,4 +520,19 @@ class Model(metaclass=ModelMeta):
                         )
 
     class Meta:
+        """
+        The ``Meta`` class is used to configure metadate for the Model.
+
+        Usage:
+
+        .. code-block:: python3
+
+            class Foo(Model):
+                ...
+
+                class Meta:
+                    table="custom_table"
+                    unique_together=(("field_a", "field_b"), )
+        """
+
         pass

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -236,6 +236,9 @@ class QuerySet(AwaitableQuery):
     def distinct(self) -> "QuerySet":
         """
         Make QuerySet distinct.
+
+        Only makes sense in combination with a .values() or .values_list() as it
+        precedes all the fetched fields with a distinct.
         """
         queryset = self._clone()
         queryset._distinct = True

--- a/tortoise/tests/test_bulk.py
+++ b/tortoise/tests/test_bulk.py
@@ -1,0 +1,19 @@
+from uuid import UUID
+
+from tortoise.contrib import test
+from tortoise.tests.testmodels import NoID, UUIDPkModel
+
+
+class TestBasic(test.TestCase):
+    async def test_bulk_create(self):
+        await NoID.bulk_create([NoID() for _ in range(1, 1000)])
+        self.assertEqual(
+            await NoID.all().values("id", "name"),
+            [{"id": val, "name": None} for val in range(1, 1000)],
+        )
+
+    async def test_bulk_create_uuidpk(self):
+        await UUIDPkModel.bulk_create([UUIDPkModel() for _ in range(1000)])
+        res = await UUIDPkModel.all().values_list("id", flat=True)
+        self.assertEqual(len(res), 1000)
+        self.assertIsInstance(res[0], UUID)

--- a/tortoise/tests/test_db_url.py
+++ b/tortoise/tests/test_db_url.py
@@ -14,21 +14,40 @@ class TestConfigGenerator(test.SimpleTestCase):
             res,
             {
                 "engine": "tortoise.backends.sqlite",
-                "credentials": {"file_path": "/some/test.sqlite"},
+                "credentials": {
+                    "file_path": "/some/test.sqlite",
+                    "journal_mode": "WAL",
+                    "journal_size_limit": 16384,
+                },
             },
         )
 
     def test_sqlite_relative(self):
         res = expand_db_url("sqlite://test.sqlite")
         self.assertDictEqual(
-            res, {"engine": "tortoise.backends.sqlite", "credentials": {"file_path": "test.sqlite"}}
+            res,
+            {
+                "engine": "tortoise.backends.sqlite",
+                "credentials": {
+                    "file_path": "test.sqlite",
+                    "journal_mode": "WAL",
+                    "journal_size_limit": 16384,
+                },
+            },
         )
 
     def test_sqlite_relative_with_subdir(self):
         res = expand_db_url("sqlite://data/db.sqlite")
         self.assertDictEqual(
             res,
-            {"engine": "tortoise.backends.sqlite", "credentials": {"file_path": "data/db.sqlite"}},
+            {
+                "engine": "tortoise.backends.sqlite",
+                "credentials": {
+                    "file_path": "data/db.sqlite",
+                    "journal_mode": "WAL",
+                    "journal_size_limit": 16384,
+                },
+            },
         )
 
     def test_sqlite_testing(self):
@@ -38,16 +57,30 @@ class TestConfigGenerator(test.SimpleTestCase):
         self.assertIn(".sqlite", file_path)
         self.assertNotEqual("sqlite:///some/test-{}.sqlite", file_path)
         self.assertDictEqual(
-            res, {"engine": "tortoise.backends.sqlite", "credentials": {"file_path": file_path}}
+            res,
+            {
+                "engine": "tortoise.backends.sqlite",
+                "credentials": {
+                    "file_path": file_path,
+                    "journal_mode": "WAL",
+                    "journal_size_limit": 16384,
+                },
+            },
         )
 
     def test_sqlite_params(self):
-        res = expand_db_url("sqlite:///some/test.sqlite?AHA=5&moo=yes")
+        res = expand_db_url("sqlite:///some/test.sqlite?AHA=5&moo=yes&journal_mode=TRUNCATE")
         self.assertDictEqual(
             res,
             {
                 "engine": "tortoise.backends.sqlite",
-                "credentials": {"file_path": "/some/test.sqlite", "AHA": "5", "moo": "yes"},
+                "credentials": {
+                    "file_path": "/some/test.sqlite",
+                    "AHA": "5",
+                    "moo": "yes",
+                    "journal_mode": "TRUNCATE",
+                    "journal_size_limit": 16384,
+                },
             },
         )
 
@@ -217,7 +250,11 @@ class TestConfigGenerator(test.SimpleTestCase):
             {
                 "connections": {
                     "default": {
-                        "credentials": {"file_path": "/some/test.sqlite"},
+                        "credentials": {
+                            "file_path": "/some/test.sqlite",
+                            "journal_mode": "WAL",
+                            "journal_size_limit": 16384,
+                        },
                         "engine": "tortoise.backends.sqlite",
                     }
                 },
@@ -242,7 +279,11 @@ class TestConfigGenerator(test.SimpleTestCase):
             {
                 "connections": {
                     "models": {
-                        "credentials": {"file_path": "/some/test.sqlite"},
+                        "credentials": {
+                            "file_path": "/some/test.sqlite",
+                            "journal_mode": "WAL",
+                            "journal_size_limit": 16384,
+                        },
                         "engine": "tortoise.backends.sqlite",
                     }
                 },
@@ -265,7 +306,11 @@ class TestConfigGenerator(test.SimpleTestCase):
             {
                 "connections": {
                     "default": {
-                        "credentials": {"file_path": "/some/test.sqlite"},
+                        "credentials": {
+                            "file_path": "/some/test.sqlite",
+                            "journal_mode": "WAL",
+                            "journal_size_limit": 16384,
+                        },
                         "engine": "tortoise.backends.sqlite",
                     }
                 },


### PR DESCRIPTION
Add support for Bulk Insert support. 
Fixes #93 

* [x] Bulk insert interface
* [x] `execute_many` for SQLite
* [x] `execute_many` for PostgreSQL
* [x] `execute_many` for MySQL
* [x] Profiled and resolved a many small bottlenecks re insertion, standard insertion is faster now as well. (Updated https://github.com/tortoise/orm-benchmarks with results)
* [x] Tests
* [x] Documentation
* [x] Changed SQLite transaction to default to WAL (requires SQLite ≥ 3.7, which is 8 years old), as without it bulk inserts performed no better than single inserts.