### PR TITLE
Direct modification of FK field now persists

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 
 Changelog
 =========
+
+0.13.4
+------
+- Assigning to the FK field will correctly set the associated db-field
+- Reading a nullalble FK field can now be None
+- Nullalble FK fields reverse-FK is now also nullable
+- Deleting a nullable FK field sets it to None
+
 0.13.3
 ------
 - Fixed installing Tortoise-ORM in non-unicode systems. (#180)

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -670,4 +670,4 @@ def run_async(coro: Coroutine) -> None:
         loop.run_until_complete(Tortoise.close_connections())
 
 
-__version__ = "0.13.3"
+__version__ = "0.13.4"

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -324,7 +324,7 @@ class Tortoise:
                             )
                         )
                     fk_relation = fields.BackwardFKRelation(
-                        model, "{}_id".format(field), fk_object.description
+                        model, "{}_id".format(field), fk_object.null, fk_object.description
                     )
                     related_model._meta.add_field(backward_relation_name, fk_relation)
 

--- a/tortoise/fields.py
+++ b/tortoise/fields.py
@@ -454,9 +454,13 @@ class BackwardFKRelation(Field):
     has_db_field = False
 
     def __init__(
-        self, type, relation_field: str, description: Optional[str]  # pylint: disable=W0622
+        self,
+        type,
+        relation_field: str,
+        null: bool,
+        description: Optional[str],  # pylint: disable=W0622
     ) -> None:
-        super().__init__(type=type)
+        super().__init__(type=type, null=null)
         self.relation_field = relation_field
         self.description = description
 

--- a/tortoise/fields.py
+++ b/tortoise/fields.py
@@ -455,10 +455,10 @@ class BackwardFKRelation(Field):
 
     def __init__(
         self,
-        type,
+        type,  # pylint: disable=W0622
         relation_field: str,
         null: bool,
-        description: Optional[str],  # pylint: disable=W0622
+        description: Optional[str],
     ) -> None:
         super().__init__(type=type, null=null)
         self.relation_field = relation_field

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -32,10 +32,7 @@ def get_unique_together(meta) -> Tuple[Tuple[str, ...], ...]:
     return unique_together
 
 
-def _fk_setter(self, value, _key, key):
-    meta = self._meta
-    field_object = meta.fields_map[key]
-    relation_field = field_object.source_field
+def _fk_setter(self, value, _key, relation_field):
     setattr(self, relation_field, value.pk if value else None)
     setattr(self, _key, value)
 
@@ -160,13 +157,14 @@ class MetaInfo:
         # Create lazy FK fields on model.
         for key in self.fk_fields:
             _key = f"_{key}"
+            relation_field = self.fields_map[key].source_field
             setattr(
                 self._model,
                 key,
                 property(
                     partial(_fk_getter, _key=_key),
-                    partial(_fk_setter, _key=_key, key=key),
-                    partial(_fk_setter, value=None, _key=_key, key=key),
+                    partial(_fk_setter, _key=_key, relation_field=relation_field),
+                    partial(_fk_setter, value=None, _key=_key, relation_field=relation_field),
                 ),
             )
 

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -156,7 +156,7 @@ class MetaInfo:
 
         # Create lazy FK fields on model.
         for key in self.fk_fields:
