### PR TITLE
WIP: feat: enable row and table comments while generating schema

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Changelog
 0.12.3
 ------
 * Added description attribute to Field class. (#124)
+* Added the ability to leverage field description from (#124) to generate table column comments and ability to add table level comments
 
 0.12.2
 ------

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -13,6 +13,7 @@ Contributors
 * Vitali Rebkavets ``@REVIMI``
 * Shlomy Balulu ``@shaloba``
 * Klaas Nebuhr ``@FirstKlaas`` 
+* Harsha Narayana ``@harshanarayana``
 
 Special Thanks
 ==============

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -86,7 +86,8 @@ Common parameters for fields:
     Defaults to ``False``.
 ``description`` (str):
     Human readable description of the field. Defaults to ``None``. This allows consumers 
-    to build automated documentation tooling based on the declarative model api. 
+    to build automated documentation tooling based on the declarative model api. This field is also
+    leveraged to generate comment messages for each database columns.
 
 Read-only properties:
 

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -114,6 +114,11 @@ The ``Meta`` class
 
         Set this to configure a manual table name, instead of a generated one
 
+        .. attribute:: table_description
+            :annotation: = ""
+
+            Set this to generate a comment message for the table being created for the current model
+
     .. attribute:: unique_together
         :annotation: = None
 

--- a/examples/basic_comments.py
+++ b/examples/basic_comments.py
@@ -11,7 +11,9 @@ from tortoise.models import Model
 class Event(Model):
     id = fields.IntField(pk=True)
     name = fields.TextField(description="Name of the event that corresponds to an action")
-    datetime = fields.DatetimeField(null=True, description="Datetime of when the event was generated")
+    datetime = fields.DatetimeField(
+        null=True, description="Datetime of when the event was generated"
+    )
 
     class Meta:
         table = "event"

--- a/examples/basic_comments.py
+++ b/examples/basic_comments.py
@@ -1,0 +1,40 @@
+"""
+This example demonstrates most basic operations with single model
+and a Table definition generation with comment support
+"""
+import asyncio
+
+from tortoise import Tortoise, fields
+from tortoise.models import Model
+
+
+class Event(Model):
+    id = fields.IntField(pk=True)
+    name = fields.TextField(description="Name of the event that corresponds to an action")
+    datetime = fields.DatetimeField(null=True, description="Datetime of when the event was generated")
+
+    class Meta:
+        table = "event"
+        table_description = "This table contains a list of all the example events"
+
+    def __str__(self):
+        return self.name
+
+
+async def run():
+    await Tortoise.init(config_file="config.json")
+    await Tortoise.generate_schemas()
+
+    event = await Event.create(name="Test")
+    await Event.filter(id=event.id).update(name="Updated name")
+
+    print(await Event.filter(name="Updated name").first())
+
+    await Event(name="Test 2").save()
+    print(await Event.all().values_list("id", flat=True))
+    print(await Event.all().values("id", "name"))
+
+
+if __name__ == "__main__":
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(run())

--- a/tortoise/backends/asyncpg/schema_generator.py
+++ b/tortoise/backends/asyncpg/schema_generator.py
@@ -2,6 +2,7 @@ from typing import List
 
 from tortoise import fields
 from tortoise.backends.base.schema_generator import BaseSchemaGenerator
+from tortoise.utils import get_escape_translation_table
 
 
 class AsyncpgSchemaGenerator(BaseSchemaGenerator):
@@ -14,22 +15,38 @@ class AsyncpgSchemaGenerator(BaseSchemaGenerator):
     def _get_primary_key_create_string(self, field_name: str) -> str:
         return '"{}" SERIAL NOT NULL PRIMARY KEY'.format(field_name)
 
+    def _escape_comment(self, comment: str) -> str:
+        table = get_escape_translation_table()
+        table[ord("'")] = u"''"
+        return comment.translate(table)
+
     def _table_comment_generator(self, model, comments_array: List) -> str:
         if model._meta.table_description:
-            comments_array.append(
-                self.TABLE_COMMENT_TEMPLATE.format(
-                    table=model._meta.table, comment=model._meta.table_description
-                )
+            comment = self.TABLE_COMMENT_TEMPLATE.format(
+                table=model._meta.table,
+                comment=self._escape_comment(comment=model._meta.table_description),
             )
+            comments_array.append(comment)
         return ""
 
     def _column_comment_generator(self, model, field, comments_array: List) -> str:
         if field.description:
-            comments_array.append(
-                self.COLUMN_COMMNET_TEMPLATE.format(
-                    table=model._meta.table,
-                    column=field.model_field_name,
-                    comment=field.description,
-                )
+            comment = self.COLUMN_COMMNET_TEMPLATE.format(
+                table=model._meta.table,
+                column=field.model_field_name,
+                comment=self._escape_comment(field.description),
             )
+            comments_array.append(comment)
         return ""
+
+    def _post_table_hook(self, *, models=None, safe=True) -> str:
+        table_comments = []  # type: List[str]
+        column_comments = []  # type: List[str]
+        for model in models:
+            self._table_comment_generator(model=model, comments_array=table_comments)
+            for field_name, db_field in model._meta.fields_db_projection.items():
+                field_object = model._meta.fields_map[field_name]
+                self._column_comment_generator(
+                    model=model, field=field_object, comments_array=column_comments
+                )
+        return " ".join(table_comments + column_comments)

--- a/tortoise/backends/asyncpg/schema_generator.py
+++ b/tortoise/backends/asyncpg/schema_generator.py
@@ -44,7 +44,7 @@ class AsyncpgSchemaGenerator(BaseSchemaGenerator):
         column_comments = []  # type: List[str]
         for model in models:
             self._table_comment_generator(model=model, comments_array=table_comments)
-            for field_name, db_field in model._meta.fields_db_projection.items():
+            for field_name, _ in model._meta.fields_db_projection.items():
                 field_object = model._meta.fields_map[field_name]
                 self._column_comment_generator(
                     model=model, field=field_object, comments_array=column_comments

--- a/tortoise/backends/asyncpg/schema_generator.py
+++ b/tortoise/backends/asyncpg/schema_generator.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from tortoise import fields
 from tortoise.backends.base.schema_generator import BaseSchemaGenerator
 
@@ -6,6 +8,28 @@ class AsyncpgSchemaGenerator(BaseSchemaGenerator):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.FIELD_TYPE_MAP.update({fields.JSONField: "JSONB", fields.UUIDField: "UUID"})
+        self.TABLE_COMMENT_TEMPLATE = "COMMENT ON TABLE {table} IS '{comment}';"
+        self.COLUMN_COMMNET_TEMPLATE = "COMMENT ON COLUMN {table}.{column} IS '{comment}';"
 
     def _get_primary_key_create_string(self, field_name: str) -> str:
         return '"{}" SERIAL NOT NULL PRIMARY KEY'.format(field_name)
+
+    def _table_comment_generator(self, model, comments_array: List) -> str:
+        if model._meta.table_description:
+            comments_array.append(
+                self.TABLE_COMMENT_TEMPLATE.format(
+                    table=model._meta.table, comment=model._meta.table_description
+                )
+            )
+        return ""
+
+    def _column_comment_generator(self, model, field, comments_array: List) -> str:
+        if field.description:
+            comments_array.append(
+                self.COLUMN_COMMNET_TEMPLATE.format(
+                    table=model._meta.table,
+                    column=field.model_field_name,
+                    comment=field.description,
+                )
+            )
+        return ""

--- a/tortoise/backends/base/client.py
+++ b/tortoise/backends/base/client.py
@@ -36,7 +36,8 @@ class Capabilities:
         daemon: bool = True,
         # Deficiencies to work around:
         safe_indexes: bool = True,
-        requires_limit: bool = False
+        requires_limit: bool = False,
+        inline_comment: bool = False
     ) -> None:
         super().__setattr__("_mutable", True)
 
@@ -44,6 +45,7 @@ class Capabilities:
         self.daemon = daemon
         self.requires_limit = requires_limit
         self.safe_indexes = safe_indexes
+        self.inline_comment = inline_comment
 
         super().__setattr__("_mutable", False)
 

--- a/tortoise/backends/base/schema_generator.py
+++ b/tortoise/backends/base/schema_generator.py
@@ -59,9 +59,13 @@ class BaseSchemaGenerator:
         raise NotImplementedError()  # pragma: nocoverage
 
     def _table_comment_generator(self, model, comments_array: List) -> str:
+        # Databases have their own way of supporting comments for table level
+        # needs to be implemented for each supported client
         raise NotImplementedError()  # pragma: nocoverage
 
     def _column_comment_generator(self, model, field, comments_array: List) -> str:
+        # Databases have their own way of supporting comments for column level
+        # needs to be implemented for each supported client
         raise NotImplementedError()  # pragma: nocoverage
 
     @staticmethod

--- a/tortoise/backends/mysql/client.py
+++ b/tortoise/backends/mysql/client.py
@@ -79,7 +79,9 @@ class MySQLClient(BaseDBAsyncClient):
     query_class = MySQLQuery
     executor_class = MySQLExecutor
     schema_generator = MySQLSchemaGenerator
-    capabilities = Capabilities("mysql", safe_indexes=False, requires_limit=True)
+    capabilities = Capabilities(
+        "mysql", safe_indexes=False, requires_limit=True, inline_comment=True
+    )
 
     def __init__(
         self, *, user: str, password: str, database: str, host: str, port: SupportsInt, **kwargs

--- a/tortoise/backends/mysql/schema_generator.py
+++ b/tortoise/backends/mysql/schema_generator.py
@@ -33,11 +33,13 @@ class MySQLSchemaGenerator(BaseSchemaGenerator):
         return "`{}` INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT".format(field_name)
 
     def _table_comment_generator(self, model, comments_array=None) -> str:
-        return (
-            "COMMENT='{}'".format(model._meta.table_description)
-            if model._meta.table_description
-            else ""
-        )
+        comment = ""
+        if model._meta.table_description:
+            comment = "COMMENT='{}'".format(self._escape_comment(model._meta.table_description))
+        return comment
 
     def _column_comment_generator(self, model, field, comments_array: List) -> str:
-        return "COMMENT '{}'".format(field.description) if field.description else ""
+        comment = ""
+        if field.description:
+            comment = "COMMENT '{}'".format(self._escape_comment(field.description))
+        return comment

--- a/tortoise/backends/sqlite/client.py
+++ b/tortoise/backends/sqlite/client.py
@@ -35,7 +35,7 @@ def translate_exceptions(func):
 class SqliteClient(BaseDBAsyncClient):
     executor_class = SqliteExecutor
     schema_generator = SqliteSchemaGenerator
-    capabilities = Capabilities("sqlite", daemon=False, requires_limit=True)
+    capabilities = Capabilities("sqlite", daemon=False, requires_limit=True, inline_comment=True)
 
     def __init__(self, file_path: str, **kwargs) -> None:
         super().__init__(**kwargs)

--- a/tortoise/backends/sqlite/schema_generator.py
+++ b/tortoise/backends/sqlite/schema_generator.py
@@ -14,12 +14,21 @@ class SqliteSchemaGenerator(BaseSchemaGenerator):
                 fields.DecimalField: "VARCHAR(40)",
             }
         )
+        self.TABLE_CREATE_TEMPLATE = 'CREATE TABLE {exists}"{table_name}" {comment} ({fields});'
 
     def _get_primary_key_create_string(self, field_name: str) -> str:
         return '"{}" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL'.format(field_name)
 
     def _table_comment_generator(self, model, comments_array: List) -> str:
-        return ""
+        comment = ""
+        if model._meta.table_description:
+            comment = "{}".format(model._meta.table_description)
+
+        return " ".join(["/*", self._escape_comment(comment=comment), "*/"]) if comment else ""
 
     def _column_comment_generator(self, model, field, comments_array: List) -> str:
-        return ""
+        comment = ""
+        if field.description:
+            comment = "{}".format(field.description)
+
+        return " ".join(["/*", self._escape_comment(comment=comment), "*/"]) if comment else ""

--- a/tortoise/backends/sqlite/schema_generator.py
+++ b/tortoise/backends/sqlite/schema_generator.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from tortoise import fields
 from tortoise.backends.base.schema_generator import BaseSchemaGenerator
 
@@ -15,3 +17,9 @@ class SqliteSchemaGenerator(BaseSchemaGenerator):
 
     def _get_primary_key_create_string(self, field_name: str) -> str:
         return '"{}" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL'.format(field_name)
+
+    def _table_comment_generator(self, model, comments_array: List) -> str:
+        return ""
+
+    def _column_comment_generator(self, model, field, comments_array: List) -> str:
+        return ""

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -55,6 +55,7 @@ class MetaInfo:
         "pk_attr",
         "_generated_db_fields",
         "_model",
+        "table_description",
     )
 
     def __init__(self, meta) -> None:
@@ -80,6 +81,7 @@ class MetaInfo:
         self.pk_attr = getattr(meta, "pk_attr", "")  # type: str
         self._generated_db_fields = None  # type: Optional[Tuple[str]]
         self._model = None  # type: "Model"  # type: ignore
+        self.table_description = getattr(meta, "table_description", "")  # type: str
 
     def add_field(self, name: str, value: Field):
         if name in self.fields_map:

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -300,9 +300,7 @@ class Model(metaclass=ModelMeta):
             setattr(
                 self,
                 key,
-                ManyToManyRelationManager(  # type: ignore
-                    field_object.type, self, field_object
-                ),
+                ManyToManyRelationManager(field_object.type, self, field_object),  # type: ignore
             )
 
         # Assign values and do type conversions

--- a/tortoise/tests/test_generate_schema.py
+++ b/tortoise/tests/test_generate_schema.py
@@ -179,6 +179,13 @@ class TestGenerateSchemaMySQL(TestGenerateSchema):
         )
         self.assertIn("`team_id` INT NOT NULL REFERENCES `team` (`id`) ON DELETE CASCADE", sql)
 
+    async def test_table_and_row_comment_generation(self):
+        await self.init_for("tortoise.tests.testmodels", safe=True)
+        self.continue_if_safe_indexes(supported=False)
+        sql = self.get_sql("comments")
+        self.assertIn("COMMENT=", sql)
+        self.assertIn("COMMENT ", sql)
+
 
 class TestGenerateSchemaPostgresSQL(TestGenerateSchema):
     async def init_for(self, module: str, safe=False) -> None:
@@ -209,3 +216,10 @@ class TestGenerateSchemaPostgresSQL(TestGenerateSchema):
         sql = self.get_sql('"noid"')
         self.assertIn('"name" VARCHAR(255)', sql)
         self.assertIn('"id" SERIAL NOT NULL PRIMARY KEY', sql)
+
+    async def test_table_and_row_comment_generation(self):
+        await self.init_for("tortoise.tests.testmodels", safe=True)
+        self.continue_if_safe_indexes(supported=False)
+        sql = self.get_sql("comments")
+        self.assertIn("COMMENT ON TABLE", sql)
+        self.assertIn("COMMENT ON COLUMN", sql)

--- a/tortoise/tests/test_generate_schema.py
+++ b/tortoise/tests/test_generate_schema.py
@@ -224,4 +224,6 @@ class TestGenerateSchemaPostgresSQL(TestGenerateSchema):
         self.assertIn("COMMENT ON TABLE", sql)
         self.assertIn("COMMENT ON COLUMN", sql)
         self.assertRegex(sql, r"COMMENT ON TABLE comments IS.*")
-        self.assertRegex(sql, r"COMMENT ON COLUMN comments\..* IS.*")
+        self.assertRegex(
+            sql, r"COMMENT ON COLUMN comments\..* IS.*;.*COMMENT ON COLUMN comments\..* IS.*"
+        )

--- a/tortoise/tests/test_generate_schema.py
+++ b/tortoise/tests/test_generate_schema.py
@@ -5,7 +5,7 @@ from asynctest.mock import CoroutineMock, patch
 from tortoise import Tortoise
 from tortoise.contrib import test
 from tortoise.exceptions import ConfigurationError
-from tortoise.utils import get_schema_sql
+from tortoise.utils import generate_post_table_sql, get_schema_sql
 
 
 class TestGenerateSchema(test.SimpleTestCase):
@@ -44,9 +44,15 @@ class TestGenerateSchema(test.SimpleTestCase):
                 }
             )
             self.sqls = get_schema_sql(Tortoise._connections["default"], safe).split("; ")
