### PR TITLE
queryset.update() uses the DB-specific to_db_value()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 
 Changelog
 =========
+0.13.3
+------
+- ``«queryset».update(…)`` now correctly uses the DB-specific ``to_db_value()``
+
 0.13.2
 ------
 * Security fixes for ``«model».save()`` & ``«model».dete()``:

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -36,6 +36,7 @@ nose2
 twine
 
 # Sample integration - Quart
+wsproto;python_version>="3.7"
 hypercorn;python_version>="3.7"
 quart;python_version>="3.7"
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -112,7 +112,7 @@ wcwidth==0.1.7            # via pytest
 webencodings==0.5.1       # via bleach
 websockets==7.0           # via sanic
 wrapt==1.11.2             # via astroid
-wsproto==0.15.0           # via hypercorn
+wsproto==0.15.0 ; python_version >= "3.7"
 zipp==0.6.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -38,14 +38,14 @@ filelock==3.0.12          # via tox
 flake8-isort==2.7.0
 flake8==3.7.8             # via flake8-isort
 gitdb2==2.0.5             # via gitpython
-gitpython==2.1.13         # via bandit
-green==2.16.1
+gitpython==3.0.2          # via bandit
+green==3.0.0
 h11==0.8.1                # via httpcore, hypercorn, wsproto
 h2==3.1.1                 # via httpcore, hypercorn
 hpack==3.0.0              # via h2
 httpcore==0.3.0 ; python_version >= "3.6"
 httptools==0.0.13         # via sanic
-hypercorn==0.7.2 ; python_version >= "3.7"
+hypercorn==0.8.2 ; python_version >= "3.7"
 hyperframe==5.2.0         # via h2
 idna==2.8                 # via httpcore, requests
 imagesize==1.1.0          # via sphinx
@@ -53,20 +53,21 @@ importlib-metadata==0.19  # via pluggy, pytest, tox
 isort==4.3.21             # via flake8-isort, pylint
 itsdangerous==1.1.0       # via quart
 jinja2==2.10.1            # via quart, sphinx
-lazy-object-proxy==1.4.1  # via astroid
-lxml==4.4.0               # via green
+lazy-object-proxy==1.4.2  # via astroid
+lxml==4.4.1               # via green
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via flake8, pylint
-more-itertools==7.2.0     # via pytest
+more-itertools==7.2.0     # via pytest, zipp
 multidict==4.5.2          # via quart, sanic
 mypy-extensions==0.4.1    # via mypy
 mypy==0.720
 nose2==0.9.1
 packaging==19.1           # via pytest, sphinx, tox
 pbr==5.4.2                # via stevedore
-pip-tools==4.0.0
+pip-tools==4.1.0
 pkginfo==1.5.0.1          # via twine
 pluggy==0.12.0            # via pytest, tox
+priority==1.3.0           # via hypercorn
 py==1.8.0                 # via pytest, tox
 pycodestyle==2.5.0        # via flake8
 pycparser==2.19           # via cffi
@@ -75,17 +76,17 @@ pygments==2.4.2
 pylint==2.3.1
 pymysql==0.9.2            # via aiomysql
 pyparsing==2.4.2          # via packaging
-pypika==0.31.1
-pytest==5.0.1
+pypika==0.35.2
+pytest==5.1.2
 pytz==2019.2              # via babel
 pyyaml==5.1.2
-quart==0.9.1 ; python_version >= "3.7"
+quart==0.10.0 ; python_version >= "3.7"
 readme-renderer==24.0     # via twine
 requests-async==0.5.0 ; python_version >= "3.6"
 requests-toolbelt==0.9.1  # via twine
 requests==2.22.0          # via coveralls, requests-async, requests-toolbelt, sphinx, twine
 rfc3986==1.3.2            # via httpcore
-sanic==19.6.2 ; python_version >= "3.6"
+sanic==19.6.3 ; python_version >= "3.6"
 six==1.12.0               # via astroid, bandit, bleach, cryptography, nose2, packaging, pip-tools, readme-renderer, sphinx, stevedore, tox
 smmap2==2.0.5             # via gitdb2
 snowballstemmer==1.9.0    # via sphinx
@@ -97,24 +98,25 @@ stevedore==1.30.1         # via bandit
 testfixtures==6.10.0      # via flake8-isort
 toml==0.10.0              # via black, hypercorn, tox
 tox==3.13.2
