### PR TITLE
Hotfix/add connection pool for postgresql only

### DIFF
--- a/tortoise/backends/asyncpg/client.py
+++ b/tortoise/backends/asyncpg/client.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     from typing import AsyncContextManager
 
 from contextvars import ContextVar
-current_transaction = ContextVar("Current TransactionWrapper obj")
+current_transaction = ContextVar("Current TransactionWrapper obj", default=None)
 
 
 def retry_connection(func):

--- a/tortoise/backends/asyncpg/client.py
+++ b/tortoise/backends/asyncpg/client.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 from functools import wraps
-from typing import List, Optional, SupportsInt  # noqa
+from typing import List, Optional, SupportsInt, Union, TYPE_CHECKING  # noqa
 
 import asyncpg
 from pypika import PostgreSQLQuery
@@ -20,7 +20,12 @@ from tortoise.exceptions import (
     OperationalError,
     TransactionManagementError,
 )
-from tortoise.transactions import current_transaction_map
+
+if TYPE_CHECKING:
+    from typing import AsyncContextManager
+
+from contextvars import ContextVar
+current_transaction = ContextVar("Current TransactionWrapper obj")
 
 
 def retry_connection(func):
@@ -39,16 +44,14 @@ def retry_connection(func):
             if getattr(self, "transaction", None):
                 self._finalized = True
                 raise TransactionManagementError("Connection gone away during transaction")
-            await self._lock.acquire()
             logging.info("Attempting reconnect")
             try:
                 await self._close()
                 await self.create_connection(with_db=True)
                 logging.info("Reconnected")
             except Exception as e:
-                raise DBConnectionError("Failed to reconnect: %s", str(e))
-            finally:
-                self._lock.release()
+                logging.info("Failed to reconnect: %s", str(e))
+                raise
 
             return await func(self, *args)
 
@@ -68,15 +71,42 @@ def translate_exceptions(func):
     return translate_exceptions_
 
 
+class PoolConnectionDispatcher:
+    __slots__ = ("pool", "connection")
+    log = logging.getLogger("db_client")
+
+    def __init__(self, pool: asyncpg.pool.Pool) -> None:
+        self.pool = pool
+        self.connection = None
+
+    async def __aenter__(self):
+        self.connection = await self.pool.acquire()
+        self.log.debug("Acquired connection %s", self.connection)
+        return self.connection
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.log.debug("Released connection %s", self.connection)
+        await self.pool.release(self.connection)
+
+
 class AsyncpgDBClient(BaseDBAsyncClient):
     DSN_TEMPLATE = "postgres://{user}:{password}@{host}:{port}/{database}"
     query_class = PostgreSQLQuery
     executor_class = AsyncpgExecutor
     schema_generator = AsyncpgSchemaGenerator
-    capabilities = Capabilities("postgres")
+    capabilities = Capabilities("postgres", pooling=True)
 
     def __init__(
-        self, user: str, password: str, database: str, host: str, port: SupportsInt, **kwargs
+        self,
+        user: str,
+        password: str,
+        database: str,
+        host: str,
+        port: SupportsInt,
+        min_size: SupportsInt = 10,
+        max_size: SupportsInt = 10000,
+        max_inactive_connection_lifetime=0,
+        **kwargs
     ) -> None:
         super().__init__(**kwargs)
 
@@ -86,15 +116,16 @@ class AsyncpgDBClient(BaseDBAsyncClient):
         self.host = host
         self.port = int(port)  # make sure port is int type
         self.extra = kwargs.copy()
-        self.schema = self.extra.pop("schema", None)
         self.extra.pop("connection_name", None)
         self.extra.pop("fetch_inserted", None)
         self.extra.pop("loop", None)
         self.extra.pop("connection_class", None)
+        self._pool = None  # type: Optional[asyncpg.pool.Pool]
+        self.min_size = int(min_size)
+        self.max_size = int(max_size)
+        self.max_inactive_connection_lifetime = int(max_inactive_connection_lifetime)
 
         self._template = {}  # type: dict
-        self._connection = None  # Type: Optional[asyncpg.Connection]
-        self._lock = asyncio.Lock()
 
         self._transaction_class = type(
             "TransactionWrapper", (TransactionWrapper, self.__class__), {}
@@ -106,30 +137,31 @@ class AsyncpgDBClient(BaseDBAsyncClient):
             "port": self.port,
             "user": self.user,
             "database": self.database if with_db else None,
+            "min_size": self.min_size,
+            "max_size": self.max_size,
+            "max_inactive_connection_lifetime": self.max_inactive_connection_lifetime,
             **self.extra,
         }
         try:
-            self._connection = await asyncpg.connect(None, password=self.password, **self._template)
-            self.log.debug(
-                "Created connection %s with params: %s", self._connection, self._template
-            )
+            self._pool = await asyncpg.create_pool(None, password=self.password, **self._template)
+            self.log.debug("Created pool %s with params: %s", self._pool, self._template)
         except asyncpg.InvalidCatalogNameError:
             raise DBConnectionError(
                 "Can't establish connection to database {}".format(self.database)
             )
