### PR TITLE
Fix non int pk

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,8 @@ Changelog
 - Fixed installing Tortoise-ORM in non-unicode systems. (#180)
 - ``«queryset».update(…)`` now correctly uses the DB-specific ``to_db_value()``
 - ``fetch_related(…)`` now correctly encodes non-integer keys.
+- ``ForeignKey`` fields of type ``UUIDField`` are now escaped consistently.
+- Pre-generated ForeignKey fields (e.g. UUIDField) is now checked for persistence correctly.
 - Duplicate M2M ``.add(…)`` now checks using consistent field encoding.
 
 0.13.2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Changelog
 ------
 - Fixed installing Tortoise-ORM in non-unicode systems. (#180)
 - ``«queryset».update(…)`` now correctly uses the DB-specific ``to_db_value()``
+- ``fetch_related(…)`` now correctly encodes non-integer keys.
+- Duplicate M2M ``.add(…)`` now checks using consistent field encoding.
 
 0.13.2
 ------

--- a/tortoise/backends/base/executor.py
+++ b/tortoise/backends/base/executor.py
@@ -170,7 +170,10 @@ class BaseExecutor:
     async def _prefetch_reverse_relation(
         self, instance_list: list, field: str, related_query
     ) -> list:
-        instance_id_set = {instance.pk for instance in instance_list}  # type: Set[Any]
+        instance_id_set = {
+            self._field_to_db(instance._meta.pk, instance.pk, instance)
+            for instance in instance_list
+        }  # type: Set[Any]
         backward_relation_manager = getattr(self.model, field)
         relation_field = backward_relation_manager.relation_field
 
@@ -191,7 +194,10 @@ class BaseExecutor:
         return instance_list
 
     async def _prefetch_m2m_relation(self, instance_list: list, field: str, related_query) -> list:
-        instance_id_set = {instance.pk for instance in instance_list}  # type: Set[Any]
+        instance_id_set = {
+            self._field_to_db(instance._meta.pk, instance.pk, instance)
+            for instance in instance_list
+        }  # type: Set[Any]
 
         field_object = self.model._meta.fields_map[field]
 

--- a/tortoise/fields.py
+++ b/tortoise/fields.py
@@ -592,7 +592,7 @@ class ManyToManyRelationManager(RelationQueryContainer):
         """
         if not instances:
             return
-        if self.instance.pk is None:
+        if not self.instance._saved_in_db:
             raise OperationalError(
                 "You should first call .save() on {model}".format(model=self.instance)
             )
@@ -624,24 +624,28 @@ class ManyToManyRelationManager(RelationQueryContainer):
 
         select_query = select_query.where(criterion)
 
+        # TODO: This is highly inefficient. Should use UNIQUE index by default.
+        #  And optionally allow duplicates.
         already_existing_relations_raw = await db.execute_query(str(select_query))
         already_existing_relations = {
-            (r[self.field.backward_key], r[self.field.forward_key])
+            (
+                pk_formatting_func(r[self.field.backward_key], self.instance),
+                related_pk_formatting_func(r[self.field.forward_key], self.instance),
+            )
             for r in already_existing_relations_raw
         }
 
         insert_is_required = False
         for instance_to_add in instances:
-            if instance_to_add.pk is None:
+            if not instance_to_add._saved_in_db:
                 raise OperationalError(
                     "You should first call .save() on {model}".format(model=instance_to_add)
                 )
-            if (self.instance.pk, instance_to_add.pk) in already_existing_relations:
+            pk_f = related_pk_formatting_func(instance_to_add.pk, instance_to_add)
+            pk_b = pk_formatting_func(self.instance.pk, self.instance)
+            if (pk_b, pk_f) in already_existing_relations:
                 continue
-            query = query.insert(
-                related_pk_formatting_func(instance_to_add.pk, instance_to_add),
-                pk_formatting_func(self.instance.pk, self.instance),
-            )
+            query = query.insert(pk_f, pk_b)
             insert_is_required = True
         if insert_is_required:
             await db.execute_query(str(query))

--- a/tortoise/fields.py
+++ b/tortoise/fields.py
@@ -485,7 +485,7 @@ class RelationQueryContainer:
 
     @property
     def _query(self):
-        if not getattr(self.instance, "_saved_in_db", False):
+        if not self.instance._saved_in_db:
             raise OperationalError(
                 "This objects hasn't been instanced, call .save() before calling related queries"
             )

--- a/tortoise/fields.py
+++ b/tortoise/fields.py
@@ -485,9 +485,9 @@ class RelationQueryContainer:
 
     @property
     def _query(self):
-        if not self.instance.pk:
+        if not getattr(self.instance, "_saved_in_db", False):
             raise OperationalError(
-                "This objects hasn't been instanced, call .save() before" " calling related queries"
+                "This objects hasn't been instanced, call .save() before calling related queries"
             )
         return self.model.filter(**{self.relation_field: self.instance.pk})
 

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -348,11 +348,12 @@ class Model(metaclass=ModelMeta):
 
         for key, value in values_map.items():
             if key in meta.fk_fields:
-                if hasattr(value, "pk") and not value.pk:
+                if not getattr(value, "_saved_in_db", False):
                     raise OperationalError(
                         "You should first call .save() on {} before referring to it".format(value)
                     )
-                relation_field = "{}_id".format(key)
+                field_object = meta.fields_map[key]
+                relation_field = field_object.source_field  # type: str  # type: ignore
                 setattr(self, relation_field, value.pk)
                 passed_fields.add(relation_field)
             elif key in meta.fields:

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -520,8 +520,8 @@ class UpdateQuery(AwaitableQuery):
                 db_field = self.model._meta.fields_db_projection[key]
                 value = executor.column_map[key](value, None)
             elif isinstance(field_object, fields.ForeignKeyField):
-                db_field = "{}_id".format(key)
-                value = value.id
+                db_field = field_object.source_field
+                value = executor.column_map[db_field](value.id, None)
             else:
                 raise FieldError("Field {} is virtual and can not be updated".format(key))
 

--- a/tortoise/tests/fields/test_fk_uuid.py
+++ b/tortoise/tests/fields/test_fk_uuid.py
@@ -1,0 +1,205 @@
+from tortoise.contrib import test
+from tortoise.exceptions import IntegrityError, NoValuesFetched, OperationalError
+from tortoise.tests import testmodels
+
+
+class TestForeignKeyUUIDField(test.TestCase):
+    async def test_empty(self):
+        with self.assertRaises(IntegrityError):
+            await testmodels.UUIDFkRelatedModel.create()
+
+    async def test_create_by_id(self):
+        tour = await testmodels.UUIDPkModel.create()
+        rel = await testmodels.UUIDFkRelatedModel.create(model_id=tour.id)
+        self.assertEqual(rel.model_id, tour.id)
+        self.assertEqual((await tour.children.all())[0], rel)
+
+    async def test_create_by_name(self):
+        tour = await testmodels.UUIDPkModel.create()
+        rel = await testmodels.UUIDFkRelatedModel.create(model=tour)
+        await rel.fetch_related("model")
+        self.assertEqual(rel.model, tour)
+        self.assertEqual((await tour.children.all())[0], rel)
+
+    @test.skip("Not yet implemented")
+    async def test_by_name__unfetched(self):
+        tour = await testmodels.UUIDPkModel.create()
+        rel = await testmodels.UUIDFkRelatedModel.create(model=tour)
+        with self.assertRaisesRegex(NoValuesFetched, "moo"):
+            rel.model  # pylint: disable=W0104
+
+    @test.skip("Not yet implemented")
+    async def test_by_name__awaited(self):
+        tour = await testmodels.UUIDPkModel.create()
+        rel = await testmodels.UUIDFkRelatedModel.create(model=tour)
+        self.assertEqual(await rel.model, tour)
+        self.assertEqual((await tour.children.all())[0], rel)
+
+    async def test_update_by_name(self):
+        tour = await testmodels.UUIDPkModel.create()
+        tour2 = await testmodels.UUIDPkModel.create()
+        rel0 = await testmodels.UUIDFkRelatedModel.create(model=tour)
+
+        await testmodels.UUIDFkRelatedModel.filter(id=rel0.id).update(model=tour2)
+        rel = await testmodels.UUIDFkRelatedModel.get(id=rel0.id)
+
+        await rel.fetch_related("model")
+        self.assertEqual(rel.model, tour2)
+        self.assertEqual(await tour.children.all(), [])
+        self.assertEqual((await tour2.children.all())[0], rel)
+
+    async def test_update_by_id(self):
+        tour = await testmodels.UUIDPkModel.create()
+        tour2 = await testmodels.UUIDPkModel.create()
+        rel0 = await testmodels.UUIDFkRelatedModel.create(model_id=tour.id)
+
+        await testmodels.UUIDFkRelatedModel.filter(id=rel0.id).update(model_id=tour2.id)
+        rel = await testmodels.UUIDFkRelatedModel.get(id=rel0.id)
+
+        self.assertEqual(rel.model_id, tour2.id)
+        self.assertEqual(await tour.children.all(), [])
+        self.assertEqual((await tour2.children.all())[0], rel)
+
+    async def test_uninstantiated_create(self):
+        tour = testmodels.UUIDPkModel()
+        with self.assertRaisesRegex(OperationalError, "You should first call .save()"):
+            await testmodels.UUIDFkRelatedModel.create(model=tour)
+
+    async def test_uninstantiated_iterate(self):
+        tour = testmodels.UUIDPkModel()
+        with self.assertRaisesRegex(
+            OperationalError, "This objects hasn't been instanced, call .save()"
+        ):
+            async for _ in tour.children:
+                pass
+
+    async def test_uninstantiated_await(self):
+        tour = testmodels.UUIDPkModel()
+        with self.assertRaisesRegex(
+            OperationalError, "This objects hasn't been instanced, call .save()"
+        ):
+            await tour.children
+
+    async def test_unfetched_contains(self):
+        tour = await testmodels.UUIDPkModel.create()
+        with self.assertRaisesRegex(
+            NoValuesFetched,
+            "No values were fetched for this relation," " first use .fetch_related()",
+        ):
+            "a" in tour.children  # pylint: disable=W0104
+
+    async def test_unfetched_iter(self):
+        tour = await testmodels.UUIDPkModel.create()
+        with self.assertRaisesRegex(
+            NoValuesFetched,
+            "No values were fetched for this relation," " first use .fetch_related()",
+        ):
+            for _ in tour.children:
+                pass
+
+    async def test_unfetched_len(self):
+        tour = await testmodels.UUIDPkModel.create()
+        with self.assertRaisesRegex(
+            NoValuesFetched,
+            "No values were fetched for this relation," " first use .fetch_related()",
+        ):
+            len(tour.children)
+
+    async def test_unfetched_bool(self):
+        tour = await testmodels.UUIDPkModel.create()
+        with self.assertRaisesRegex(
+            NoValuesFetched,
+            "No values were fetched for this relation," " first use .fetch_related()",
+        ):
+            bool(tour.children)
+
+    async def test_unfetched_getitem(self):
+        tour = await testmodels.UUIDPkModel.create()
+        with self.assertRaisesRegex(
+            NoValuesFetched,
+            "No values were fetched for this relation," " first use .fetch_related()",
+        ):
+            tour.children[0]  # pylint: disable=W0104
+
+    async def test_instantiated_create(self):
+        tour = await testmodels.UUIDPkModel.create()
+        await testmodels.UUIDFkRelatedModel.create(model=tour)
+
+    async def test_instantiated_iterate(self):
+        tour = await testmodels.UUIDPkModel.create()
+        async for _ in tour.children:
+            pass
+
+    async def test_instantiated_await(self):
+        tour = await testmodels.UUIDPkModel.create()
+        await tour.children
+
+    async def test_minimal__fetched_contains(self):
+        tour = await testmodels.UUIDPkModel.create()
+        rel = await testmodels.UUIDFkRelatedModel.create(model=tour)
+        await tour.fetch_related("children")
+        self.assertTrue(rel in tour.children)
+
+    async def test_minimal__fetched_iter(self):
+        tour = await testmodels.UUIDPkModel.create()
+        rel = await testmodels.UUIDFkRelatedModel.create(model=tour)
+        await tour.fetch_related("children")
+        self.assertEqual([obj for obj in tour.children], [rel])
+
+    async def test_minimal__fetched_len(self):
+        tour = await testmodels.UUIDPkModel.create()
+        await testmodels.UUIDFkRelatedModel.create(model=tour)
+        await tour.fetch_related("children")
+        self.assertEqual(len(tour.children), 1)
+
+    async def test_minimal__fetched_bool(self):
+        tour = await testmodels.UUIDPkModel.create()
+        await tour.fetch_related("children")
+        self.assertFalse(bool(tour.children))
+        await testmodels.UUIDFkRelatedModel.create(model=tour)
+        await tour.fetch_related("children")
+        self.assertTrue(bool(tour.children))
+
+    async def test_minimal__fetched_getitem(self):
+        tour = await testmodels.UUIDPkModel.create()
+        rel = await testmodels.UUIDFkRelatedModel.create(model=tour)
+        await tour.fetch_related("children")
+        self.assertEqual(tour.children[0], rel)
+
+        with self.assertRaises(IndexError):
+            tour.children[1]  # pylint: disable=W0104
+
+    async def test_event__filter(self):
+        tour = await testmodels.UUIDPkModel.create()
+        event1 = await testmodels.UUIDFkRelatedModel.create(name="Event1", model=tour)
+        event2 = await testmodels.UUIDFkRelatedModel.create(name="Event2", model=tour)
+        self.assertEqual(await tour.children.filter(name="Event1"), [event1])
+        self.assertEqual(await tour.children.filter(name="Event2"), [event2])
+        self.assertEqual(await tour.children.filter(name="Event3"), [])
+
+    async def test_event__all(self):
+        tour = await testmodels.UUIDPkModel.create()
+        event1 = await testmodels.UUIDFkRelatedModel.create(name="Event1", model=tour)
+        event2 = await testmodels.UUIDFkRelatedModel.create(name="Event2", model=tour)
+        self.assertSetEqual(set(await tour.children.all()), {event1, event2})
+
+    async def test_event__order_by(self):
+        tour = await testmodels.UUIDPkModel.create()
+        event1 = await testmodels.UUIDFkRelatedModel.create(name="Event1", model=tour)
+        event2 = await testmodels.UUIDFkRelatedModel.create(name="Event2", model=tour)
+        self.assertEqual(await tour.children.order_by("-name"), [event2, event1])
+        self.assertEqual(await tour.children.order_by("name"), [event1, event2])
+
+    async def test_event__limit(self):
+        tour = await testmodels.UUIDPkModel.create()
+        event1 = await testmodels.UUIDFkRelatedModel.create(name="Event1", model=tour)
+        event2 = await testmodels.UUIDFkRelatedModel.create(name="Event2", model=tour)
+        await testmodels.UUIDFkRelatedModel.create(name="Event3", model=tour)
+        self.assertEqual(await tour.children.limit(2).order_by("name"), [event1, event2])
+
+    async def test_event__offset(self):
+        tour = await testmodels.UUIDPkModel.create()
+        await testmodels.UUIDFkRelatedModel.create(name="Event1", model=tour)
+        event2 = await testmodels.UUIDFkRelatedModel.create(name="Event2", model=tour)
+        event3 = await testmodels.UUIDFkRelatedModel.create(name="Event3", model=tour)
+        self.assertEqual(await tour.children.offset(1).order_by("name"), [event2, event3])

--- a/tortoise/tests/fields/test_m2m_uuid.py
+++ b/tortoise/tests/fields/test_m2m_uuid.py
@@ -1,0 +1,110 @@
+from tortoise.contrib import test
+from tortoise.exceptions import OperationalError
+from tortoise.tests import testmodels
+
+
+class TestManyToManyUUIDField(test.TestCase):
+    UUIDPkModel = testmodels.UUIDPkModel
+    UUIDM2MRelatedModel = testmodels.UUIDM2MRelatedModel
+
+    async def test_empty(self):
+        await self.UUIDM2MRelatedModel.create()
+
+    async def test__add(self):
+        one = await self.UUIDM2MRelatedModel.create()
+        two = await self.UUIDPkModel.create()
+        await one.models.add(two)
+        self.assertEqual(await one.models, [two])
+        self.assertEqual(await two.peers, [one])
+
+    async def test__add__nothing(self):
+        one = await self.UUIDPkModel.create()
+        await one.peers.add()
+
+    async def test__add__reverse(self):
+        one = await self.UUIDM2MRelatedModel.create()
+        two = await self.UUIDPkModel.create()
+        await two.peers.add(one)
+        self.assertEqual(await one.models, [two])
+        self.assertEqual(await two.peers, [one])
+
+    async def test__add__many(self):
+        one = await self.UUIDPkModel.create()
+        two = await self.UUIDM2MRelatedModel.create()
+        await one.peers.add(two)
+        await one.peers.add(two)
+        await two.models.add(one)
+        self.assertEqual(await one.peers, [two])
+        self.assertEqual(await two.models, [one])
+
+    async def test__add__two(self):
+        one = await self.UUIDPkModel.create()
+        two1 = await self.UUIDM2MRelatedModel.create()
+        two2 = await self.UUIDM2MRelatedModel.create()
+        await one.peers.add(two1, two2)
+        self.assertEqual(await one.peers, [two1, two2])
+        self.assertEqual(await two1.models, [one])
+        self.assertEqual(await two2.models, [one])
+
+    async def test__add__two_two(self):
+        one1 = await self.UUIDPkModel.create()
+        one2 = await self.UUIDPkModel.create()
+        two1 = await self.UUIDM2MRelatedModel.create()
+        two2 = await self.UUIDM2MRelatedModel.create()
+        await one1.peers.add(two1, two2)
+        await one2.peers.add(two1, two2)
+        self.assertEqual(await one1.peers, [two1, two2])
+        self.assertEqual(await one2.peers, [two1, two2])
+        self.assertEqual(await two1.models, [one1, one2])
+        self.assertEqual(await two2.models, [one1, one2])
+
+    async def test__remove(self):
+        one = await self.UUIDPkModel.create()
+        two1 = await self.UUIDM2MRelatedModel.create()
+        two2 = await self.UUIDM2MRelatedModel.create()
+        await one.peers.add(two1, two2)
+        await one.peers.remove(two1)
+        self.assertEqual(await one.peers, [two2])
+        self.assertEqual(await two1.models, [])
+        self.assertEqual(await two2.models, [one])
+
+    async def test__remove__many(self):
+        one = await self.UUIDPkModel.create()
+        two1 = await self.UUIDM2MRelatedModel.create()
+        two2 = await self.UUIDM2MRelatedModel.create()
+        two3 = await self.UUIDM2MRelatedModel.create()
+        await one.peers.add(two1, two2, two3)
+        await one.peers.remove(two1, two2)
+        self.assertEqual(await one.peers, [two3])
+        self.assertEqual(await two1.models, [])
+        self.assertEqual(await two2.models, [])
+        self.assertEqual(await two3.models, [one])
+
+    async def test__remove__blank(self):
+        one = await self.UUIDPkModel.create()
+        with self.assertRaisesRegex(OperationalError, r"remove\(\) called on no instances"):
+            await one.peers.remove()
+
+    async def test__clear(self):
+        one = await self.UUIDPkModel.create()
+        two1 = await self.UUIDM2MRelatedModel.create()
+        two2 = await self.UUIDM2MRelatedModel.create()
+        await one.peers.add(two1, two2)
+        await one.peers.clear()
+        self.assertEqual(await one.peers, [])
+        self.assertEqual(await two1.models, [])
+        self.assertEqual(await two2.models, [])
+
+    async def test__uninstantiated_add(self):
+        one = self.UUIDPkModel()
+        two = await self.UUIDM2MRelatedModel.create()
+        with self.assertRaisesRegex(OperationalError, r"You should first call .save\(\) on"):
+            await one.peers.add(two)
+
+    async def test__add_uninstantiated(self):
+        one = self.UUIDPkModel()
+        two = await self.UUIDM2MRelatedModel.create()
+        with self.assertRaisesRegex(OperationalError, r"You should first call .save\(\) on"):
+            await two.models.add(one)
+
+    # TODO: Sorting?

--- a/tortoise/tests/test_primary_key.py
+++ b/tortoise/tests/test_primary_key.py
@@ -50,6 +50,9 @@ class TestQueryset(test.TestCase):
         related_instance = await UUIDFkRelatedModel.filter(model_id=value).first()
         self.assertEqual(related_instance.model_id, value)
 
+        await related_instance.fetch_related("model")
+        self.assertEqual(related_instance.model, instance)
+
         await instance.fetch_related("children")
         self.assertEqual(instance.children[0], related_instance)
 
@@ -63,6 +66,10 @@ class TestQueryset(test.TestCase):
 
         await instance.peers.add(related_instance)
         await related_instance2.models.add(instance, instance2)
+
+        await instance.fetch_related("peers")
+        self.assertEqual(len(instance.peers), 2)
+        self.assertEqual(set(instance.peers), {related_instance, related_instance2})
 
         await related_instance.fetch_related("models")
         self.assertEqual(len(related_instance.models), 1)

--- a/tortoise/tests/testmodels.py
+++ b/tortoise/tests/testmodels.py
@@ -242,11 +242,13 @@ class UUIDPkModel(Model):
 
 
 class UUIDFkRelatedModel(Model):
+    id = fields.UUIDField(pk=True)
     name = fields.CharField(max_length=50, null=True)
     model = fields.ForeignKeyField("models.UUIDPkModel", related_name="children")
 
 
 class UUIDM2MRelatedModel(Model):
+    id = fields.UUIDField(pk=True)
     value = fields.TextField(default="test")
     models = fields.ManyToManyField("models.UUIDPkModel", related_name="peers")
 

--- a/tortoise/tests/testmodels.py
+++ b/tortoise/tests/testmodels.py
@@ -242,6 +242,7 @@ class UUIDPkModel(Model):
 
 
 class UUIDFkRelatedModel(Model):
+    name = fields.CharField(max_length=50, null=True)
     model = fields.ForeignKeyField("models.UUIDPkModel", related_name="children")
 
 


### PR DESCRIPTION
Fixes #151 

* Fixes FK use cases of UUIDField as it works differently than ints:
  * Is pre-generated, not post-generated
  * Requires escaping/encoding
* Fixed M2M cases with UUIDFields
* Fixed select_related with UUIDFields
