### PR TITLE
Fix PK generation for Bigint (PostgreSQL, MySQL) and added Smallint PK support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ Changelog
 - Simple update is now ~3-6× faster
 - Partial update is now ~3× faster
 - Delete is now ~2.7x faster
+- Fix generated Schema Primary Key for ``BigIntField`` for MySQL and PostgreSQL.
+- Added support for using a ``SmallIntField`` as a auto-gen Primary Key.
 
 0.13.1
 ------

--- a/tortoise/backends/asyncpg/schema_generator.py
+++ b/tortoise/backends/asyncpg/schema_generator.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from tortoise import fields
 from tortoise.backends.base.schema_generator import BaseSchemaGenerator
@@ -19,8 +19,16 @@ class AsyncpgSchemaGenerator(BaseSchemaGenerator):
         super().__init__(*args, **kwargs)
         self.comments_array = []  # type: List[str]
 
-    def _get_primary_key_create_string(self, field_name: str, comment: str) -> str:
-        return '"{}" SERIAL NOT NULL PRIMARY KEY'.format(field_name)
+    def _get_primary_key_create_string(
+        self, field_object: fields.Field, field_name: str, comment: str
+    ) -> Optional[str]:
+        if isinstance(field_object, fields.SmallIntField):
+            return '"{}" SMALLSERIAL NOT NULL PRIMARY KEY'.format(field_name)
+        if isinstance(field_object, fields.IntField):
+            return '"{}" SERIAL NOT NULL PRIMARY KEY'.format(field_name)
+        if isinstance(field_object, fields.BigIntField):
+            return '"{}" BIGSERIAL NOT NULL PRIMARY KEY'.format(field_name)
+        return None
 
     def _escape_comment(self, comment: str) -> str:
         table = get_escape_translation_table()

--- a/tortoise/backends/mysql/executor.py
+++ b/tortoise/backends/mysql/executor.py
@@ -3,7 +3,7 @@ from pypika.enums import SqlTypes
 
 from tortoise import Model
 from tortoise.backends.base.executor import BaseExecutor
-from tortoise.fields import BigIntField, IntField
+from tortoise.fields import BigIntField, IntField, SmallIntField
 from tortoise.filters import (
     contains,
     ends_with,
@@ -60,7 +60,10 @@ class MySQLExecutor(BaseExecutor):
 
     async def _process_insert_result(self, instance: Model, results: int):
         pk_field_object = self.model._meta.pk
-        if isinstance(pk_field_object, (IntField, BigIntField)) and pk_field_object.generated:
+        if (
+            isinstance(pk_field_object, (SmallIntField, IntField, BigIntField))
+            and pk_field_object.generated
+        ):
             instance.pk = results
 
         # MySQL can only generate a single ROWID

--- a/tortoise/backends/mysql/schema_generator.py
+++ b/tortoise/backends/mysql/schema_generator.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from tortoise import fields
 from tortoise.backends.base.schema_generator import BaseSchemaGenerator
 
@@ -22,8 +24,22 @@ class MySQLSchemaGenerator(BaseSchemaGenerator):
         fields.TextField: "TEXT",
     }
 
-    def _get_primary_key_create_string(self, field_name: str, comment: str) -> str:
-        return "`{}` INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT{}".format(field_name, comment)
+    def _get_primary_key_create_string(
+        self, field_object: fields.Field, field_name: str, comment: str
+    ) -> Optional[str]:
+        if isinstance(field_object, fields.SmallIntField):
+            return "`{}` SMALLINT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT{}".format(
+                field_name, comment
+            )
+        if isinstance(field_object, fields.IntField):
+            return "`{}` INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT{}".format(
+                field_name, comment
+            )
+        if isinstance(field_object, fields.BigIntField):
+            return "`{}` BIGINT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT{}".format(
+                field_name, comment
+            )
+        return None
 
     def _table_generate_extra(self, table: str) -> str:
         return " CHARACTER SET {}".format(self.client.charset) if self.client.charset else ""

--- a/tortoise/backends/sqlite/executor.py
+++ b/tortoise/backends/sqlite/executor.py
@@ -6,7 +6,7 @@ from pypika import Parameter
 
 from tortoise import Model, fields
 from tortoise.backends.base.executor import BaseExecutor
-from tortoise.fields import BigIntField, IntField
+from tortoise.fields import BigIntField, IntField, SmallIntField
 
 
 def to_db_bool(self, value, instance) -> Optional[int]:
@@ -52,7 +52,10 @@ class SqliteExecutor(BaseExecutor):
 
     async def _process_insert_result(self, instance: Model, results: int):
         pk_field_object = self.model._meta.pk