-        # Set post-connection variables
-        if self.schema:
-            await self.execute_script("SET search_path TO {}".format(self.schema))
 
     async def _close(self) -> None:
-        if self._connection:  # pragma: nobranch
-            await self._connection.close()
-            self.log.debug("Closed connection %s with params: %s", self._connection, self._template)
+        if self._pool:  # pragma: nobranch
+            try:
+                await asyncio.wait_for(self._pool.close(), 10)
+            except asyncio.TimeoutError:
+                await self._pool.terminate()
+            self.log.debug("Closed pool %s with params: %s", self._pool, self._template)
             self._template.clear()
 
     async def close(self) -> None:
         await self._close()
-        self._connection = None
+        self._pool = None
 
     async def db_create(self) -> None:
         await self.create_connection(with_db=False)
@@ -146,15 +178,22 @@ class AsyncpgDBClient(BaseDBAsyncClient):
             pass
         await self.close()
 
-    def acquire_connection(self) -> ConnectionWrapper:
-        return ConnectionWrapper(self._connection, self._lock)
+    def acquire_connection(self) -> "AsyncContextManager":
+        return PoolConnectionDispatcher(self._pool)
 
     def _in_transaction(self) -> "TransactionWrapper":
-        return self._transaction_class(self)
+        transaction_wrapper = self._transaction_class(None, self)
+        current_transaction.set(transaction_wrapper)
+        return transaction_wrapper
 
     @translate_exceptions
     @retry_connection
     async def execute_insert(self, query: str, values: list) -> Optional[asyncpg.Record]:
+        transaction_wrapper = current_transaction.get()
+        if transaction_wrapper:
+            stmt = await transaction_wrapper._connection.prepare(query)
+            return await stmt.fetchrow(*values)
+
         async with self.acquire_connection() as connection:
             self.log.debug("%s: %s", query, values)
             # TODO: Cache prepared statement
@@ -164,6 +203,12 @@ class AsyncpgDBClient(BaseDBAsyncClient):
     @translate_exceptions
     @retry_connection
     async def execute_many(self, query: str, values: list) -> None:
+        transaction_wrapper = current_transaction.get()
+        if transaction_wrapper:
+            self.log.debug("%s: %s", query, values)
+            # TODO: Consider using copy_records_to_table instead
+            await transaction_wrapper._connection.executemany(query, values)
+
         async with self.acquire_connection() as connection:
             self.log.debug("%s: %s", query, values)
             # TODO: Consider using copy_records_to_table instead
@@ -172,6 +217,11 @@ class AsyncpgDBClient(BaseDBAsyncClient):
     @translate_exceptions
     @retry_connection
     async def execute_query(self, query: str) -> List[dict]:
+        transaction_wrapper = current_transaction.get()
+        if transaction_wrapper:
+            self.log.debug(query)
+            return await transaction_wrapper._connection.fetch(query)
+
         async with self.acquire_connection() as connection:
             self.log.debug(query)
             return await connection.fetch(query)
@@ -179,51 +229,74 @@ class AsyncpgDBClient(BaseDBAsyncClient):
     @translate_exceptions
     @retry_connection
     async def execute_script(self, query: str) -> None:
+        transaction_wrapper = current_transaction.get()
+        if transaction_wrapper:
+            self.log.debug(query)
+            await transaction_wrapper._connection.execute(query)
+
         async with self.acquire_connection() as connection:
             self.log.debug(query)
             await connection.execute(query)
 
 
-class TransactionWrapper(AsyncpgDBClient, BaseTransactionWrapper):
-    def __init__(self, connection) -> None:
-        self._connection = connection._connection
-        self._lock = connection._lock
+class TransactionWrapper(BaseTransactionWrapper, AsyncpgDBClient):
+    def __init__(
+        self, connection: asyncpg.Connection, parent: Union[AsyncpgDBClient, "TransactionWrapper"]
+    ) -> None:
+        self._pool = parent._pool  # type: asyncpg.pool.Pool
+        self._current_transaction = parent._current_transaction
         self.log = logging.getLogger("db_client")
         self._transaction_class = self.__class__
-        self._old_context_value = None
-        self.connection_name = connection.connection_name
+        self._old_context_value = None  # type: Optional[BaseDBAsyncClient]
+        self.connection_name = parent.connection_name
         self.transaction = None
         self._finalized = False
-        self._parent = connection
+        self._parent = parent
+        self._connection = connection
+        if isinstance(parent, TransactionWrapper):
+            self._lock = parent._lock  # type: asyncio.Lock
+        else:
+            self._lock = asyncio.Lock()
 
     async def create_connection(self, with_db: bool) -> None:
         await self._parent.create_connection(with_db)
-        self._connection = self._parent._connection
+        self._pool = self._parent._pool
 
     async def _close(self) -> None:
         await self._parent._close()
-        self._connection = self._parent._connection
+        self._pool = self._parent._pool
+
+    def acquire_connection(self) -> "AsyncContextManager":
+        return ConnectionWrapper(self._connection, self._lock)
+
+    def _in_transaction(self) -> "TransactionWrapper":
+        return self._transaction_class(self._connection, self)
 
     @retry_connection
     async def start(self):