+            self.post_sqls = generate_post_table_sql(Tortoise._connections["default"], safe).split(
+                "; "
+            )
 
     def get_sql(self, text: str) -> str:
         return re.sub(r"[ \t\n\r]+", " ", [sql for sql in self.sqls if text in sql][0])
+
+    def get_post_sql(self, text: str) -> str:
+        return re.sub(r"[ \t\n\r]+", " ", [sql for sql in self.post_sqls if text in sql][0])
 
     async def test_noid(self):
         await self.init_for("tortoise.tests.testmodels")
@@ -132,6 +138,14 @@ class TestGenerateSchema(test.SimpleTestCase):
         ):
             await self.init_for("tortoise.tests.models_m2m_1")
 
+    async def test_table_and_row_comment_generation(self):
+        await self.init_for("tortoise.tests.testmodels", safe=True)
+        self.continue_if_safe_indexes(supported=False)
+        sql = self.get_sql("comments")
+        self.assertRegex(sql, r".*\/\* Upvotes done on the comment.*\*\/")
+        self.assertRegex(sql, r".*\\n.*")
+        self.assertRegex(sql, r".*it\'s.*")
+
 
 class TestGenerateSchemaMySQL(TestGenerateSchema):
     async def init_for(self, module: str, safe=False) -> None:
@@ -185,6 +199,8 @@ class TestGenerateSchemaMySQL(TestGenerateSchema):
         sql = self.get_sql("comments")
         self.assertIn("COMMENT=", sql)
         self.assertIn("COMMENT ", sql)
+        self.assertRegex(sql, r".*\\n.*")
+        self.assertRegex(sql, r".*it\\'s.*")
 
 
 class TestGenerateSchemaPostgresSQL(TestGenerateSchema):
@@ -220,10 +236,12 @@ class TestGenerateSchemaPostgresSQL(TestGenerateSchema):
     async def test_table_and_row_comment_generation(self):
         await self.init_for("tortoise.tests.testmodels", safe=True)
         self.continue_if_safe_indexes(supported=False)
-        sql = self.get_sql("comments")
+        sql = self.get_post_sql("comments")
         self.assertIn("COMMENT ON TABLE", sql)
         self.assertIn("COMMENT ON COLUMN", sql)
         self.assertRegex(sql, r"COMMENT ON TABLE comments IS.*")
         self.assertRegex(
             sql, r"COMMENT ON COLUMN comments\..* IS.*;.*COMMENT ON COLUMN comments\..* IS.*"
         )
+        self.assertRegex(sql, r".*\\n.*")
+        self.assertRegex(sql, r".*it\'s.*")

