### PR TITLE
__models__ attr

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,10 @@
 Changelog
 =========
 
+0.12.6
+------
+* Handle a __models__ variable within modules to override the model discovery mechanism.
+
 0.12.5
 ------
 * Using non registered models or wrong references causes an ConfigurationError with a helpful message.

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -14,6 +14,7 @@ Contributors
 * Shlomy Balulu ``@shaloba``
 * Klaas Nebuhr ``@FirstKlaas`` 
 * Harsha Narayana ``@harshanarayana``
+* Terra Brown ``@superloach``
 
 Special Thanks
 ==============

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -71,6 +71,11 @@ This models won't be created in schema generation and won't create relations to 
 
 Further we have field ``fields.DatetimeField(auto_now=True)``. Options ``auto_now`` and ``auto_now_add`` work like Django's options.
 
+Use of ``__models__``
+------------
+
+If you define the variable ``__models__`` in the module which you load your models from, ``generate_schema`` will use that list, rather than automatically finding models for you.
+
 Primary Keys
 ------------
 

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -30,8 +30,9 @@ You can do it like this:
 Here we create connection to SQLite database client and then we discover & initialise models.
 
 ``generate_schema`` generates schema on empty database, you shouldn't run it on every app init, run it just once, maybe out of your main code.
-There is also the option when generating the schemas to set the ``safe`` parameter to ``True`` which will only insert the tables if they don't
-already exist.
+There is also the option when generating the schemas to set the ``safe`` parameter to ``True`` which will only insert the tables if they don't already exist.
+
+If you define the ``__models__`` variable in ``app.models`` (or wherever you specify to load your models from), ``generate_schema`` will use that list, rather than automatically finding models for you.
 
 .. _cleaningup:
 

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -32,7 +32,7 @@ Here we create connection to SQLite database client and then we discover & initi
 ``generate_schema`` generates schema on empty database, you shouldn't run it on every app init, run it just once, maybe out of your main code.
 There is also the option when generating the schemas to set the ``safe`` parameter to ``True`` which will only insert the tables if they don't already exist.
 
-If you define the ``__models__`` variable in ``app.models`` (or wherever you specify to load your models from), ``generate_schema`` will use that list, rather than automatically finding models for you.
+If you define the variable ``__models__`` in the ``app.models`` module (or wherever you specify to load your models from), ``generate_schema`` will use that list, rather than automatically finding models for you.
 
 .. _cleaningup:
 

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -198,10 +198,8 @@ class Tortoise:
         except ImportError:
             raise ConfigurationError('Module "{}" not found'.format(models_path))
         discovered_models = []
-        try:
-            # use duck typing to check for existence and iterability
-            possible_models = [*module.__models__]
-        except Exception:
+        possible_models = [*getattr(module, '__models__', None)]
+        if not possible_models:
             possible_models = [getattr(module, attr_name) for attr_name in dir(module)]
         for attr in possible_models:
             if isclass(attr) and issubclass(attr, Model) and not attr._meta.abstract:

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -198,7 +198,11 @@ class Tortoise:
         except ImportError:
             raise ConfigurationError('Module "{}" not found'.format(models_path))
         discovered_models = []
-        possible_models = [*getattr(module, '__models__', None)]
+        possible_models = getattr(module, "__models__", None)
+        try:
+            possible_models = [*possible_models]
+        except TypeError:
+            possible_models = None
         if not possible_models:
             possible_models = [getattr(module, attr_name) for attr_name in dir(module)]
         for attr in possible_models:

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -198,8 +198,12 @@ class Tortoise:
         except ImportError:
             raise ConfigurationError('Module "{}" not found'.format(models_path))
         discovered_models = []
