### PR TITLE
Ensure that default PK is added to the top of the attrs.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,11 +8,15 @@ Changelog
 
   This is now fully parametrized, and these operations are no longer susceptible to escaping issues.
 
-- Simple update is now ~3-6× faster
-- Partial update is now ~3× faster
-- Delete is now ~2.7x faster
+* Performance improvements:
+
+  - Simple update is now ~3-6× faster
+  - Partial update is now ~3× faster
+  - Delete is now ~2.7x faster
+
 - Fix generated Schema Primary Key for ``BigIntField`` for MySQL and PostgreSQL.
 - Added support for using a ``SmallIntField`` as a auto-gen Primary Key.
+- Ensure that default PK is added to the top of the attrs.
 
 0.13.1
 ------

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -218,7 +218,7 @@ class ModelMeta(type):
 
             if not custom_pk_present:
                 if "id" not in attrs:
-                    attrs["id"] = fields.IntField(pk=True)
+                    attrs = {"id": fields.IntField(pk=True), **attrs}
 
                 if not isinstance(attrs["id"], fields.Field) or not attrs["id"].pk:
                     raise ConfigurationError(

--- a/tortoise/tests/models_schema_create.py
+++ b/tortoise/tests/models_schema_create.py
@@ -59,3 +59,7 @@ class SourceFields(Model):
 
     class Meta:
         table = "sometable"
+
+
+class DefaultPK(Model):
+    val = fields.IntField()

--- a/tortoise/tests/test_generate_schema.py
+++ b/tortoise/tests/test_generate_schema.py
@@ -150,6 +150,10 @@ class TestGenerateSchema(test.SimpleTestCase):
         self.assertEqual(
             sql.strip(),
             """
+CREATE TABLE "defaultpk" (
+    "id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    "val" INT NOT NULL
+);
 CREATE TABLE "sometable" (
     "sometable_id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     "some_chars_table" VARCHAR(255) NOT NULL,
@@ -197,6 +201,10 @@ CREATE TABLE "teamevents" (
         self.assertEqual(
             sql.strip(),
             """
+CREATE TABLE IF NOT EXISTS "defaultpk" (
+    "id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    "val" INT NOT NULL
+);
 CREATE TABLE IF NOT EXISTS "sometable" (
     "sometable_id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     "some_chars_table" VARCHAR(255) NOT NULL,
@@ -301,6 +309,10 @@ class TestGenerateSchemaMySQL(TestGenerateSchema):
         self.assertEqual(
             sql.strip(),
             """
+CREATE TABLE `defaultpk` (
+    `id` INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    `val` INT NOT NULL
+) CHARACTER SET utf8mb4;
 CREATE TABLE `sometable` (
     `sometable_id` INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT,
     `some_chars_table` VARCHAR(255) NOT NULL,
@@ -369,6 +381,10 @@ CREATE TABLE `teamevents` (
         self.assertEqual(
             sql.strip(),
             """
+CREATE TABLE IF NOT EXISTS `defaultpk` (
+    `id` INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    `val` INT NOT NULL
+) CHARACTER SET utf8mb4;
 CREATE TABLE IF NOT EXISTS `sometable` (
     `sometable_id` INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT,
     `some_chars_table` VARCHAR(255) NOT NULL,
@@ -457,6 +473,10 @@ class TestGenerateSchemaPostgresSQL(TestGenerateSchema):
         self.assertEqual(
             sql.strip(),
             """
+CREATE TABLE "defaultpk" (
+    "id" SERIAL NOT NULL PRIMARY KEY,
+    "val" INT NOT NULL
+);
 CREATE TABLE "sometable" (
     "sometable_id" SERIAL NOT NULL PRIMARY KEY,
     "some_chars_table" VARCHAR(255) NOT NULL,
@@ -514,6 +534,10 @@ COMMENT ON TABLE teamevents IS 'How participants relate';
         self.assertEqual(
             sql.strip(),
             """
+CREATE TABLE IF NOT EXISTS "defaultpk" (
+    "id" SERIAL NOT NULL PRIMARY KEY,
+    "val" INT NOT NULL
+);
 CREATE TABLE IF NOT EXISTS "sometable" (
     "sometable_id" SERIAL NOT NULL PRIMARY KEY,
     "some_chars_table" VARCHAR(255) NOT NULL,


### PR DESCRIPTION
It was slightly annoying that the default PK was not at the top of the generated DDL.

This will only preserve order for Py3.6+