### PR TITLE
Fixed a few edge cases re `source_field` handling

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ Changelog
 - ``ForeignKey`` fields of type ``UUIDField`` are now escaped consistently.
 - Pre-generated ForeignKey fields (e.g. UUIDField) is now checked for persistence correctly.
 - Duplicate M2M ``.add(…)`` now checks using consistent field encoding.
+- ``source_field`` Fields are now handled correctly for ordering.
+- ``source_field`` Fields are now handled correctly for updating.
 
 0.13.2
 ------

--- a/tortoise/tests/fields/test_m2m_uuid.py
+++ b/tortoise/tests/fields/test_m2m_uuid.py
@@ -108,3 +108,8 @@ class TestManyToManyUUIDField(test.TestCase):
             await two.models.add(one)
 
     # TODO: Sorting?
+
+
+class TestManyToManyUUIDSourceField(TestManyToManyUUIDField):
+    UUIDPkModel = testmodels.UUIDPkSourceModel  # type: ignore
+    UUIDM2MRelatedModel = testmodels.UUIDM2MRelatedSourceModel  # type: ignore

--- a/tortoise/tests/test_queryset.py
+++ b/tortoise/tests/test_queryset.py
@@ -202,7 +202,7 @@ class TestQueryset(test.TestCase):
 
     async def test_update_pk(self):
         obj0 = await IntFields.create(intnum=2147483647)
-        with self.assertRaisesRegex(IntegrityError, "is generated and can not be updated"):
+        with self.assertRaisesRegex(IntegrityError, "is PK and can not be updated"):
             await IntFields.filter(id=obj0.id).update(id=1)
 
     async def test_update_virtual(self):

--- a/tortoise/tests/testmodels.py
+++ b/tortoise/tests/testmodels.py
@@ -253,6 +253,35 @@ class UUIDM2MRelatedModel(Model):
     models = fields.ManyToManyField("models.UUIDPkModel", related_name="peers")
 
 
+class UUIDPkSourceModel(Model):
+    id = fields.UUIDField(pk=True, source_field="a")
+
+    class Meta:
+        table = "upsm"
+
+
+class UUIDFkRelatedSourceModel(Model):
+    id = fields.UUIDField(pk=True, source_field="b")
+    name = fields.CharField(max_length=50, null=True, source_field="c")
+    model = fields.ForeignKeyField(
+        "models.UUIDPkSourceModel", related_name="children", source_field="d"
+    )
+
+    class Meta:
+        table = "ufrsm"
+
+
+class UUIDM2MRelatedSourceModel(Model):
+    id = fields.UUIDField(pk=True, source_field="e")
+    value = fields.TextField(default="test", source_field="f")
+    models = fields.ManyToManyField(
+        "models.UUIDPkSourceModel", related_name="peers", forward_key="e", backward_key="h"
+    )
+
+    class Meta:
+        table = "umrsm"
+
+
 class CharPkModel(Model):
     id = fields.CharField(max_length=64, pk=True)
 


### PR DESCRIPTION
Found some consistency issues whilst doing tests for #182

- `source_field` Fields are now handled correctly for ordering.
- `source_field` Fields are now handled correctly for updating.