-        for attr_name in dir(module):
-            attr = getattr(module, attr_name)
+        try:
+            # use duck typing to check for existence and iterability
+            possible_models = [*module.__models__]
+        except (AttributeError, TypeError):
+            possible_models = [getattr(module, attr_name) for attr_name in dir(module)]
+        for attr in possible_models:
             if isclass(attr) and issubclass(attr, Model) and not attr._meta.abstract:
                 if attr._meta.app and attr._meta.app != app_label:
                     continue

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -201,7 +201,7 @@ class Tortoise:
         try:
             # use duck typing to check for existence and iterability
             possible_models = [*module.__models__]
-        except (AttributeError, TypeError):
+        except Exception:
             possible_models = [getattr(module, attr_name) for attr_name in dir(module)]
         for attr in possible_models:
             if isclass(attr) and issubclass(attr, Model) and not attr._meta.abstract:

--- a/tortoise/tests/test__models__.py
+++ b/tortoise/tests/test__models__.py
@@ -1,0 +1,71 @@
+"""
+Tests for __models__
+"""
+
+import re
+
+from asynctest.mock import CoroutineMock, patch
+
+from tortoise import Tortoise
+from tortoise.contrib import test
+from tortoise.exceptions import ConfigurationError
+from tortoise.utils import generate_post_table_sql, get_schema_sql
+
+
+class TestGenerateSchema(test.SimpleTestCase):
+    async def setUp(self):
+        try:
+            Tortoise.apps = {}
+            Tortoise._connections = {}
+            Tortoise._inited = False
+        except ConfigurationError:
+            pass
+        Tortoise._inited = False
+        self.sqls = ""
+        self.engine = test.getDBConfig(app_label="models", modules=[])["connections"]["models"][
+            "engine"
+        ]
+
+    async def tearDown(self):
+        Tortoise._connections = {}
+        await Tortoise._reset_apps()
+
+    async def init_for(self, module: str, safe=False) -> None:
+        if self.engine != "tortoise.backends.sqlite":
+            raise test.SkipTest("sqlite only")
+        with patch(
+            "tortoise.backends.sqlite.client.SqliteClient.create_connection", new=CoroutineMock()
+        ):
+            await Tortoise.init(
+                {
+                    "connections": {
+                        "default": {
+                            "engine": "tortoise.backends.sqlite",
+                            "credentials": {"file_path": ":memory:"},
+                        }
+                    },
+                    "apps": {"models": {"models": [module], "default_connection": "default"}},
+                }
+            )
+            self.sqls = get_schema_sql(Tortoise._connections["default"], safe).split("; ")
+            self.post_sqls = generate_post_table_sql(Tortoise._connections["default"], safe).split(
+                "; "
+            )
+
+    def get_sql(self, text: str) -> str:
+        return re.sub(r"[ \t\n\r]+", " ", [sql for sql in self.sqls if text in sql][0])
+
+    def get_post_sql(self, text: str) -> str:
+        return re.sub(r"[ \t\n\r]+", " ", [sql for sql in self.post_sqls if text in sql][0])
+
+    async def test_good(self):
+        await self.init_for("tortoise.tests.test__models__good")
+        self.assertIn('goodtournament', '; '.join(self.sqls))
+        self.assertIn('inaclasstournament', '; '.join(self.sqls))
+        self.assertNotIn('badtournament', '; '.join(self.sqls))
+
+    async def test_bad(self):
+        await self.init_for("tortoise.tests.test__models__bad")
+        self.assertNotIn('goodtournament', '; '.join(self.sqls))
+        self.assertNotIn('inaclasstournament', '; '.join(self.sqls))
+        self.assertIn('badtournament', '; '.join(self.sqls))

--- a/tortoise/tests/test__models__.py
+++ b/tortoise/tests/test__models__.py
@@ -60,12 +60,12 @@ class TestGenerateSchema(test.SimpleTestCase):
 
     async def test_good(self):
         await self.init_for("tortoise.tests.test__models__good")
-        self.assertIn('goodtournament', '; '.join(self.sqls))
-        self.assertIn('inaclasstournament', '; '.join(self.sqls))
-        self.assertNotIn('badtournament', '; '.join(self.sqls))
+        self.assertIn("goodtournament", "; ".join(self.sqls))
+        self.assertIn("inaclasstournament", "; ".join(self.sqls))
+        self.assertNotIn("badtournament", "; ".join(self.sqls))
 
     async def test_bad(self):
         await self.init_for("tortoise.tests.test__models__bad")