-tqdm==4.32.2              # via twine
+tqdm==4.35.0              # via twine
 twine==1.13.0
 typed-ast==1.4.0          # via astroid, mypy
 typing-extensions==3.7.4  # via hypercorn, mypy
+typing==3.6.2             # via pypika
 ujson==1.35               # via sanic
 unidecode==1.1.1          # via green
 urllib3==1.25.3           # via requests
-uvloop==0.12.2            # via sanic
-virtualenv==16.7.2        # via tox
+uvloop==0.13.0            # via sanic
+virtualenv==16.7.4        # via tox
 wcwidth==0.1.7            # via pytest
 webencodings==0.5.1       # via bleach
-websockets==6.0           # via sanic
+websockets==7.0           # via sanic
 wrapt==1.11.2             # via astroid
-wsproto==0.14.1           # via hypercorn
-zipp==0.5.2               # via importlib-metadata
+wsproto==0.15.0           # via hypercorn
+zipp==0.6.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.0.1        # via sphinx, twine
+# setuptools==41.2.0        # via sphinx, twine
 aiocontextvars==0.2.2 ; python_version < "3.7"
 contextvars==2.4 ; python_version < "3.7"
 immutables==0.9 ; python_version < "3.7"

--- a/requirements-pypy.txt
+++ b/requirements-pypy.txt
@@ -13,13 +13,14 @@ ciso8601==2.1.1
 colorama==0.4.1           # via green
 coverage==4.5.4           # via green
 cryptography==2.7         # via pymysql
-green==2.16.1
-lxml==4.4.0               # via green
+green==3.0.0
+lxml==4.4.1               # via green
 pycparser==2.19           # via cffi
 pymysql==0.9.2            # via aiomysql
-pypika==0.31.1
+pypika==0.35.2
 pyyaml==5.1.2
 six==1.12.0               # via cryptography
+typing==3.6.2             # via pypika
 unidecode==1.1.1          # via green
 aiocontextvars==0.2.2 ; python_version < "3.7"
 contextvars==2.4 ; python_version < "3.7"

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ use_parentheses=True
 line_length=100
 
 [green]
-processes     = 1
+#processes     = 1
 no-skip-report= True
 initializer   = tortoise.contrib.test.env_initializer
 finalizer     = tortoise.contrib.test.finalizer

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ use_parentheses=True
 line_length=100
 
 [green]
-#processes     = 1
 no-skip-report= True
 initializer   = tortoise.contrib.test.env_initializer
 finalizer     = tortoise.contrib.test.finalizer

--- a/tortoise/backends/asyncpg/client.py
+++ b/tortoise/backends/asyncpg/client.py
@@ -46,7 +46,7 @@ def retry_connection(func):
                 await self.create_connection(with_db=True)
                 logging.info("Reconnected")
             except Exception as e:
-                raise DBConnectionError("Failed to reconnect: %s", str(e))
+                raise DBConnectionError("Failed to reconnect: {}".format(str(e)))
             finally:
                 self._lock.release()
 
@@ -178,8 +178,7 @@ class AsyncpgDBClient(BaseDBAsyncClient):
                 # TODO: Cache prepared statement
                 stmt = await connection.prepare(query)
                 return await stmt.fetch(*values)
-            else:
-                return await connection.fetch(query)
+            return await connection.fetch(query)
 
     @translate_exceptions
     @retry_connection

--- a/tortoise/backends/base/schema_generator.py
+++ b/tortoise/backends/base/schema_generator.py
@@ -88,7 +88,7 @@ class BaseSchemaGenerator:
         # overwritten if required to match the database specific escaping.
         return comment.translate(get_escape_translation_table())
 
-    def _table_generate_extra(self, table: str) -> str:
+    def _table_generate_extra(self, table: str) -> str:  # pylint: disable=R0201
         return ""
 
     @staticmethod

--- a/tortoise/tests/fields/test_bool.py
+++ b/tortoise/tests/fields/test_bool.py
@@ -17,6 +17,13 @@ class TestBooleanFields(test.TestCase):
         obj2 = await testmodels.BooleanFields.get(id=obj.id)
         self.assertEqual(obj, obj2)
 