-        if isinstance(pk_field_object, (IntField, BigIntField)) and pk_field_object.generated:
+        if (
+            isinstance(pk_field_object, (SmallIntField, IntField, BigIntField))
+            and pk_field_object.generated
+        ):
             instance.pk = results
 
         # SQLite can only generate a single ROWID

--- a/tortoise/backends/sqlite/schema_generator.py
+++ b/tortoise/backends/sqlite/schema_generator.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from tortoise import fields
 from tortoise.backends.base.schema_generator import BaseSchemaGenerator
 
@@ -23,8 +25,12 @@ class SqliteSchemaGenerator(BaseSchemaGenerator):
         _escape_table[ord("/")] = "\\/"
         return comment.translate(_escape_table)
 
-    def _get_primary_key_create_string(self, field_name: str, comment: str) -> str:
-        return '"{}" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL{}'.format(field_name, comment)
+    def _get_primary_key_create_string(
+        self, field_object: fields.Field, field_name: str, comment: str
+    ) -> Optional[str]:
+        if isinstance(field_object, (fields.SmallIntField, fields.IntField, fields.BigIntField)):
+            return '"{}" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL{}'.format(field_name, comment)
+        return None
 
     def _table_comment_generator(self, table: str, comment: str) -> str:
         return " /* {} */".format(self._escape_comment(comment))

--- a/tortoise/fields.py
+++ b/tortoise/fields.py
@@ -120,12 +120,17 @@ class BigIntField(Field):
 class SmallIntField(Field):
     """
     Small integer field. (16-bit signed)
+
+    ``pk`` (bool):
+        True if field is Primary Key.
     """
 
     __slots__ = ()
 