-        self.assertNotIn('goodtournament', '; '.join(self.sqls))
-        self.assertNotIn('inaclasstournament', '; '.join(self.sqls))
-        self.assertIn('badtournament', '; '.join(self.sqls))
+        self.assertNotIn("goodtournament", "; ".join(self.sqls))
+        self.assertNotIn("inaclasstournament", "; ".join(self.sqls))
+        self.assertIn("badtournament", "; ".join(self.sqls))

--- a/tortoise/tests/test__models__bad.py
+++ b/tortoise/tests/test__models__bad.py
@@ -1,0 +1,37 @@
+"""
+'Failure' tests for __models__
+"""
+
+from tortoise import fields
+from tortoise.models import Model
+
+
+class BadTournament(Model):
+    id = fields.IntField(pk=True)
+    name = fields.TextField()
+    created = fields.DatetimeField(auto_now_add=True, index=True)
+
+    def __str__(self):
+        return self.name
+
+
+class GoodTournament(Model):
+    id = fields.IntField(pk=True)
+    name = fields.TextField()
+    created = fields.DatetimeField(auto_now_add=True, index=True)
+
+    def __str__(self):
+        return self.name
+
+
+class Tmp:
+    class InAClassTournament(Model):
+        id = fields.IntField(pk=True)
+        name = fields.TextField()
+        created = fields.DatetimeField(auto_now_add=True, index=True)
+
+        def __str__(self):
+            return self.name
+
+
+__models__ = [BadTournament]

--- a/tortoise/tests/test__models__good.py
+++ b/tortoise/tests/test__models__good.py
@@ -4,7 +4,6 @@
 
 from tortoise import fields
 from tortoise.models import Model
-from tortoise.tests.testfields import EnumField
 
 
 class BadTournament(Model):

--- a/tortoise/tests/test__models__good.py
+++ b/tortoise/tests/test__models__good.py
@@ -1,0 +1,38 @@
+"""
+'Success' tests for __models__
+"""
+
+from tortoise import fields
+from tortoise.models import Model
+from tortoise.tests.testfields import EnumField
+
+
+class BadTournament(Model):
+    id = fields.IntField(pk=True)
+    name = fields.TextField()
+    created = fields.DatetimeField(auto_now_add=True, index=True)
+
+    def __str__(self):
+        return self.name
+
+
+class GoodTournament(Model):
+    id = fields.IntField(pk=True)
+    name = fields.TextField()
+    created = fields.DatetimeField(auto_now_add=True, index=True)
+
+    def __str__(self):
+        return self.name
+
+
+class Tmp:
+    class InAClassTournament(Model):
+        id = fields.IntField(pk=True)
+        name = fields.TextField()
+        created = fields.DatetimeField(auto_now_add=True, index=True)
+
+        def __str__(self):
+            return self.name
+
+
+__models__ = [GoodTournament, Tmp.InAClassTournament]


### PR DESCRIPTION
If a module contains the variable `__models__`, use that list to load the models in `_discover_models`, rather than all of the module's attributes. Use duck typing to check for existence and iterability.

In some cases, it may be nice to define models within another class:
```python
class Database(Tortoise):
    def __init__(self):
        print(self.InAClassEntry)

    class InAClassEntry(Model):
        pass

# InAClassEntry will be loaded from within Database
__models__ = [Database.InAClassEntry]
```
Additionally, it may be nice to manually exclude certain models temporarily:
```python
class GoodEntry(Model):
    pass

class BadEntry(Model):
    # some bad code
    pass

# BadEntry will not be loaded
__models__ = [GoodEntry]
```

## How Has This Been Tested?
I created `test__models__`, `test__models__good`, and `test__models__bad` - the tests pass.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.