--- a/tortoise/tests/test_generate_schema.py
+++ b/tortoise/tests/test_generate_schema.py
@@ -223,3 +223,5 @@ class TestGenerateSchemaPostgresSQL(TestGenerateSchema):
         sql = self.get_sql("comments")
         self.assertIn("COMMENT ON TABLE", sql)
         self.assertIn("COMMENT ON COLUMN", sql)
+        self.assertRegex(sql, r"COMMENT ON TABLE comments IS.*")
+        self.assertRegex(sql, r"COMMENT ON COLUMN comments\..* IS.*")

--- a/tortoise/tests/testmodels.py
+++ b/tortoise/tests/testmodels.py
@@ -258,3 +258,13 @@ class CharFkRelatedModel(Model):
 class CharM2MRelatedModel(Model):
     value = fields.TextField(default="test")
     models = fields.ManyToManyField("models.CharPkModel", related_name="peers")
+
+
+class CommentModel(Model):
+    class Meta:
+        table = "comments"
+        table_description = "Test Table comment"
+
+    id = fields.IntField(pk=True, description="Primary key field for the comments")
+    message = fields.TextField(description="Comment messages entered in the blog post")
+    commented_by = fields.TextField()

--- a/tortoise/tests/testmodels.py
+++ b/tortoise/tests/testmodels.py
@@ -268,4 +268,6 @@ class CommentModel(Model):
     id = fields.IntField(pk=True, description="Primary key field for the comments")
     message = fields.TextField(description="Comment messages entered in the blog post")
     rating = fields.IntField(description="Upvotes done on the comment")
