### PR TITLE
Added a description attribute to Field class #124

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Changelog
 0.12.2
 ------
 * Fix accidental double order-by for ``.values()`` based queries. (#143)
+* Added description attribute to Field class. (#124)
 
 0.12.1
 ------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,10 +3,13 @@
 Changelog
 =========
 
+0.12.3
+------
+* Added description attribute to Field class. (#124)
+
 0.12.2
 ------
 * Fix accidental double order-by for ``.values()`` based queries. (#143)
-* Added description attribute to Field class. (#124)
 
 0.12.1
 ------

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -12,6 +12,7 @@ Contributors
 * Florimond Manca ``@florimondmanca``
 * Vitali Rebkavets ``@REVIMI``
 * Shlomy Balulu ``@shaloba``
+* Klaas Nebuhr ``@FirstKlaas`` 
 
 Special Thanks
 ==============

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -84,6 +84,9 @@ Common parameters for fields:
     A flag indicating that this field is read-only and its value is generated in database.
     You typically don't need to use this if you created the schema through Tortoise.
     Defaults to ``False``.
+``description`` (str):
+    Human readable description of the field. Defaults to ``None``. This allows consumers 
+    to build automated documentation tooling based on the declarative model api. 
 
 Read-only properties:
 

--- a/tortoise/fields.py
+++ b/tortoise/fields.py
@@ -42,6 +42,7 @@ class Field:
         "model_field_name",
         "model",
         "reference",
+        "description",
     )
     has_db_field = True
 
@@ -57,6 +58,7 @@ class Field:
         index: bool = False,
         reference: Optional[str] = None,
         model: "Optional[Model]" = None,
+        description: Optional[str] = None,
         **kwargs
     ) -> None:
         self.type = type
@@ -70,6 +72,7 @@ class Field:
         self.model_field_name = ""  # type: str
         self.model = model
         self.reference = reference
+        self.description = description
 
     def to_db_value(self, value: Any, instance) -> Any:
         if value is None or type(value) == self.type:  # pylint: disable=C0123


### PR DESCRIPTION
Added a description attribute to Field class as proposed in issue #124  

## Description
Added an attribute (with type hint Optional[str]) to the class Field. It Defaults to None

## Motivation and Context
It's the first time for me contributing to a project like this. So I took an "good first issue" to learn the whole process. The Issue #124 seemed to be a good starting point for me. 

## How Has This Been Tested?
I called make check and make test.

## Checklist:
- [X ] My code follows the code style of this project.
- [ X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Hope I did it right and I can tackle the next Issue. I there is anything I can improve, let me know. 