+        if not self._connection:
+            self._connection = await self._pool.acquire()
         self.transaction = self._connection.transaction()
         await self.transaction.start()
-        current_transaction = current_transaction_map[self.connection_name]
-        self._old_context_value = current_transaction.get()
-        current_transaction.set(self)
+        self._old_context_value = self._current_transaction.get()
+        self._current_transaction.set(self)
 
-    def release(self) -> None:
+    async def finalize(self) -> None:
+        if not self._old_context_value:
+            raise OperationalError("Finalize was called before transaction start")
         self._finalized = True
-        current_transaction_map[self.connection_name].set(self._old_context_value)
+        self._current_transaction.set(self._old_context_value)
+        await self._pool.release(self._connection)
+        self._connection = None
 
     async def commit(self):
         if self._finalized:
             raise TransactionManagementError("Transaction already finalised")
         await self.transaction.commit()
-        self.release()
+        await self.finalize()
 
     async def rollback(self):
         if self._finalized:
             raise TransactionManagementError("Transaction already finalised")
         await self.transaction.rollback()
-        self.release()
+        await self.finalize()

--- a/tortoise/backends/base/client.py
+++ b/tortoise/backends/base/client.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 from typing import Any, Sequence
 
 from pypika import Query
@@ -6,6 +7,11 @@ from pypika import Query
 from tortoise.backends.base.executor import BaseExecutor
 from tortoise.backends.base.schema_generator import BaseSchemaGenerator
 from tortoise.exceptions import TransactionManagementError
+
+if sys.version_info < (3, 7):
+    from aiocontextvars import ContextVar  # pylint: disable=E0401
+else:
+    from contextvars import ContextVar
 
 
 class Capabilities:
@@ -37,7 +43,8 @@ class Capabilities:
         # Deficiencies to work around:
         safe_indexes: bool = True,
         requires_limit: bool = False,
-        inline_comment: bool = False
+        inline_comment: bool = False,
+        pooling: bool = False
     ) -> None:
         super().__setattr__("_mutable", True)
 
@@ -46,6 +53,7 @@ class Capabilities:
         self.requires_limit = requires_limit
         self.safe_indexes = safe_indexes
         self.inline_comment = inline_comment
+        self.pooling = pooling
 
         super().__setattr__("_mutable", False)
 
@@ -69,6 +77,8 @@ class BaseDBAsyncClient:
         self.connection_name = connection_name
         self.fetch_inserted = fetch_inserted
 
+        self._current_transaction = ContextVar(self.connection_name, default=self)  # Type: dict
+
     async def create_connection(self, with_db: bool) -> None:
         raise NotImplementedError()  # pragma: nocoverage
 
@@ -81,7 +91,7 @@ class BaseDBAsyncClient:
     async def db_delete(self) -> None:
         raise NotImplementedError()  # pragma: nocoverage
 
-    def acquire_connection(self) -> "ConnectionWrapper":
+    def acquire_connection(self):
         raise NotImplementedError()  # pragma: nocoverage
 
     def _in_transaction(self) -> "BaseTransactionWrapper":
@@ -95,6 +105,9 @@ class BaseDBAsyncClient:
 
     async def execute_script(self, query: str) -> None:
         raise NotImplementedError()  # pragma: nocoverage
+
+    def get_current_transaction(self) -> "BaseDBAsyncClient":
+        return self._current_transaction.get()
 
     # async def execute_explain(self, query: str) -> Sequence[dict]:
     #     raise NotImplementedError()  # pragma: nocoverage
@@ -119,7 +132,7 @@ class BaseTransactionWrapper:
     async def start(self) -> None:
         raise NotImplementedError()  # pragma: nocoverage
 
-    def release(self) -> None:
+    async def finalize(self) -> None:
         raise NotImplementedError()  # pragma: nocoverage
 
     async def rollback(self) -> None:
@@ -128,6 +141,9 @@ class BaseTransactionWrapper:
     async def commit(self) -> None:
         raise NotImplementedError()  # pragma: nocoverage
 
+    async def release(self, connection):
+        pass
+
     async def __aenter__(self):
         await self.start()
         return self
@@ -135,7 +151,7 @@ class BaseTransactionWrapper:
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
         if exc_type:
             if issubclass(exc_type, TransactionManagementError):
-                self.release()
+                await self.finalize()
             else:
                 await self.rollback()
         else:


### PR DESCRIPTION
Add connection pool and make it work correctly.

## Description
So basically, I am using Tortoise in my Project which needs to handle more than 20000 QPS,  thus the asyncpg connection pool is required. So I've tried to incorporate PR 141's asyncpg/client and base/client into tortoise, so at lease I can get a temporary connection pool version of tortoise to get my project work. But after a little pressure test, (somewhere around 120 requests/s, 3 create per transaction, 40 transactions/s), error occurs, says a "transaction is already closed", which means the ddl s inside the same transaction were using different connections. it's because the execute_insert function inside AsyncpgDBClient is creating new connections wether it's inside a transaction or not, so in order to let all ddl s use same connection, I use a contextvars to store the transactionwrapper instance in the current coroutine context.

