### PR TITLE
[WIP] Generate schema correctly with non-default column/table names.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,8 @@ Bugfixes:
 - Fixed missing table/column comment generation for ``ForeignKeyField`` and ``ManyToManyField``
 - Fixed comment generation to escape properly for ``SQLite``
 - Fixed comment generation for ``PostgreSQL`` to not duplicate comments
+- Fixed generation of schema for fields that defined custom ``source_field`` values defined
+- Fixed working with Models that have fields with custom ``source_field`` values defined
 
 Docs/examples:
 ^^^^^^^^^^^^^^

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ use_parentheses=True
 line_length=100
 
 [green]
-processes     = 0
+processes     = 1
 no-skip-report= True
 initializer   = tortoise.contrib.test.env_initializer
 finalizer     = tortoise.contrib.test.finalizer

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -94,7 +94,8 @@ class Tortoise:
                     related_model = get_related_model(related_app_name, related_model_name)
 
                     key_field = "{}_id".format(field)
-                    fk_object.source_field = key_field
+                    if not fk_object.source_field:
+                        fk_object.source_field = key_field
                     key_fk_object = deepcopy(related_model._meta.pk)
                     key_fk_object.pk = False
                     key_fk_object.index = fk_object.index
@@ -102,6 +103,7 @@ class Tortoise:
                     key_fk_object.null = fk_object.null
                     key_fk_object.generated = fk_object.generated
                     key_fk_object.reference = fk_object
+                    key_fk_object.source_field = fk_object.source_field
                     model._meta.add_field(key_field, key_fk_object)
 
                     fk_object.type = related_model

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -27,7 +27,7 @@ except ImportError:  # pragma: nocoverage
 
 logger = logging.getLogger("tortoise")
 
-if sys.version_info < (3, 6):
+if sys.version_info < (3, 6):  # pragma: nocoverage
     warnings.warn("Tortoise-ORM is soon going to require Python 3.6", DeprecationWarning)
 
 
@@ -99,8 +99,6 @@ class Tortoise:
                     related_model = get_related_model(related_app_name, related_model_name)
 
                     key_field = "{}_id".format(field)
-                    if not fk_object.source_field:
-                        fk_object.source_field = key_field
                     key_fk_object = deepcopy(related_model._meta.pk)
                     key_fk_object.pk = False
                     key_fk_object.index = fk_object.index
@@ -108,7 +106,12 @@ class Tortoise:
                     key_fk_object.null = fk_object.null
                     key_fk_object.generated = fk_object.generated
                     key_fk_object.reference = fk_object
-                    key_fk_object.source_field = fk_object.source_field
+                    if fk_object.source_field:
+                        key_fk_object.source_field = fk_object.source_field
+                        fk_object.source_field = key_field
+                    else:
+                        fk_object.source_field = key_field
+                        key_fk_object.source_field = key_field
                     model._meta.add_field(key_field, key_fk_object)
 
                     fk_object.type = related_model

--- a/tortoise/backends/asyncpg/executor.py
+++ b/tortoise/backends/asyncpg/executor.py
@@ -24,5 +24,6 @@ class AsyncpgExecutor(BaseExecutor):
     async def _process_insert_result(self, instance: Model, results: Optional[asyncpg.Record]):
         if results:
             generated_fields = self.model._meta.generated_db_fields
+            db_projection = instance._meta.fields_db_projection_reverse
             for key, val in zip(generated_fields, results):
-                setattr(instance, key, val)
+                setattr(instance, db_projection[key], val)

--- a/tortoise/backends/asyncpg/schema_generator.py
+++ b/tortoise/backends/asyncpg/schema_generator.py
@@ -42,6 +42,8 @@ class AsyncpgSchemaGenerator(BaseSchemaGenerator):
         return ""
 
     def _post_table_hook(self) -> str:
-        val = "\n" + "\n".join(self.comments_array)
+        val = "\n".join(self.comments_array)
         self.comments_array = []
-        return val
+        if val:
+            return "\n" + val
+        return ""

--- a/tortoise/backends/base/executor.py
+++ b/tortoise/backends/base/executor.py
@@ -214,7 +214,7 @@ class BaseExecutor:
             )
             for e in raw_results
         }
-        related_object_list = [related_query.model(_from_db=True, **e) for e in raw_results]
+        related_object_list = [related_query.model._init_from_db(**e) for e in raw_results]
         await self.__class__(
             model=related_query.model, db=self.db, prefetch_map=related_query._prefetch_map
         ).fetch_for_list(related_object_list)