-    def __init__(self, **kwargs) -> None:
-        super().__init__(int, **kwargs)
+    def __init__(self, pk: bool = False, **kwargs) -> None:
+        if pk:
+            kwargs["generated"] = bool(kwargs.get("generated", True))
+        super().__init__(int, pk=pk, **kwargs)
 
 
 class CharField(Field):

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -208,7 +208,7 @@ class ModelMeta(type):
                                 "only single pk are supported".format(name)
                             )
                         if value.generated and not isinstance(
-                            value, (fields.IntField, fields.BigIntField)
+                            value, (fields.SmallIntField, fields.IntField, fields.BigIntField)
                         ):
                             raise ConfigurationError(
                                 "Generated primary key allowed only for IntField and BigIntField"

--- a/tortoise/tests/models_schema_create.py
+++ b/tortoise/tests/models_schema_create.py
@@ -6,7 +6,7 @@ from tortoise.models import Model
 
 
 class Tournament(Model):
-    tid = fields.IntField(pk=True)
+    tid = fields.SmallIntField(pk=True)
     name = fields.TextField(description="Tournament name", index=True)
     created = fields.DatetimeField(auto_now_add=True, description="Created */'`/* datetime")
 
@@ -15,7 +15,7 @@ class Tournament(Model):
 
 
 class Event(Model):
-    id = fields.IntField(pk=True, description="Event ID")
+    id = fields.BigIntField(pk=True, description="Event ID")
     name = fields.TextField(unique=True)
     tournament = fields.ForeignKeyField(
         "models.Tournament", related_name="events", description="FK to tournament"

--- a/tortoise/tests/test_generate_schema.py
+++ b/tortoise/tests/test_generate_schema.py
@@ -60,7 +60,7 @@ class TestGenerateSchema(test.SimpleTestCase):
         await self.init_for("tortoise.tests.testmodels")
         sql = self.get_sql('"minrelation"')
         self.assertIn(
-            '"tournament_id" INT NOT NULL REFERENCES "tournament" (id) ON DELETE CASCADE', sql
+            '"tournament_id" SMALLINT NOT NULL REFERENCES "tournament" (id) ON DELETE CASCADE', sql
         )
         self.assertNotIn("participants", sql)
 
@@ -172,7 +172,7 @@ CREATE TABLE "event" (
     "modified" TIMESTAMP NOT NULL,
     "prize" VARCHAR(40),
     "token" VARCHAR(100) NOT NULL UNIQUE /* Unique token */,
-    "tournament_id" INT NOT NULL REFERENCES "tournament" (tid) ON DELETE CASCADE /* FK to tournament */
+    "tournament_id" SMALLINT NOT NULL REFERENCES "tournament" (tid) ON DELETE CASCADE /* FK to tournament */
 ) /* This table contains a list of all the events */;
 CREATE TABLE "sometable_self" (
     "backward_sts" INT NOT NULL REFERENCES "sometable" (sometable_id) ON DELETE CASCADE,
@@ -183,7 +183,7 @@ CREATE TABLE "team_team" (
     "team_id" VARCHAR(50) NOT NULL REFERENCES "team" (name) ON DELETE CASCADE
 );
 CREATE TABLE "teamevents" (
-    "event_id" INT NOT NULL REFERENCES "event" (id) ON DELETE CASCADE,
+    "event_id" BIGINT NOT NULL REFERENCES "event" (id) ON DELETE CASCADE,
     "team_id" VARCHAR(50) NOT NULL REFERENCES "team" (name) ON DELETE CASCADE
 ) /* How participants relate */;
 """.strip(),  # noqa
@@ -219,7 +219,7 @@ CREATE TABLE IF NOT EXISTS "event" (
     "modified" TIMESTAMP NOT NULL,
     "prize" VARCHAR(40),
     "token" VARCHAR(100) NOT NULL UNIQUE /* Unique token */,
-    "tournament_id" INT NOT NULL REFERENCES "tournament" (tid) ON DELETE CASCADE /* FK to tournament */
+    "tournament_id" SMALLINT NOT NULL REFERENCES "tournament" (tid) ON DELETE CASCADE /* FK to tournament */
 ) /* This table contains a list of all the events */;
 CREATE TABLE IF NOT EXISTS "sometable_self" (
     "backward_sts" INT NOT NULL REFERENCES "sometable" (sometable_id) ON DELETE CASCADE,
@@ -230,7 +230,7 @@ CREATE TABLE IF NOT EXISTS "team_team" (
     "team_id" VARCHAR(50) NOT NULL REFERENCES "team" (name) ON DELETE CASCADE
 );
 CREATE TABLE IF NOT EXISTS "teamevents" (
-    "event_id" INT NOT NULL REFERENCES "event" (id) ON DELETE CASCADE,
+    "event_id" BIGINT NOT NULL REFERENCES "event" (id) ON DELETE CASCADE,
     "team_id" VARCHAR(50) NOT NULL REFERENCES "team" (name) ON DELETE CASCADE
 ) /* How participants relate */;
 """.strip(),  # noqa
@@ -274,7 +274,8 @@ class TestGenerateSchemaMySQL(TestGenerateSchema):
         await self.init_for("tortoise.tests.testmodels")
         sql = self.get_sql("`minrelation`")
         self.assertIn(
-            "`tournament_id` INT NOT NULL REFERENCES `tournament` (`id`) ON DELETE CASCADE", sql
+            "`tournament_id` SMALLINT NOT NULL REFERENCES `tournament` (`id`) ON DELETE CASCADE",
+            sql,
         )
         self.assertNotIn("participants", sql)
 
@@ -311,18 +312,18 @@ CREATE TABLE `team` (
     `manager_id` VARCHAR(50) REFERENCES `team` (`name`) ON DELETE CASCADE
 ) CHARACTER SET utf8mb4 COMMENT='The TEAMS!';
 CREATE TABLE `tournament` (
-    `tid` INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    `tid` SMALLINT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT,
     `name` TEXT NOT NULL  COMMENT 'Tournament name',
     `created` DATETIME(6) NOT NULL  COMMENT 'Created */\\'`/* datetime'
 ) CHARACTER SET utf8mb4 COMMENT='What Tournaments */\\'`/* we have';
 CREATE INDEX `tournament_name_116110_idx` ON `tournament` (name);
 CREATE TABLE `event` (
-    `id` INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT COMMENT 'Event ID',
+    `id` BIGINT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT COMMENT 'Event ID',
     `name` TEXT NOT NULL UNIQUE,
     `modified` DATETIME(6) NOT NULL,
     `prize` DECIMAL(10,2),
     `token` VARCHAR(100) NOT NULL UNIQUE COMMENT 'Unique token',
-    `tournament_id` INT NOT NULL COMMENT 'FK to tournament' REFERENCES `tournament` (`tid`) ON DELETE CASCADE
+    `tournament_id` SMALLINT NOT NULL COMMENT 'FK to tournament' REFERENCES `tournament` (`tid`) ON DELETE CASCADE
 ) CHARACTER SET utf8mb4 COMMENT='This table contains a list of all the events';
 CREATE TABLE `sometable_self` (
     `backward_sts` INT NOT NULL REFERENCES `sometable` (`sometable_id`) ON DELETE CASCADE,
@@ -333,7 +334,7 @@ CREATE TABLE `team_team` (
     `team_id` VARCHAR(50) NOT NULL REFERENCES `team` (`name`) ON DELETE CASCADE
 ) CHARACTER SET utf8mb4;
 CREATE TABLE `teamevents` (
-    `event_id` INT NOT NULL REFERENCES `event` (`id`) ON DELETE CASCADE,
+    `event_id` BIGINT NOT NULL REFERENCES `event` (`id`) ON DELETE CASCADE,
     `team_id` VARCHAR(50) NOT NULL REFERENCES `team` (`name`) ON DELETE CASCADE
 ) CHARACTER SET utf8mb4 COMMENT='How participants relate';
 """.strip(),  # noqa
@@ -378,17 +379,17 @@ CREATE TABLE IF NOT EXISTS `team` (
     `manager_id` VARCHAR(50) REFERENCES `team` (`name`) ON DELETE CASCADE
 ) CHARACTER SET utf8mb4 COMMENT='The TEAMS!';
 CREATE TABLE IF NOT EXISTS `tournament` (
-    `tid` INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    `tid` SMALLINT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT,
     `name` TEXT NOT NULL  COMMENT 'Tournament name',
     `created` DATETIME(6) NOT NULL  COMMENT 'Created */\\'`/* datetime'
 ) CHARACTER SET utf8mb4 COMMENT='What Tournaments */\\'`/* we have';
 CREATE TABLE IF NOT EXISTS `event` (
-    `id` INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT COMMENT 'Event ID',
+    `id` BIGINT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT COMMENT 'Event ID',
     `name` TEXT NOT NULL UNIQUE,
     `modified` DATETIME(6) NOT NULL,
     `prize` DECIMAL(10,2),
     `token` VARCHAR(100) NOT NULL UNIQUE COMMENT 'Unique token',
-    `tournament_id` INT NOT NULL COMMENT 'FK to tournament' REFERENCES `tournament` (`tid`) ON DELETE CASCADE
+    `tournament_id` SMALLINT NOT NULL COMMENT 'FK to tournament' REFERENCES `tournament` (`tid`) ON DELETE CASCADE
 ) CHARACTER SET utf8mb4 COMMENT='This table contains a list of all the events';
 CREATE TABLE IF NOT EXISTS `sometable_self` (
     `backward_sts` INT NOT NULL REFERENCES `sometable` (`sometable_id`) ON DELETE CASCADE,
@@ -399,7 +400,7 @@ CREATE TABLE IF NOT EXISTS `team_team` (
     `team_id` VARCHAR(50) NOT NULL REFERENCES `team` (`name`) ON DELETE CASCADE
 ) CHARACTER SET utf8mb4;
 CREATE TABLE IF NOT EXISTS `teamevents` (
-    `event_id` INT NOT NULL REFERENCES `event` (`id`) ON DELETE CASCADE,
+    `event_id` BIGINT NOT NULL REFERENCES `event` (`id`) ON DELETE CASCADE,
     `team_id` VARCHAR(50) NOT NULL REFERENCES `team` (`name`) ON DELETE CASCADE
 ) CHARACTER SET utf8mb4 COMMENT='How participants relate';
 """.strip(),  # noqa
@@ -469,7 +470,7 @@ CREATE TABLE "team" (
 COMMENT ON COLUMN team.name IS 'The TEAM name (and PK)';
 COMMENT ON TABLE team IS 'The TEAMS!';
 CREATE TABLE "tournament" (
-    "tid" SERIAL NOT NULL PRIMARY KEY,
+    "tid" SMALLSERIAL NOT NULL PRIMARY KEY,
     "name" TEXT NOT NULL,
     "created" TIMESTAMP NOT NULL
 );
@@ -478,12 +479,12 @@ COMMENT ON COLUMN tournament.name IS 'Tournament name';
 COMMENT ON COLUMN tournament.created IS 'Created */''`/* datetime';
 COMMENT ON TABLE tournament IS 'What Tournaments */''`/* we have';
 CREATE TABLE "event" (
-    "id" SERIAL NOT NULL PRIMARY KEY,
+    "id" BIGSERIAL NOT NULL PRIMARY KEY,
     "name" TEXT NOT NULL UNIQUE,
     "modified" TIMESTAMP NOT NULL,
     "prize" DECIMAL(10,2),
     "token" VARCHAR(100) NOT NULL UNIQUE,
-    "tournament_id" INT NOT NULL REFERENCES "tournament" (tid) ON DELETE CASCADE
+    "tournament_id" SMALLINT NOT NULL REFERENCES "tournament" (tid) ON DELETE CASCADE
 );
 COMMENT ON COLUMN event.id IS 'Event ID';
 COMMENT ON COLUMN event.token IS 'Unique token';
@@ -498,7 +499,7 @@ CREATE TABLE "team_team" (
     "team_id" VARCHAR(50) NOT NULL REFERENCES "team" (name) ON DELETE CASCADE
 );
 CREATE TABLE "teamevents" (
-    "event_id" INT NOT NULL REFERENCES "event" (id) ON DELETE CASCADE,
+    "event_id" BIGINT NOT NULL REFERENCES "event" (id) ON DELETE CASCADE,
     "team_id" VARCHAR(50) NOT NULL REFERENCES "team" (name) ON DELETE CASCADE
 );
 COMMENT ON TABLE teamevents IS 'How participants relate';
@@ -526,7 +527,7 @@ CREATE TABLE IF NOT EXISTS "team" (
 COMMENT ON COLUMN team.name IS 'The TEAM name (and PK)';
 COMMENT ON TABLE team IS 'The TEAMS!';
 CREATE TABLE IF NOT EXISTS "tournament" (
-    "tid" SERIAL NOT NULL PRIMARY KEY,
+    "tid" SMALLSERIAL NOT NULL PRIMARY KEY,
     "name" TEXT NOT NULL,
     "created" TIMESTAMP NOT NULL
 );
@@ -535,12 +536,12 @@ COMMENT ON COLUMN tournament.name IS 'Tournament name';
 COMMENT ON COLUMN tournament.created IS 'Created */''`/* datetime';
 COMMENT ON TABLE tournament IS 'What Tournaments */''`/* we have';
 CREATE TABLE IF NOT EXISTS "event" (
-    "id" SERIAL NOT NULL PRIMARY KEY,
+    "id" BIGSERIAL NOT NULL PRIMARY KEY,
     "name" TEXT NOT NULL UNIQUE,
     "modified" TIMESTAMP NOT NULL,
     "prize" DECIMAL(10,2),
     "token" VARCHAR(100) NOT NULL UNIQUE,
-    "tournament_id" INT NOT NULL REFERENCES "tournament" (tid) ON DELETE CASCADE
+    "tournament_id" SMALLINT NOT NULL REFERENCES "tournament" (tid) ON DELETE CASCADE
 );
 COMMENT ON COLUMN event.id IS 'Event ID';
 COMMENT ON COLUMN event.token IS 'Unique token';
@@ -555,7 +556,7 @@ CREATE TABLE IF NOT EXISTS "team_team" (
     "team_id" VARCHAR(50) NOT NULL REFERENCES "team" (name) ON DELETE CASCADE
 );
 CREATE TABLE IF NOT EXISTS "teamevents" (
-    "event_id" INT NOT NULL REFERENCES "event" (id) ON DELETE CASCADE,
+    "event_id" BIGINT NOT NULL REFERENCES "event" (id) ON DELETE CASCADE,
     "team_id" VARCHAR(50) NOT NULL REFERENCES "team" (name) ON DELETE CASCADE
 );
 COMMENT ON TABLE teamevents IS 'How participants relate';

--- a/tortoise/tests/testmodels.py
+++ b/tortoise/tests/testmodels.py
@@ -16,7 +16,7 @@ def generate_token():
 
 
 class Tournament(Model):
-    id = fields.IntField(pk=True)
+    id = fields.SmallIntField(pk=True)
     name = fields.CharField(max_length=255)
     desc = fields.TextField(null=True)
     created = fields.DatetimeField(auto_now_add=True, index=True)
@@ -37,7 +37,7 @@ class Reporter(Model):
 
 
 class Event(Model):
-    id = fields.IntField(pk=True)
+    id = fields.BigIntField(pk=True)
     name = fields.TextField()
     tournament = fields.ForeignKeyField("models.Tournament", related_name="events")
     reporter = fields.ForeignKeyField("models.Reporter", null=True)


### PR DESCRIPTION
Whilst working on #173 I noticed that a generated PK for a `BigIntField` was just on type `INT`.

Obviously this is wrong. Refactored autonumber PK DDL generation, and modified the tests so that those get tested.
I also added PK support for `SmallIntField` as it was properly supported in both PostgreSQL and MySQL.

SQLite only supports `INTEGER` autonumbers, which are just aliases for `__rowid__` which is always a 64-bit number.
Considering that SQLite doesn't actually honour any int type other than 64-bit unsigned, I left the minor discrepancy where foreign keys are still `BIGINT` and `SMALLINT`, even though the PK they link to is just `INTEGER`.