+    async def test_update(self):
+        obj0 = await testmodels.BooleanFields.create(boolean=False)
+        await testmodels.BooleanFields.filter(id=obj0.id).update(boolean=False)
+        obj = await testmodels.BooleanFields.get(id=obj0.id)
+        self.assertEqual(obj.boolean, False)
+        self.assertEqual(obj.boolean_null, None)
+
     async def test_values(self):
         obj0 = await testmodels.BooleanFields.create(boolean=True)
         values = await testmodels.BooleanFields.get(id=obj0.id).values("boolean")

--- a/tortoise/tests/fields/test_char.py
+++ b/tortoise/tests/fields/test_char.py
@@ -28,6 +28,13 @@ class TestCharFields(test.TestCase):
         obj2 = await testmodels.CharFields.get(id=obj.id)
         self.assertEqual(obj, obj2)
 
+    async def test_update(self):
+        obj0 = await testmodels.CharFields.create(char="moo")
+        await testmodels.CharFields.filter(id=obj0.id).update(char="ba'a")
+        obj = await testmodels.CharFields.get(id=obj0.id)
+        self.assertEqual(obj.char, "ba'a")
+        self.assertEqual(obj.char_null, None)
+
     async def test_cast(self):
         obj0 = await testmodels.CharFields.create(char=33)
         obj = await testmodels.CharFields.get(id=obj0.id)

--- a/tortoise/tests/fields/test_decimal.py
+++ b/tortoise/tests/fields/test_decimal.py
@@ -42,6 +42,14 @@ class TestDecimalFields(test.TestCase):
         obj2 = await testmodels.DecimalFields.get(id=obj.id)
         self.assertEqual(obj, obj2)
 
+    async def test_update(self):
+        obj0 = await testmodels.DecimalFields.create(decimal=Decimal("1.23456"), decimal_nodec=18.7)
+        await testmodels.DecimalFields.filter(id=obj0.id).update(decimal=Decimal("2.345"))
+        obj = await testmodels.DecimalFields.get(id=obj0.id)
+        self.assertEqual(obj.decimal, Decimal("2.345"))
+        self.assertEqual(obj.decimal_nodec, 19)
+        self.assertEqual(obj.decimal_null, None)
+
     async def test_values(self):
         obj0 = await testmodels.DecimalFields.create(decimal=Decimal("1.23456"), decimal_nodec=18.7)
         values = await testmodels.DecimalFields.get(id=obj0.id).values("decimal", "decimal_nodec")

--- a/tortoise/tests/fields/test_fk.py
+++ b/tortoise/tests/fields/test_fk.py
@@ -48,6 +48,31 @@ class TestForeignKeyField(test.TestCase):
         self.assertEqual(rel.tournament, tour)
         self.assertEqual((await tour.events.all())[0], rel)
 
+    async def test_update_by_name(self):
+        tour = await testmodels.Tournament.create(name="Team1")
+        tour2 = await testmodels.Tournament.create(name="Team2")
+        rel0 = await testmodels.Event.create(name="Event1", tournament=tour)
+
+        await testmodels.Event.filter(id=rel0.id).update(tournament=tour2)
+        rel = await testmodels.Event.get(id=rel0.id)
+
+        await rel.fetch_related("tournament")
+        self.assertEqual(rel.tournament, tour2)
+        self.assertEqual(await tour.events.all(), [])
+        self.assertEqual((await tour2.events.all())[0], rel)
+
+    async def test_update_by_id(self):
+        tour = await testmodels.Tournament.create(name="Team1")
+        tour2 = await testmodels.Tournament.create(name="Team2")
+        rel0 = await testmodels.Event.create(name="Event1", tournament_id=tour.id)
+
+        await testmodels.Event.filter(id=rel0.id).update(tournament_id=tour2.id)
+        rel = await testmodels.Event.get(id=rel0.id)
+
+        self.assertEqual(rel.tournament_id, tour2.id)
+        self.assertEqual(await tour.events.all(), [])
+        self.assertEqual((await tour2.events.all())[0], rel)
+
     async def test_minimal__uninstantiated_create(self):
         tour = testmodels.Tournament(name="Team1")
         with self.assertRaisesRegex(OperationalError, "You should first call .save()"):

--- a/tortoise/tests/fields/test_float.py
+++ b/tortoise/tests/fields/test_float.py
@@ -20,6 +20,14 @@ class TestFloatFields(test.TestCase):
         obj2 = await testmodels.FloatFields.get(id=obj.id)
         self.assertEqual(obj, obj2)
 
