### PR TITLE
Fixed safe creation of M2M table for MySQL.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,7 @@ Bugfixes:
 - Fixed comment generation for ``PostgreSQL`` to not duplicate comments
 - Fixed generation of schema for fields that defined custom ``source_field`` values defined
 - Fixed working with Models that have fields with custom ``source_field`` values defined
+- Fixed safe creation of M2M tables for MySQL dialect (#168)
 
 Docs/examples:
 ^^^^^^^^^^^^^^

--- a/tortoise/backends/base/schema_generator.py
+++ b/tortoise/backends/base/schema_generator.py
@@ -1,9 +1,12 @@
+import logging
 import warnings
 from typing import List, Set  # noqa
 
 from tortoise import fields
 from tortoise.exceptions import ConfigurationError
 from tortoise.utils import get_escape_translation_table
+
+logger = logging.getLogger("tortoise")
 
 
 class BaseSchemaGenerator:
@@ -222,15 +225,13 @@ class BaseSchemaGenerator:
         ]
         if safe and not self.client.capabilities.safe_indexes:
             warnings.warn(
-                "Skipping creation of field indexes for fields {field_names} "
-                'on table "{table_name}" : safe index creation is not supported yet for {dialect}. '
-                "Please find the SQL queries to create the indexes below.".format(
-                    field_names=", ".join(fields_with_index),
-                    table_name=model._meta.table,
-                    dialect=self.client.capabilities.dialect,
+                "Skipping creation of field indexes: safe index creation is not supported yet for "
+                "{dialect}. Please find the SQL queries to create the indexes in the logs.".format(
+                    dialect=self.client.capabilities.dialect
                 )
             )
-            warnings.warn("\n".join(field_indexes_sqls))
+            for fis in field_indexes_sqls:
+                logger.warning(fis)
         else:
             table_create_string = "\n".join([table_create_string, *field_indexes_sqls])
 

--- a/tortoise/backends/mysql/schema_generator.py
+++ b/tortoise/backends/mysql/schema_generator.py
@@ -8,7 +8,7 @@ class MySQLSchemaGenerator(BaseSchemaGenerator):
     FIELD_TEMPLATE = "`{name}` {type} {nullable} {unique}{comment}"
     FK_TEMPLATE = " REFERENCES `{table}` (`{field}`) ON DELETE {on_delete}{comment}"
     M2M_TABLE_TEMPLATE = (
-        "CREATE TABLE `{table_name}` (\n"
+        "CREATE TABLE {exists}`{table_name}` (\n"
         "    `{backward_key}` {backward_type} NOT NULL REFERENCES `{backward_table}`"
         " (`{backward_field}`) ON DELETE CASCADE,\n"
         "    `{forward_key}` {forward_type} NOT NULL REFERENCES `{forward_table}`"


### PR DESCRIPTION
Also sent uncreated index to logger.warning because warnings module would automatically swallow all but first message.

Fixes #168 