+    escaped_comment_field = fields.TextField(description="This column acts as it's own comment")
+    multiline_comment = fields.TextField(description="Some \n comment")
     commented_by = fields.TextField()

--- a/tortoise/tests/testmodels.py
+++ b/tortoise/tests/testmodels.py
@@ -267,4 +267,5 @@ class CommentModel(Model):
 
     id = fields.IntField(pk=True, description="Primary key field for the comments")
     message = fields.TextField(description="Comment messages entered in the blog post")
+    rating = fields.IntField(description="Upvotes done on the comment")
     commented_by = fields.TextField()

--- a/tortoise/utils.py
+++ b/tortoise/utils.py
@@ -1,4 +1,4 @@
-from typing import Awaitable, Callable, Iterator, Optional
+from typing import Awaitable, Callable, Iterator, List, Optional
 
 
 class QueryAsyncIterator:
@@ -30,6 +30,27 @@ def get_schema_sql(client, safe: bool) -> str:
     return generator.get_create_schema_sql(safe)
 
 
+def generate_post_table_sql(client, safe: bool) -> str:
+    generator = client.schema_generator(client)
+    return generator.generate_post_table_hook_sql(safe=safe)
+
+
 async def generate_schema_for_client(client, safe: bool) -> None:
     generator = client.schema_generator(client)
     await generator.generate_from_string(get_schema_sql(client, safe))