--- a/tortoise/backends/mysql/schema_generator.py
+++ b/tortoise/backends/mysql/schema_generator.py
@@ -6,13 +6,13 @@ class MySQLSchemaGenerator(BaseSchemaGenerator):
     TABLE_CREATE_TEMPLATE = "CREATE TABLE {exists}`{table_name}` ({fields}){comment};"
     INDEX_CREATE_TEMPLATE = "CREATE INDEX `{index_name}` ON `{table_name}` ({fields});"
     FIELD_TEMPLATE = "`{name}` {type} {nullable} {unique}{comment}"
-    FK_TEMPLATE = " REFERENCES `{table}` (`id`) ON DELETE {on_delete}{comment}"
+    FK_TEMPLATE = " REFERENCES `{table}` (`{field}`) ON DELETE {on_delete}{comment}"
     M2M_TABLE_TEMPLATE = (
         "CREATE TABLE `{table_name}` (\n"
-        "    `{backward_key}` {backward_type} NOT NULL REFERENCES `{backward_table}` (`id`)"
-        " ON DELETE CASCADE,\n"
-        "    `{forward_key}` {forward_type} NOT NULL REFERENCES `{forward_table}` (`id`)"
-        " ON DELETE CASCADE\n"
+        "    `{backward_key}` {backward_type} NOT NULL REFERENCES `{backward_table}`"
+        " (`{backward_field}`) ON DELETE CASCADE,\n"
+        "    `{forward_key}` {forward_type} NOT NULL REFERENCES `{forward_table}`"
+        " (`{forward_field}`) ON DELETE CASCADE\n"
         "){comment};"
     )
     FIELD_TYPE_MAP = {

--- a/tortoise/filters.py
+++ b/tortoise/filters.py
@@ -158,60 +158,97 @@ def get_filters_for_field(
         return get_m2m_filters(field_name, field)
     if isinstance(field, fields.BackwardFKRelation):
         return get_backward_fk_filters(field_name, field)
+    actual_field_name = field_name
+    if field_name == "pk" and field:
+        actual_field_name = field.model_field_name
     return {
-        field_name: {"field": source_field, "operator": operator.eq},
-        "{}__not".format(field_name): {"field": source_field, "operator": not_equal},
+        field_name: {
+            "field": actual_field_name,
+            "source_field": source_field,
+            "operator": operator.eq,
+        },
+        "{}__not".format(field_name): {
+            "field": actual_field_name,
+            "source_field": source_field,
+            "operator": not_equal,
+        },
         "{}__in".format(field_name): {
-            "field": source_field,
+            "field": actual_field_name,
+            "source_field": source_field,
             "operator": is_in,
             "value_encoder": list_encoder,
         },
         "{}__not_in".format(field_name): {
-            "field": source_field,
+            "field": actual_field_name,
+            "source_field": source_field,
             "operator": not_in,
             "value_encoder": list_encoder,
         },
         "{}__isnull".format(field_name): {
-            "field": source_field,
+            "field": actual_field_name,
+            "source_field": source_field,
             "operator": is_null,
             "value_encoder": bool_encoder,
         },
         "{}__not_isnull".format(field_name): {
-            "field": source_field,
+            "field": actual_field_name,
+            "source_field": source_field,
             "operator": not_null,
             "value_encoder": bool_encoder,
         },
-        "{}__gte".format(field_name): {"field": source_field, "operator": operator.ge},
-        "{}__lte".format(field_name): {"field": source_field, "operator": operator.le},
-        "{}__gt".format(field_name): {"field": source_field, "operator": operator.gt},
-        "{}__lt".format(field_name): {"field": source_field, "operator": operator.lt},
+        "{}__gte".format(field_name): {
+            "field": actual_field_name,
+            "source_field": source_field,
+            "operator": operator.ge,
+        },
+        "{}__lte".format(field_name): {
+            "field": actual_field_name,
+            "source_field": source_field,
+            "operator": operator.le,
+        },
+        "{}__gt".format(field_name): {
+            "field": actual_field_name,
+            "source_field": source_field,
+            "operator": operator.gt,
+        },
+        "{}__lt".format(field_name): {
+            "field": actual_field_name,
+            "source_field": source_field,
+            "operator": operator.lt,
+        },
         "{}__contains".format(field_name): {
-            "field": source_field,
+            "field": actual_field_name,
+            "source_field": source_field,
             "operator": contains,
             "value_encoder": string_encoder,
         },
         "{}__startswith".format(field_name): {
-            "field": source_field,
+            "field": actual_field_name,
+            "source_field": source_field,
             "operator": starts_with,
             "value_encoder": string_encoder,
         },
         "{}__endswith".format(field_name): {
-            "field": source_field,
+            "field": actual_field_name,
+            "source_field": source_field,
             "operator": ends_with,
             "value_encoder": string_encoder,
         },
         "{}__icontains".format(field_name): {
-            "field": source_field,
+            "field": actual_field_name,
+            "source_field": source_field,
             "operator": insensitive_contains,
             "value_encoder": string_encoder,
         },
         "{}__istartswith".format(field_name): {
-            "field": source_field,
+            "field": actual_field_name,
+            "source_field": source_field,
             "operator": insensitive_starts_with,
             "value_encoder": string_encoder,
         },
         "{}__iendswith".format(field_name): {
-            "field": source_field,
+            "field": actual_field_name,
+            "source_field": source_field,
             "operator": insensitive_ends_with,
             "value_encoder": string_encoder,
         },

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -311,8 +311,9 @@ class Model(metaclass=ModelMeta):
         meta = self._meta
 
         for key, value in kwargs.items():
-            if key in meta.fields:
-                setattr(self, key, meta.fields_map[key].to_python_value(value))
+            model_field = meta.fields_db_projection_reverse.get(key)
+            if model_field:
+                setattr(self, model_field, meta.fields_map[model_field].to_python_value(value))
 
         return self
 

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -283,10 +283,10 @@ class Model(metaclass=ModelMeta):
     # I don' like this here, but it makes autocompletion and static analysis much happier
     _meta = MetaInfo(None)
 
-    def __init__(self, *args, _from_db: bool = False, **kwargs) -> None:
+    def __init__(self, *args, **kwargs) -> None:
         # self._meta is a very common attribute lookup, lets cache it.
         meta = self._meta
-        self._saved_in_db = _from_db or (meta.pk_attr in kwargs and meta.pk.generated)
+        self._saved_in_db = meta.pk_attr in kwargs and meta.pk.generated
         self._init_lazy_fkm2m()
 
         # Assign values and do type conversions

--- a/tortoise/query_utils.py
+++ b/tortoise/query_utils.py
@@ -34,7 +34,7 @@ def _process_filter_kwarg(model, key, value) -> Tuple[Criterion, Optional[Tuple[
             if param.get("value_encoder")
             else model._meta.db.executor_class._field_to_db(field_object, value, model)
         )
-        criterion = param["operator"](getattr(table, param["field"]), encoded_value)
+        criterion = param["operator"](getattr(table, param["source_field"]), encoded_value)
     return criterion, join
 
 

--- a/tortoise/tests/models_schema_create.py
+++ b/tortoise/tests/models_schema_create.py
@@ -6,7 +6,7 @@ from tortoise.models import Model
 
 
 class Tournament(Model):
-    id = fields.IntField(pk=True)
+    tid = fields.IntField(pk=True)
     name = fields.TextField(description="Tournament name", index=True)
     created = fields.DatetimeField(auto_now_add=True, description="Created */'`/* datetime")
 
@@ -23,7 +23,7 @@ class Event(Model):
     participants = fields.ManyToManyField(
         "models.Team",
         related_name="events",
-        through="event_team",
+        through="teamevents",
         description="How participants relate",
     )
     modified = fields.DatetimeField(auto_now=True)
@@ -36,6 +36,26 @@ class Event(Model):
 
 class Team(Model):
     name = fields.CharField(max_length=50, pk=True, description="The TEAM name (and PK)")
+    manager = fields.ForeignKeyField("models.Team", related_name="team_members", null=True)
+    talks_to = fields.ManyToManyField("models.Team", related_name="gets_talked_to")
 
     class Meta:
         table_description = "The TEAMS!"
+
+
+class SourceFields(Model):
+    id = fields.IntField(pk=True, source_field="sometable_id")
+    chars = fields.CharField(max_length=255, source_field="some_chars_table", index=True)
+    fk = fields.ForeignKeyField(
+        "models.SourceFields", related_name="team_members", null=True, source_field="fk_sometable"
+    )
+    rel_to = fields.ManyToManyField(
+        "models.SourceFields",
+        related_name="rel_from",
+        through="sometable_self",
+        forward_key="sts_forward",
+        backward_key="backward_sts",
+    )
+
+    class Meta:
+        table = "sometable"

--- a/tortoise/tests/test_source_field.py
+++ b/tortoise/tests/test_source_field.py
@@ -3,8 +3,22 @@ from tortoise.tests.testmodels import SourceFields
 
 
 class TestRelations(test.TestCase):
-    async def test_basic(self):
-        a_1 = await SourceFields.create(chars="aaa")
-        a_2 = await SourceFields.get(id=a_1.id)
+    async def test_get_all(self):
+        obj1 = await SourceFields.create(chars="aaa")
+        self.assertIsNotNone(obj1.id, str(dir(obj1)))
+        obj2 = await SourceFields.create(chars="bbb")
 
-        self.assertEqual(a_1, a_2)
+        objs = await SourceFields.all()
+        self.assertEqual(objs, [obj1, obj2])
+
+    async def test_get_by_pk(self):
+        obj = await SourceFields.create(chars="aaa")
+        obj1 = await SourceFields.get(id=obj.id)
+
+        self.assertEqual(obj, obj1)
+
+    async def test_get_by_chars(self):
+        obj = await SourceFields.create(chars="aaa")
+        obj1 = await SourceFields.get(chars="aaa")
+
+        self.assertEqual(obj, obj1)

--- a/tortoise/tests/test_source_field.py
+++ b/tortoise/tests/test_source_field.py
@@ -1,24 +1,166 @@
+"""
+This module does a series of use tests on a non-source_field model,
+  and then the EXACT same ones on a source_field'ed model.
+
+This is to test that behaviour doesn't change when one defined source_field parameters.
+"""
 from tortoise.contrib import test
-from tortoise.tests.testmodels import SourceFields
+from tortoise.tests.testmodels import SourceFields, StraightFields
 
 
-class TestRelations(test.TestCase):
+class StraightFieldTests(test.TestCase):
+    def setUp(self) -> None:
+        self.model = StraightFields
+
     async def test_get_all(self):
-        obj1 = await SourceFields.create(chars="aaa")
+        obj1 = await self.model.create(chars="aaa")
         self.assertIsNotNone(obj1.id, str(dir(obj1)))
-        obj2 = await SourceFields.create(chars="bbb")
+        obj2 = await self.model.create(chars="bbb")
 
-        objs = await SourceFields.all()
+        objs = await self.model.all()
         self.assertEqual(objs, [obj1, obj2])
 
     async def test_get_by_pk(self):
-        obj = await SourceFields.create(chars="aaa")
-        obj1 = await SourceFields.get(id=obj.id)
+        obj = await self.model.create(chars="aaa")
+        obj1 = await self.model.get(id=obj.id)
 
         self.assertEqual(obj, obj1)
 
     async def test_get_by_chars(self):
-        obj = await SourceFields.create(chars="aaa")
-        obj1 = await SourceFields.get(chars="aaa")
+        obj = await self.model.create(chars="aaa")
+        obj1 = await self.model.get(chars="aaa")
 
         self.assertEqual(obj, obj1)
+
+    async def test_get_fk_forward_fetch_related(self):
+        obj1 = await self.model.create(chars="aaa")
+        obj2 = await self.model.create(chars="bbb", fk=obj1)
+
+        obj2a = await self.model.get(id=obj2.id)
+        await obj2a.fetch_related("fk")
+        self.assertEqual(obj2, obj2a)
+        self.assertEqual(obj1, obj2a.fk)
+
+    async def test_get_fk_forward_prefetch_related(self):
+        obj1 = await self.model.create(chars="aaa")
+        obj2 = await self.model.create(chars="bbb", fk=obj1)
+
+        obj2a = await self.model.get(id=obj2.id).prefetch_related("fk")
+        self.assertEqual(obj2, obj2a)
+        self.assertEqual(obj1, obj2a.fk)
+
+    async def test_get_fk_reverse_await(self):
+        obj1 = await self.model.create(chars="aaa")
+        obj2 = await self.model.create(chars="bbb", fk=obj1)
+        obj3 = await self.model.create(chars="ccc", fk=obj1)
+
+        obj1a = await self.model.get(id=obj1.id)
+        self.assertEqual(await obj1a.fkrev, [obj2, obj3])
+
+    async def test_get_fk_reverse_filter(self):
+        obj1 = await self.model.create(chars="aaa")
+        obj2 = await self.model.create(chars="bbb", fk=obj1)
+        obj3 = await self.model.create(chars="ccc", fk=obj1)
+
+        objs = await self.model.filter(fk=obj1)
+        self.assertEqual(objs, [obj2, obj3])
+
+    async def test_get_fk_reverse_async_for(self):
+        obj1 = await self.model.create(chars="aaa")
+        obj2 = await self.model.create(chars="bbb", fk=obj1)
+        obj3 = await self.model.create(chars="ccc", fk=obj1)
+
+        obj1a = await self.model.get(id=obj1.id)
+        objs = []
+        async for obj in obj1a.fkrev:
+            objs.append(obj)
+        self.assertEqual(objs, [obj2, obj3])
+
+    async def test_get_fk_reverse_fetch_related(self):
+        obj1 = await self.model.create(chars="aaa")
+        obj2 = await self.model.create(chars="bbb", fk=obj1)
+        obj3 = await self.model.create(chars="ccc", fk=obj1)
+
+        obj1a = await self.model.get(id=obj1.id)
+        await obj1a.fetch_related("fkrev")
+        self.assertEqual(list(obj1a.fkrev), [obj2, obj3])
+
+    async def test_get_fk_reverse_prefetch_related(self):
+        obj1 = await self.model.create(chars="aaa")
+        obj2 = await self.model.create(chars="bbb", fk=obj1)
+        obj3 = await self.model.create(chars="ccc", fk=obj1)
+
+        obj1a = await self.model.get(id=obj1.id).prefetch_related("fkrev")
+        self.assertEqual(list(obj1a.fkrev), [obj2, obj3])
+
+    async def test_get_m2m_forward_await(self):
+        obj1 = await self.model.create(chars="aaa")
+        obj2 = await self.model.create(chars="bbb")
+        await obj1.rel_to.add(obj2)
+
+        obj2a = await self.model.get(id=obj2.id)
+        self.assertEqual(await obj2a.rel_from, [obj1])
+
+        obj1a = await self.model.get(id=obj1.id)
+        self.assertEqual(await obj1a.rel_to, [obj2])
+
+    async def test_get_m2m_reverse_await(self):
+        obj1 = await self.model.create(chars="aaa")
+        obj2 = await self.model.create(chars="bbb")
+        await obj2.rel_from.add(obj1)
+
+        obj2a = await self.model.get(id=obj2.id)
+        self.assertEqual(await obj2a.rel_from, [obj1])
+
+        obj1a = await self.model.get(id=obj1.id)
+        self.assertEqual(await obj1a.rel_to, [obj2])
+
+    async def test_get_m2m_filter(self):
+        obj1 = await self.model.create(chars="aaa")
+        obj2 = await self.model.create(chars="bbb")
+        await obj1.rel_to.add(obj2)
+
+        rel_froms = await self.model.filter(rel_from=obj1)
+        self.assertEqual(rel_froms, [obj2])
+
+        rel_tos = await self.model.filter(rel_to=obj2)
+        self.assertEqual(rel_tos, [obj1])
+
+    async def test_get_m2m_forward_fetch_related(self):
+        obj1 = await self.model.create(chars="aaa")
+        obj2 = await self.model.create(chars="bbb")
+        await obj1.rel_to.add(obj2)
+
+        obj2a = await self.model.get(id=obj2.id)
+        await obj2a.fetch_related("rel_from")
+        self.assertEqual(list(obj2a.rel_from), [obj1])
+
+    async def test_get_m2m_reverse_fetch_related(self):
+        obj1 = await self.model.create(chars="aaa")
+        obj2 = await self.model.create(chars="bbb")
+        await obj1.rel_to.add(obj2)
+
+        obj1a = await self.model.get(id=obj1.id)
+        await obj1a.fetch_related("rel_to")
+        self.assertEqual(list(obj1a.rel_to), [obj2])
+
+    async def test_get_m2m_forward_prefetch_related(self):
+        obj1 = await self.model.create(chars="aaa")
+        obj2 = await self.model.create(chars="bbb")
+        await obj1.rel_to.add(obj2)
+
+        obj2a = await self.model.get(id=obj2.id).prefetch_related("rel_from")
+        self.assertEqual(list(obj2a.rel_from), [obj1])
+
+    async def test_get_m2m_reverse_prefetch_related(self):
+        obj1 = await self.model.create(chars="aaa")
+        obj2 = await self.model.create(chars="bbb")
+        await obj1.rel_to.add(obj2)
+
+        obj1a = await self.model.get(id=obj1.id).prefetch_related("rel_to")
+        self.assertEqual(list(obj1a.rel_to), [obj2])
+
+
+class SourceFieldTests(StraightFieldTests):
+    def setUp(self) -> None:
+        self.model = SourceFields

--- a/tortoise/tests/test_source_field.py
+++ b/tortoise/tests/test_source_field.py
@@ -1,0 +1,10 @@
+from tortoise.contrib import test
+from tortoise.tests.testmodels import SourceFields
+
+
+class TestRelations(test.TestCase):
+    async def test_basic(self):
+        a_1 = await SourceFields.create(chars="aaa")
+        a_2 = await SourceFields.get(id=a_1.id)
+
+        self.assertEqual(a_1, a_2)

--- a/tortoise/tests/test_source_field.py
+++ b/tortoise/tests/test_source_field.py
@@ -163,4 +163,4 @@ class StraightFieldTests(test.TestCase):
 
 class SourceFieldTests(StraightFieldTests):
     def setUp(self) -> None:
-        self.model = SourceFields
+        self.model = SourceFields  # type: ignore

--- a/tortoise/tests/testmodels.py
+++ b/tortoise/tests/testmodels.py
@@ -341,11 +341,18 @@ class Employee(Model):
         return "\n".join(text)
 
 
+class StraightFields(Model):
+    id = fields.IntField(pk=True)
+    chars = fields.CharField(max_length=255, index=True)
+    fk = fields.ForeignKeyField("models.StraightFields", related_name="fkrev", null=True)
+    rel_to = fields.ManyToManyField("models.StraightFields", related_name="rel_from")
+
+
 class SourceFields(Model):
     id = fields.IntField(pk=True, source_field="sometable_id")
     chars = fields.CharField(max_length=255, source_field="some_chars_table", index=True)
     fk = fields.ForeignKeyField(
-        "models.SourceFields", related_name="team_members", null=True, source_field="fk_sometable"
+        "models.SourceFields", related_name="fkrev", null=True, source_field="fk_sometable"
     )
     rel_to = fields.ManyToManyField(
         "models.SourceFields",
@@ -357,3 +364,6 @@ class SourceFields(Model):
 
     class Meta:
         table = "sometable"
+
+    def __str__(self):
+        return "<SourceFields {}, {}, {}>".format(self.id, self.chars, self.fk_id)

--- a/tortoise/tests/testmodels.py
+++ b/tortoise/tests/testmodels.py
@@ -366,6 +366,3 @@ class SourceFields(Model):
 
     class Meta:
         table = "sometable"
-
-    def __str__(self):
-        return "<SourceFields {}, {}, {}>".format(self.id, self.chars, self.fk_id)

--- a/tortoise/tests/testmodels.py
+++ b/tortoise/tests/testmodels.py
@@ -339,3 +339,21 @@ class Employee(Model):
         for member in self.team_members:
             text.append(await member.full_hierarchy__fetch_related(level + 1))
         return "\n".join(text)
+
+
+class SourceFields(Model):
+    id = fields.IntField(pk=True, source_field="sometable_id")
+    chars = fields.CharField(max_length=255, source_field="some_chars_table", index=True)
+    fk = fields.ForeignKeyField(
+        "models.SourceFields", related_name="team_members", null=True, source_field="fk_sometable"
+    )
+    rel_to = fields.ManyToManyField(
+        "models.SourceFields",
+        related_name="rel_from",
+        through="sometable_self",
+        forward_key="sts_forward",
+        backward_key="backward_sts",
+    )
+
+    class Meta:
+        table = "sometable"


### PR DESCRIPTION
Should fix #55 

I was quite surprised at how hardcoded some of the field names were, especially with foreign keys. 

* [x] Tests & fixes to generate schema with custom field/table names
  * [x] Test custom PK name & relations from FK
  * [x] Test source_field column with index uses correct name
  * [x] Test custom FK name is preserved (specifically the issues that #55 is talking about)
* [x] Use this model to test basic functionality works as expected:
  * [x] Save & Simple get_by_id
  * [x] Search by indexed non-pk column
  * [x] Forward foreign key
  * [x] Backward foreign keys
  * [x] Filter by foreign key values
  * [x] M2M keys