+    async def test_update(self):
+        obj0 = await testmodels.FloatFields.create(floatnum=1.23)
+        await testmodels.FloatFields.filter(id=obj0.id).update(floatnum=2.34)
+        obj = await testmodels.FloatFields.get(id=obj0.id)
+        self.assertEqual(obj.floatnum, 2.34)
+        self.assertNotEqual(Decimal(obj.floatnum), Decimal("2.34"))
+        self.assertEqual(obj.floatnum_null, None)
+
     async def test_cast_int(self):
         obj0 = await testmodels.FloatFields.create(floatnum=123)
         obj = await testmodels.FloatFields.get(id=obj0.id)

--- a/tortoise/tests/fields/test_int.py
+++ b/tortoise/tests/fields/test_int.py
@@ -21,6 +21,13 @@ class TestIntFields(test.TestCase):
         obj = await testmodels.IntFields.filter(id=obj0.id).first()
         self.assertEqual(obj, None)
 
+    async def test_update(self):
+        obj0 = await testmodels.IntFields.create(intnum=2147483647)
+        await testmodels.IntFields.filter(id=obj0.id).update(intnum=2147483646)
+        obj = await testmodels.IntFields.get(id=obj0.id)
+        self.assertEqual(obj.intnum, 2147483646)
+        self.assertEqual(obj.intnum_null, None)
+
     async def test_min(self):
         obj0 = await testmodels.IntFields.create(intnum=-2147483648)
         obj = await testmodels.IntFields.get(id=obj0.id)

--- a/tortoise/tests/fields/test_json.py
+++ b/tortoise/tests/fields/test_json.py
@@ -17,6 +17,13 @@ class TestJSONFields(test.TestCase):
         obj2 = await testmodels.JSONFields.get(id=obj.id)
         self.assertEqual(obj, obj2)
 
+    async def test_update(self):
+        obj0 = await testmodels.JSONFields.create(data={"some": ["text", 3]})
+        await testmodels.JSONFields.filter(id=obj0.id).update(data={"other": ["text", 5]})
+        obj = await testmodels.JSONFields.get(id=obj0.id)
+        self.assertEqual(obj.data, {"other": ["text", 5]})
+        self.assertEqual(obj.data_null, None)
+
     async def test_list(self):
         obj0 = await testmodels.JSONFields.create(data=["text", 3])
         obj = await testmodels.JSONFields.get(id=obj0.id)

--- a/tortoise/tests/fields/test_time.py
+++ b/tortoise/tests/fields/test_time.py
@@ -38,6 +38,15 @@ class TestDatetimeFields(test.TestCase):
         self.assertLess(obj2.datetime_auto - now, timedelta(seconds=1))
         self.assertEqual(obj2.datetime_add, obj.datetime_add)
 
+    async def test_update(self):
+        obj0 = await testmodels.DatetimeFields.create(datetime=datetime(2019, 9, 1, 0, 0, 0))
+        await testmodels.DatetimeFields.filter(id=obj0.id).update(
+            datetime=datetime(2019, 9, 1, 6, 0, 8)
+        )
+        obj = await testmodels.DatetimeFields.get(id=obj0.id)
+        self.assertEqual(obj.datetime, datetime(2019, 9, 1, 6, 0, 8))
+        self.assertEqual(obj.datetime_null, None)
+
     async def test_cast(self):
         now = datetime.utcnow()
         obj0 = await testmodels.DatetimeFields.create(datetime=now.isoformat())

--- a/tortoise/tests/fields/test_uuid.py
+++ b/tortoise/tests/fields/test_uuid.py
@@ -29,6 +29,15 @@ class TestUUIDFields(test.TestCase):
         obj = await testmodels.UUIDFields.filter(id=obj0.id).first()
         self.assertEqual(obj, None)
 
+    async def test_update(self):
+        data = uuid.uuid4()
+        data2 = uuid.uuid4()
+        obj0 = await testmodels.UUIDFields.create(data=data)
+        await testmodels.UUIDFields.filter(id=obj0.id).update(data=data2)
+        obj = await testmodels.UUIDFields.get(id=obj0.id)
+        self.assertEqual(obj.data, data2)
+        self.assertEqual(obj.data_null, None)
+
     async def test_create_not_null(self):
         data = uuid.uuid4()
         obj0 = await testmodels.UUIDFields.create(data=data, data_null=data)


### PR DESCRIPTION
Fixes #178

* Ensure that `«queryset».update()` is properly tested, and that it calls the right `to_db_value()` 