+    post_table_generation_hook = generate_post_table_sql(client, safe)
+    if post_table_generation_hook:
+        await generator.generate_from_string(post_table_generation_hook)
+
+
+def get_escape_translation_table() -> List[str]:
+    """escape sequence taken based on definition provided by PostgreSQL and MySQL"""
+    _escape_table = [chr(x) for x in range(128)]
+    _escape_table[0] = u"\\0"
+    _escape_table[ord("\\")] = u"\\\\"
+    _escape_table[ord("\n")] = u"\\n"
+    _escape_table[ord("\r")] = u"\\r"
+    _escape_table[ord("\032")] = u"\\Z"
+    _escape_table[ord('"')] = u'\\"'
+    _escape_table[ord("'")] = u"\\'"
+    return _escape_table


### PR DESCRIPTION
## Description
Enable row and table level comments while generating the schema based on #148 

## Motivation and Context
Having well commented and documented tables and rows in a DB table is always useful. This feature enables a way to define row and table level comments while defining your database Models. 

## How Has This Been Tested?
1. Changes were tested using `tox` command for all define env. 
2. Changes are tested against sqlite3, mysql and Postgresql databases. 

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

> NOTE: This is a WIP PR. 


## To Do
- [x] Enable basic escaping to handle quotes and basic escape characters
- [x] Add additional tests to account for quoted string corner cases
- [x] Examples and Documentation update