### PR TITLE
Partial saves are now supported (#157): `obj.save(update_fields=['model','field','names'])`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ New Features:
 - ``.values()`` and ``.values_list()`` now default to all fields if none are specified.
 - ``generate_schema()`` now generates well-formatted DDL SQL statements.
 - Added ``TruncationTestCase`` testing class that truncates tables to allow faster testing of transactions.
+- Partial saves are now supported (#157): ``obj.save(update_fields=['model','field','names'])``
 
 Bugfixes:
 ^^^^^^^^^

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ use_parentheses=True
 line_length=100
 
 [green]
-processes     = 0
+processes     = 1
 no-skip-report= True
 initializer   = tortoise.contrib.test.env_initializer
 finalizer     = tortoise.contrib.test.finalizer

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,15 @@
 # coding: utf8
 import re
 import sys
+import warnings
 
 from setuptools import find_packages, setup
 
 if sys.version_info < (3, 5, 3):
     raise RuntimeError("tortoise requires Python 3.5.3+")
+
+if sys.version_info < (3, 6):
+    warnings.warn("Tortoise-ORM is soon going to require Python 3.6", DeprecationWarning)
 
 
 def version() -> str:

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -3,6 +3,8 @@ import importlib
 import json
 import logging
 import os
+import sys
+import warnings
 from copy import deepcopy
 from inspect import isclass
 from typing import Coroutine, Dict, List, Optional, Tuple, Type, Union, cast  # noqa
@@ -24,6 +26,9 @@ except ImportError:  # pragma: nocoverage
     from aiocontextvars import ContextVar  # type: ignore
 
 logger = logging.getLogger("tortoise")
+
+if sys.version_info < (3, 6):
+    warnings.warn("Tortoise-ORM is soon going to require Python 3.6", DeprecationWarning)
 
 
 class Tortoise:

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -406,14 +406,18 @@ class Model(metaclass=ModelMeta):
     Can be used as a field name when doing filtering e.g. ``.filter(pk=...)`` etc...
     """
 
-    async def save(self, using_db=None) -> None:
+    async def save(self, using_db=None, update_fields=None) -> None:
         """
         Creates/Updates the current model object.
+
+        If ``update_fields`` is provided, it should be a tuple/list of fields by name.
+        This is the subset of fields that should be updated.
+        If the object needs to be created ``update_fields`` will be ignored.
         """
         db = using_db or self._meta.db
         executor = db.executor_class(model=self.__class__, db=db)
         if self._saved_in_db:
-            await executor.execute_update(self)
+            await executor.execute_update(self, update_fields)
         else:
             await executor.execute_insert(self)
             self._saved_in_db = True

--- a/tortoise/tests/test_model_methods.py
+++ b/tortoise/tests/test_model_methods.py
@@ -15,20 +15,20 @@ class TestModelMethods(test.TestCase):
         self.assertEqual(self.mdl.id, oldid)
 
     async def test_save_full(self):
-        self.mdl.name = 'TestS'
-        self.mdl.desc = 'Something'
+        self.mdl.name = "TestS"
+        self.mdl.desc = "Something"
         await self.mdl.save()
         n_mdl = await self.cls.get(id=self.mdl.id)
-        self.assertEqual(n_mdl.name, 'TestS')
-        self.assertEqual(n_mdl.desc, 'Something')
+        self.assertEqual(n_mdl.name, "TestS")
+        self.assertEqual(n_mdl.desc, "Something")
 
     async def test_save_partial(self):
-        self.mdl.name = 'TestS'
-        self.mdl.desc = 'Something'
-        await self.mdl.save(update_fields=['desc'])
+        self.mdl.name = "TestS"
+        self.mdl.desc = "Something"
+        await self.mdl.save(update_fields=["desc"])
         n_mdl = await self.cls.get(id=self.mdl.id)
-        self.assertEqual(n_mdl.name, 'Test')
-        self.assertEqual(n_mdl.desc, 'Something')
+        self.assertEqual(n_mdl.name, "Test")
+        self.assertEqual(n_mdl.desc, "Something")
 
     async def test_create(self):
         mdl = self.cls(name="Test2")

--- a/tortoise/tests/test_model_methods.py
+++ b/tortoise/tests/test_model_methods.py
@@ -14,6 +14,22 @@ class TestModelMethods(test.TestCase):
         await self.mdl.save()
         self.assertEqual(self.mdl.id, oldid)
 
+    async def test_save_full(self):
+        self.mdl.name = 'TestS'
+        self.mdl.desc = 'Something'
+        await self.mdl.save()
+        n_mdl = await self.cls.get(id=self.mdl.id)
+        self.assertEqual(n_mdl.name, 'TestS')
+        self.assertEqual(n_mdl.desc, 'Something')
+
+    async def test_save_partial(self):
+        self.mdl.name = 'TestS'
+        self.mdl.desc = 'Something'
+        await self.mdl.save(update_fields=['desc'])
+        n_mdl = await self.cls.get(id=self.mdl.id)
+        self.assertEqual(n_mdl.name, 'Test')
+        self.assertEqual(n_mdl.desc, 'Something')
+
     async def test_create(self):
         mdl = self.cls(name="Test2")
         self.assertIsNone(mdl.id)

--- a/tortoise/tests/testmodels.py
+++ b/tortoise/tests/testmodels.py
@@ -187,6 +187,7 @@ class NoID(Model):
     name = fields.CharField(max_length=255, null=True)
     desc = fields.TextField(null=True)
 
+
 class RacePlacingEnum(Enum):
     FIRST = "first"
     SECOND = "second"

--- a/tortoise/tests/testmodels.py
+++ b/tortoise/tests/testmodels.py
@@ -17,7 +17,8 @@ def generate_token():
 
 class Tournament(Model):
     id = fields.IntField(pk=True)
-    name = fields.TextField()
+    name = fields.CharField(max_length=255)
+    desc = fields.TextField(null=True)
     created = fields.DatetimeField(auto_now_add=True, index=True)
 
     def __str__(self):
@@ -184,7 +185,7 @@ class M2MTwo(Model):
 
 class NoID(Model):
     name = fields.CharField(max_length=255, null=True)
-
+    desc = fields.TextField(null=True)
 
 class RacePlacingEnum(Enum):
     FIRST = "first"


### PR DESCRIPTION
Implements #157 with some tests.

This was pretty easy.

Also, added the deprecation warnings for py3.5