-            _key = f"_{key}"
+            _key = "_{}".format(key)
             relation_field = self.fields_map[key].source_field
             setattr(
                 self._model,

--- a/tortoise/tests/fields/test_fk_uuid.py
+++ b/tortoise/tests/fields/test_fk_uuid.py
@@ -219,6 +219,67 @@ class TestForeignKeyUUIDField(test.TestCase):
         event3 = await self.UUIDFkRelatedModel.create(name="Event3", model=tour)
         self.assertEqual(await tour.children.offset(1).order_by("name"), [event2, event3])
 
+    async def test_assign_by_id(self):
+        tour = await self.UUIDPkModel.create()
+        event = await self.UUIDFkRelatedNullModel.create(model=None)
+        event.model_id = tour.id
+        await event.save()
+        event0 = await self.UUIDFkRelatedNullModel.get(id=event.id)
+        self.assertEqual(event0.model_id, tour.id)
+        await event0.fetch_related("model")
+        self.assertEqual(event0.model, tour)
+
+    async def test_assign_by_name(self):
+        tour = await self.UUIDPkModel.create()
+        event = await self.UUIDFkRelatedNullModel.create(model=None)
+        event.model = tour
+        await event.save()
+        event0 = await self.UUIDFkRelatedNullModel.get(id=event.id)
+        self.assertEqual(event0.model_id, tour.id)
+        await event0.fetch_related("model")
+        self.assertEqual(event0.model, tour)
+
+    async def test_assign_none_by_id(self):
+        tour = await self.UUIDPkModel.create()
+        event = await self.UUIDFkRelatedNullModel.create(model=tour)
+        event.model_id = None
+        await event.save()
+        event0 = await self.UUIDFkRelatedNullModel.get(id=event.id)
+        self.assertEqual(event0.model_id, None)
+        await event0.fetch_related("model")
+        self.assertEqual(event0.model, None)
+
+    async def test_assign_none_by_name(self):
+        tour = await self.UUIDPkModel.create()
+        event = await self.UUIDFkRelatedNullModel.create(model=tour)
+        event.model = None
+        await event.save()
+        event0 = await self.UUIDFkRelatedNullModel.get(id=event.id)
+        self.assertEqual(event0.model_id, None)
+        await event0.fetch_related("model")
+        self.assertEqual(event0.model, None)
+
+    async def test_assign_none_by_id_fails(self):
+        tour = await self.UUIDPkModel.create()
+        event = await self.UUIDFkRelatedModel.create(model=tour)
+        event.model_id = None
+        with self.assertRaises(IntegrityError):
+            await event.save()
+
+    async def test_assign_none_by_name_fails(self):
+        tour = await self.UUIDPkModel.create()
+        event = await self.UUIDFkRelatedModel.create(model=tour)
+        event.model = None
+        with self.assertRaises(IntegrityError):
+            await event.save()
+
+    async def test_delete_by_name(self):
+        tour = await self.UUIDPkModel.create()
+        event = await self.UUIDFkRelatedModel.create(model=tour)
+        del event.model
+        with self.assertRaises(IntegrityError):
+            await event.save()
+
 
 class TestForeignKeyUUIDSourcedField(TestForeignKeyUUIDField):
     """

--- a/tortoise/tests/fields/test_fk_uuid.py
+++ b/tortoise/tests/fields/test_fk_uuid.py
@@ -14,10 +14,14 @@ class TestForeignKeyUUIDField(test.TestCase):
 
     UUIDPkModel = testmodels.UUIDPkModel
     UUIDFkRelatedModel = testmodels.UUIDFkRelatedModel
+    UUIDFkRelatedNullModel = testmodels.UUIDFkRelatedNullModel
 
     async def test_empty(self):
         with self.assertRaises(IntegrityError):
             await self.UUIDFkRelatedModel.create()
+
+    async def test_empty_null(self):
+        await self.UUIDFkRelatedNullModel.create()
 
     async def test_create_by_id(self):
         tour = await self.UUIDPkModel.create()
@@ -225,3 +229,4 @@ class TestForeignKeyUUIDSourcedField(TestForeignKeyUUIDField):
 
     UUIDPkModel = testmodels.UUIDPkSourceModel  # type: ignore
     UUIDFkRelatedModel = testmodels.UUIDFkRelatedSourceModel  # type: ignore
+    UUIDFkRelatedNullModel = testmodels.UUIDFkRelatedNullSourceModel  # type: ignore

--- a/tortoise/tests/test_describe_model.py
+++ b/tortoise/tests/test_describe_model.py
@@ -13,6 +13,7 @@ from tortoise.tests.testmodels import (
     Team,
     Tournament,
     UUIDFkRelatedModel,
+    UUIDFkRelatedNullModel,
     UUIDM2MRelatedModel,
     UUIDPkModel,
 )
@@ -123,7 +124,7 @@ class TestBasic(test.TestCase):
                         "field_type": "BackwardFKRelation",
                         "python_type": "models.StraightFields",
                         "generated": False,
-                        "nullable": False,
+                        "nullable": True,
                         "unique": False,
                         "indexed": False,
                         "default": None,
@@ -240,7 +241,7 @@ class TestBasic(test.TestCase):
                         "field_type": fields.BackwardFKRelation,
                         "python_type": StraightFields,
                         "generated": False,
-                        "nullable": False,
+                        "nullable": True,
                         "unique": False,
                         "indexed": False,
                         "default": None,
@@ -357,7 +358,7 @@ class TestBasic(test.TestCase):
                         "field_type": "BackwardFKRelation",
                         "python_type": "models.SourceFields",
                         "generated": False,
-                        "nullable": False,
+                        "nullable": True,
                         "unique": False,
                         "indexed": False,
                         "default": None,
@@ -474,7 +475,7 @@ class TestBasic(test.TestCase):
                         "field_type": fields.BackwardFKRelation,
                         "python_type": SourceFields,
                         "generated": False,
-                        "nullable": False,
+                        "nullable": True,
                         "unique": False,
                         "indexed": False,
                         "default": None,
@@ -546,7 +547,18 @@ class TestBasic(test.TestCase):
                         "indexed": False,
                         "default": None,
                         "description": None,
-                    }
+                    },
+                    {
+                        "name": "children_null",
+                        "field_type": "BackwardFKRelation",
+                        "python_type": "models.UUIDFkRelatedNullModel",
+                        "generated": False,
+                        "nullable": True,
+                        "unique": False,
+                        "indexed": False,
+                        "default": None,
+                        "description": None,
+                    },
                 ],
                 "m2m_fields": [
                     {
@@ -602,7 +614,18 @@ class TestBasic(test.TestCase):
                         "indexed": False,
                         "default": None,
                         "description": None,
-                    }
+                    },
+                    {
+                        "name": "children_null",
+                        "field_type": fields.BackwardFKRelation,
+                        "python_type": UUIDFkRelatedNullModel,
+                        "generated": False,
+                        "nullable": True,
+                        "unique": False,
+                        "indexed": False,
+                        "default": None,
+                        "description": None,
+                    },
                 ],
                 "m2m_fields": [
                     {

--- a/tortoise/tests/testmodels.py
+++ b/tortoise/tests/testmodels.py
@@ -247,6 +247,12 @@ class UUIDFkRelatedModel(Model):
     model = fields.ForeignKeyField("models.UUIDPkModel", related_name="children")
 
 
+class UUIDFkRelatedNullModel(Model):
+    id = fields.UUIDField(pk=True)
+    name = fields.CharField(max_length=50, null=True)
+    model = fields.ForeignKeyField("models.UUIDPkModel", related_name="children_null", null=True)
+
+
 class UUIDM2MRelatedModel(Model):
     id = fields.UUIDField(pk=True)
     value = fields.TextField(default="test")
@@ -269,6 +275,17 @@ class UUIDFkRelatedSourceModel(Model):
 
     class Meta:
         table = "ufrsm"
+
+
+class UUIDFkRelatedNullSourceModel(Model):
+    id = fields.UUIDField(pk=True, source_field="i")
+    name = fields.CharField(max_length=50, null=True, source_field="j")
+    model = fields.ForeignKeyField(
+        "models.UUIDPkSourceModel", related_name="children_null", source_field="k", null=True
+    )
+
+    class Meta:
+        table = "ufrnsm"
 
 
 class UUIDM2MRelatedSourceModel(Model):


### PR DESCRIPTION
Fixes #184 

Done:
- Assigning to the FK field will correctly set the associated db-field
- Reading a nullalble FK field can now be None
- Nullalble FK fields reverse-FK is now also nullable
- Deleting a nullable FK field sets it to None