### PR TITLE
MySQL engine fixes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,11 @@
 Changelog
 =========
 
+0.13.9
+------
+- Foreign keys and indexes are now defined correctly in MySQL so that they take effect as expected
+- MySQL now doesn't warn of unsafe index creation anymore
+
 0.13.8
 ------
 - Fixed bug in schema creation for MySQL where non-int PK did not get declared properly (#195)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-checkfiles = tortoise/ examples/ tests/ setup.py conftest.py
+checkfiles = tortoise/ examples/ tests/ conftest.py
 black_opts = -l 100
 py_warn = PYTHONWARNINGS=default PYTHONASYNCIODEBUG=1 PYTHONDEBUG=x PYTHONDEVMODE=dev
 

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,8 @@ test: deps
 _testall:
 	-$(py_warn) TORTOISE_TEST_DB=sqlite://:memory: py.test -q --cov-report=
 	-python -V | grep PyPy || $(py_warn) TORTOISE_TEST_DB=postgres://postgres:@127.0.0.1:5432/test_\{\} py.test -q --cov-append --cov-report=
-	-$(py_warn) TORTOISE_TEST_DB="mysql://root:@127.0.0.1:3306/test_\{\}" py.test -q --cov-append
+	-$(py_warn) TORTOISE_TEST_DB="mysql://root:@127.0.0.1:3306/test_\{\}?storage_engine=MYISAM" py.test -q --cov-append --cov-report=
+	-$(py_warn) TORTOISE_TEST_DB="mysql://root:@127.0.0.1:3306/test_\{\}?storage_engine=INNODB" py.test -q --cov-append
 
 testall: deps _testall
 

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ _testall:
 	-$(py_warn) TORTOISE_TEST_DB=sqlite://:memory: py.test -q --cov-report=
 	-python -V | grep PyPy || $(py_warn) TORTOISE_TEST_DB=postgres://postgres:@127.0.0.1:5432/test_\{\} py.test -q --cov-append --cov-report=
 	-$(py_warn) TORTOISE_TEST_DB="mysql://root:@127.0.0.1:3306/test_\{\}?storage_engine=MYISAM" py.test -q --cov-append --cov-report=
-	-$(py_warn) TORTOISE_TEST_DB="mysql://root:@127.0.0.1:3306/test_\{\}?storage_engine=INNODB" py.test -q --cov-append
+	-$(py_warn) TORTOISE_TEST_DB="mysql://root:@127.0.0.1:3306/test_\{\}" py.test -q --cov-append
 
 testall: deps _testall
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ finalizer     = tortoise.contrib.test.finalizer
 addopts = -n auto --cov=tortoise
 
 [mypy]
-new_semantic_analyzer = True
+pretty = True
 ignore_missing_imports = True
 check_untyped_defs = True
 disallow_subclassing_any = True

--- a/tests/fields/test_fk.py
+++ b/tests/fields/test_fk.py
@@ -157,7 +157,7 @@ class TestForeignKeyField(test.TestCase):
         tour = await testmodels.Tournament.create(name="Team1")
         rel = await testmodels.MinRelation.create(tournament=tour)
         await tour.fetch_related("minrelations")
-        self.assertEqual([obj for obj in tour.minrelations], [rel])
+        self.assertEqual(list(tour.minrelations), [rel])
 
     async def test_minimal__fetched_len(self):
         tour = await testmodels.Tournament.create(name="Team1")

--- a/tests/fields/test_fk_uuid.py
+++ b/tests/fields/test_fk_uuid.py
@@ -159,7 +159,7 @@ class TestForeignKeyUUIDField(test.TestCase):
         tour = await self.UUIDPkModel.create()
         rel = await self.UUIDFkRelatedModel.create(model=tour)
         await tour.fetch_related("children")
-        self.assertEqual([obj for obj in tour.children], [rel])
+        self.assertEqual(list(tour.children), [rel])
 
     async def test_minimal__fetched_len(self):
         tour = await self.UUIDPkModel.create()

--- a/tests/fields/test_m2m_uuid.py
+++ b/tests/fields/test_m2m_uuid.py
@@ -42,7 +42,7 @@ class TestManyToManyUUIDField(test.TestCase):
         two1 = await self.UUIDM2MRelatedModel.create()
         two2 = await self.UUIDM2MRelatedModel.create()
         await one.peers.add(two1, two2)
-        self.assertEqual(await one.peers, [two1, two2])
+        self.assertEqual(set(await one.peers), {two1, two2})
         self.assertEqual(await two1.models, [one])
         self.assertEqual(await two2.models, [one])
 
@@ -53,10 +53,10 @@ class TestManyToManyUUIDField(test.TestCase):
         two2 = await self.UUIDM2MRelatedModel.create()
         await one1.peers.add(two1, two2)
         await one2.peers.add(two1, two2)
-        self.assertEqual(await one1.peers, [two1, two2])
-        self.assertEqual(await one2.peers, [two1, two2])
-        self.assertEqual(await two1.models, [one1, one2])
-        self.assertEqual(await two2.models, [one1, one2])
+        self.assertEqual(set(await one1.peers), {two1, two2})
+        self.assertEqual(set(await one2.peers), {two1, two2})
+        self.assertEqual(set(await two1.models), {one1, one2})
+        self.assertEqual(set(await two2.models), {one1, one2})
 
     async def test__remove(self):
         one = await self.UUIDPkModel.create()

--- a/tests/requirements-pypy.txt
+++ b/tests/requirements-pypy.txt
@@ -29,7 +29,7 @@ py==1.8.0                 # via pytest
 pycparser==2.19           # via cffi
 pymysql==0.9.2            # via aiomysql
 pyparsing==2.4.2          # via packaging
-pypika==0.35.5
+pypika==0.35.8
 pytest-cov==2.7.1
 pytest-forked==1.0.2      # via pytest-xdist
 pytest-xdist==1.29.0
@@ -37,7 +37,7 @@ pytest==5.1.3
 pyyaml==5.1.2
 requests==2.22.0          # via coveralls
 six==1.12.0               # via cryptography, packaging, pytest-xdist
-urllib3==1.25.5           # via requests
+urllib3==1.25.6           # via requests
 wcwidth==0.1.7            # via pytest
 zipp==0.6.0               # via importlib-metadata
 aiocontextvars==0.2.2 ; python_version < "3.7"

--- a/tests/requirements.in
+++ b/tests/requirements.in
@@ -35,7 +35,7 @@ pytest-xdist
 pytest-cov
 
 # Pypi
-twine
+twine<2.0
 
 # Sample integration - Quart
 wsproto;python_version>="3.7"

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -105,7 +105,7 @@ testfixtures==6.10.0      # via flake8-isort
 toml==0.10.0              # via black, hypercorn, tox
 tox==3.14.0
 tqdm==4.36.1              # via twine
-twine==2.0.0
+twine==1.15.0
 typed-ast==1.4.0          # via astroid, mypy
 typing-extensions==3.7.4  # via hypercorn, mypy
 ujson==1.35               # via sanic

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -12,7 +12,7 @@ alabaster==0.7.12         # via sphinx
 apipkg==1.5               # via execnet
 appdirs==1.4.3            # via black
 asn1crypto==0.24.0        # via cryptography
-astroid==2.2.5            # via pylint
+astroid==2.3.0            # via pylint
 asyncpg==0.18.3
 asynctest==0.13.0
 atomicwrites==1.3.0       # via pytest
@@ -47,7 +47,7 @@ h2==3.1.1                 # via httpcore, hypercorn
 hpack==3.0.0              # via h2
 httpcore==0.3.0 ; python_version >= "3.6"
 httptools==0.0.13         # via sanic, uvicorn
-hypercorn==0.8.2 ; python_version >= "3.7"
+hypercorn==0.8.4 ; python_version >= "3.7"
 hyperframe==5.2.0         # via h2
 idna==2.8                 # via httpcore, requests
 imagesize==1.1.0          # via sphinx
@@ -62,7 +62,7 @@ mccabe==0.6.1             # via flake8, pylint
 more-itertools==7.2.0     # via pytest, zipp
 multidict==4.5.2          # via quart, sanic
 mypy-extensions==0.4.1    # via mypy
-mypy==0.720
+mypy==0.730
 nose2==0.9.1
 packaging==19.2           # via pytest, sphinx, tox
 pbr==5.4.3                # via stevedore
@@ -75,10 +75,10 @@ pycodestyle==2.5.0        # via flake8
 pycparser==2.19           # via cffi
 pyflakes==2.1.1           # via flake8
 pygments==2.4.2
-pylint==2.3.1
+pylint==2.4.1
 pymysql==0.9.2            # via aiomysql
 pyparsing==2.4.2          # via packaging
-pypika==0.35.5
+pypika==0.35.8
 pytest-cov==2.7.1
 pytest-forked==1.0.2      # via pytest-xdist
 pytest-xdist==1.29.0
@@ -105,12 +105,12 @@ testfixtures==6.10.0      # via flake8-isort
 toml==0.10.0              # via black, hypercorn, tox
 tox==3.14.0
 tqdm==4.36.1              # via twine
-twine==1.15.0
+twine==2.0.0
 typed-ast==1.4.0          # via astroid, mypy
 typing-extensions==3.7.4  # via hypercorn, mypy
 ujson==1.35               # via sanic
 unidecode==1.1.1          # via green
-urllib3==1.25.5           # via requests
+urllib3==1.25.6           # via requests
 uvicorn==0.8.6 ; python_version >= "3.6"
 uvloop==0.12.2            # via sanic, uvicorn
 virtualenv==16.7.5        # via tox

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -21,6 +21,7 @@ class TestConcurrencyIsolated(test.IsolatedTestCase):
         async with in_transaction():
             await asyncio.gather(*[Tournament.create(name="Test") for _ in range(100)])
 
+    @test.requireCapability(supports_transactions=True)
     @test.expectedFailure
     async def test_concurrency_transactions_create(self):
         await asyncio.gather(*[self.create_trans_concurrent() for _ in range(10)])
@@ -28,6 +29,7 @@ class TestConcurrencyIsolated(test.IsolatedTestCase):
         self.assertEqual(count, 10000)
 
 
+@test.requireCapability(supports_transactions=True)
 class TestConcurrencyTransactioned(test.TestCase):
     async def test_concurrency_read(self):
         await Tournament.create(name="Test")

--- a/tests/test_db_url.py
+++ b/tests/test_db_url.py
@@ -194,6 +194,7 @@ class TestConfigGenerator(test.SimpleTestCase):
                     "port": 33060,
                     "user": "root",
                     "charset": "utf8mb4",
+                    "sql_mode": "STRICT_TRANS_TABLES",
                 },
             },
         )
@@ -211,6 +212,7 @@ class TestConfigGenerator(test.SimpleTestCase):
                     "port": 33060,
                     "user": "root",
                     "charset": "utf8mb4",
+                    "sql_mode": "STRICT_TRANS_TABLES",
                 },
             },
         )
@@ -228,6 +230,7 @@ class TestConfigGenerator(test.SimpleTestCase):
                     "port": 3306,
                     "user": "root",
                     "charset": "utf8mb4",
+                    "sql_mode": "STRICT_TRANS_TABLES",
                 },
             },
         )
@@ -251,6 +254,7 @@ class TestConfigGenerator(test.SimpleTestCase):
                     "port": 3306,
                     "user": "root",
                     "charset": "utf8mb4",
+                    "sql_mode": "STRICT_TRANS_TABLES",
                 },
             },
         )
@@ -277,6 +281,7 @@ class TestConfigGenerator(test.SimpleTestCase):
                     "connect_timeout": 1.5,
                     "echo": True,
                     "charset": "utf8mb4",
+                    "sql_mode": "STRICT_TRANS_TABLES",
                 },
             },
         )

--- a/tests/test_generate_schema.py
+++ b/tests/test_generate_schema.py
@@ -288,10 +288,12 @@ class TestGenerateSchemaMySQL(TestGenerateSchema):
         self.assertNotIn("participants", sql)
 
         sql = self.get_sql("`minrelation_team`")
+        self.assertIn("`minrelation_id` INT NOT NULL", sql)
         self.assertIn(
-            "`minrelation_id` INT NOT NULL REFERENCES `minrelation` (`id`) ON DELETE CASCADE", sql
+            "FOREIGN KEY (`minrelation_id`) REFERENCES `minrelation` (`id`) ON DELETE CASCADE", sql
         )
-        self.assertIn("`team_id` INT NOT NULL REFERENCES `team` (`id`) ON DELETE CASCADE", sql)
+        self.assertIn("`team_id` INT NOT NULL", sql)
+        self.assertIn("FOREIGN KEY (`team_id`) REFERENCES `team` (`id`) ON DELETE CASCADE", sql)
 
     async def test_table_and_row_comment_generation(self):
         await self.init_for("tests.testmodels")
@@ -338,16 +340,22 @@ CREATE TABLE `event` (
     `tournament_id` SMALLINT NOT NULL COMMENT 'FK to tournament' REFERENCES `tournament` (`tid`) ON DELETE CASCADE
 ) CHARACTER SET utf8mb4 COMMENT='This table contains a list of all the events';
 CREATE TABLE `sometable_self` (
-    `backward_sts` INT NOT NULL REFERENCES `sometable` (`sometable_id`) ON DELETE CASCADE,
-    `sts_forward` INT NOT NULL REFERENCES `sometable` (`sometable_id`) ON DELETE CASCADE
+    `backward_sts` INT NOT NULL,
+    `sts_forward` INT NOT NULL,
+    FOREIGN KEY (`backward_sts`) REFERENCES `sometable` (`sometable_id`) ON DELETE CASCADE,
+    FOREIGN KEY (`sts_forward`) REFERENCES `sometable` (`sometable_id`) ON DELETE CASCADE
 ) CHARACTER SET utf8mb4;
 CREATE TABLE `team_team` (
-    `team_rel_id` VARCHAR(50) NOT NULL REFERENCES `team` (`name`) ON DELETE CASCADE,
-    `team_id` VARCHAR(50) NOT NULL REFERENCES `team` (`name`) ON DELETE CASCADE
+    `team_rel_id` VARCHAR(50) NOT NULL,
+    `team_id` VARCHAR(50) NOT NULL,
+    FOREIGN KEY (`team_rel_id`) REFERENCES `team` (`name`) ON DELETE CASCADE,
+    FOREIGN KEY (`team_id`) REFERENCES `team` (`name`) ON DELETE CASCADE
 ) CHARACTER SET utf8mb4;
 CREATE TABLE `teamevents` (
-    `event_id` BIGINT NOT NULL REFERENCES `event` (`id`) ON DELETE CASCADE,
-    `team_id` VARCHAR(50) NOT NULL REFERENCES `team` (`name`) ON DELETE CASCADE
+    `event_id` BIGINT NOT NULL,
+    `team_id` VARCHAR(50) NOT NULL,
+    FOREIGN KEY (`event_id`) REFERENCES `event` (`id`) ON DELETE CASCADE,
+    FOREIGN KEY (`team_id`) REFERENCES `team` (`name`) ON DELETE CASCADE
 ) CHARACTER SET utf8mb4 COMMENT='How participants relate';
 """.strip(),  # noqa
         )
@@ -408,17 +416,24 @@ CREATE TABLE IF NOT EXISTS `event` (
     `tournament_id` SMALLINT NOT NULL COMMENT 'FK to tournament' REFERENCES `tournament` (`tid`) ON DELETE CASCADE
 ) CHARACTER SET utf8mb4 COMMENT='This table contains a list of all the events';
 CREATE TABLE IF NOT EXISTS `sometable_self` (
-    `backward_sts` INT NOT NULL REFERENCES `sometable` (`sometable_id`) ON DELETE CASCADE,
-    `sts_forward` INT NOT NULL REFERENCES `sometable` (`sometable_id`) ON DELETE CASCADE
+    `backward_sts` INT NOT NULL,
+    `sts_forward` INT NOT NULL,
+    FOREIGN KEY (`backward_sts`) REFERENCES `sometable` (`sometable_id`) ON DELETE CASCADE,
+    FOREIGN KEY (`sts_forward`) REFERENCES `sometable` (`sometable_id`) ON DELETE CASCADE
 ) CHARACTER SET utf8mb4;
 CREATE TABLE IF NOT EXISTS `team_team` (
-    `team_rel_id` VARCHAR(50) NOT NULL REFERENCES `team` (`name`) ON DELETE CASCADE,
-    `team_id` VARCHAR(50) NOT NULL REFERENCES `team` (`name`) ON DELETE CASCADE
+    `team_rel_id` VARCHAR(50) NOT NULL,
+    `team_id` VARCHAR(50) NOT NULL,
+    FOREIGN KEY (`team_rel_id`) REFERENCES `team` (`name`) ON DELETE CASCADE,
+    FOREIGN KEY (`team_id`) REFERENCES `team` (`name`) ON DELETE CASCADE
 ) CHARACTER SET utf8mb4;
 CREATE TABLE IF NOT EXISTS `teamevents` (
-    `event_id` BIGINT NOT NULL REFERENCES `event` (`id`) ON DELETE CASCADE,
-    `team_id` VARCHAR(50) NOT NULL REFERENCES `team` (`name`) ON DELETE CASCADE
+    `event_id` BIGINT NOT NULL,
+    `team_id` VARCHAR(50) NOT NULL,
+    FOREIGN KEY (`event_id`) REFERENCES `event` (`id`) ON DELETE CASCADE,
+    FOREIGN KEY (`team_id`) REFERENCES `team` (`name`) ON DELETE CASCADE
 ) CHARACTER SET utf8mb4 COMMENT='How participants relate';
+
 """.strip(),  # noqa
         )
 

--- a/tests/test_generate_schema.py
+++ b/tests/test_generate_schema.py
@@ -276,7 +276,7 @@ class TestGenerateSchemaMySQL(TestGenerateSchema):
         await self.init_for("tests.testmodels")
         sql = self.get_sql("`noid`")
         self.assertIn("`name` VARCHAR(255)", sql)
-        self.assertIn("`id` INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT", sql)
+        self.assertIn("`id` INT NOT NULL PRIMARY KEY AUTO_INCREMENT", sql)
 
     async def test_minrelation(self):
         await self.init_for("tests.testmodels")
@@ -310,11 +310,11 @@ class TestGenerateSchemaMySQL(TestGenerateSchema):
             sql.strip(),
             """
 CREATE TABLE `defaultpk` (
-    `id` INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    `id` INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
     `val` INT NOT NULL
 ) CHARACTER SET utf8mb4;
 CREATE TABLE `sometable` (
-    `sometable_id` INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    `sometable_id` INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
     `some_chars_table` VARCHAR(255) NOT NULL,
     `fk_sometable` INT REFERENCES `sometable` (`sometable_id`) ON DELETE CASCADE
 ) CHARACTER SET utf8mb4;
@@ -324,13 +324,13 @@ CREATE TABLE `team` (
     `manager_id` VARCHAR(50) REFERENCES `team` (`name`) ON DELETE CASCADE
 ) CHARACTER SET utf8mb4 COMMENT='The TEAMS!';
 CREATE TABLE `tournament` (
-    `tid` SMALLINT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    `tid` SMALLINT NOT NULL PRIMARY KEY AUTO_INCREMENT,
     `name` TEXT NOT NULL  COMMENT 'Tournament name',
     `created` DATETIME(6) NOT NULL  COMMENT 'Created */\\'`/* datetime'
 ) CHARACTER SET utf8mb4 COMMENT='What Tournaments */\\'`/* we have';
 CREATE INDEX `tournament_name_116110_idx` ON `tournament` (name);
 CREATE TABLE `event` (
-    `id` BIGINT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT COMMENT 'Event ID',
+    `id` BIGINT NOT NULL PRIMARY KEY AUTO_INCREMENT COMMENT 'Event ID',
     `name` TEXT NOT NULL UNIQUE,
     `modified` DATETIME(6) NOT NULL,
     `prize` DECIMAL(10,2),
@@ -382,11 +382,11 @@ CREATE TABLE `teamevents` (
             sql.strip(),
             """
 CREATE TABLE IF NOT EXISTS `defaultpk` (
-    `id` INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    `id` INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
     `val` INT NOT NULL
 ) CHARACTER SET utf8mb4;
 CREATE TABLE IF NOT EXISTS `sometable` (
-    `sometable_id` INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    `sometable_id` INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
     `some_chars_table` VARCHAR(255) NOT NULL,
     `fk_sometable` INT REFERENCES `sometable` (`sometable_id`) ON DELETE CASCADE
 ) CHARACTER SET utf8mb4;
@@ -395,12 +395,12 @@ CREATE TABLE IF NOT EXISTS `team` (
     `manager_id` VARCHAR(50) REFERENCES `team` (`name`) ON DELETE CASCADE
 ) CHARACTER SET utf8mb4 COMMENT='The TEAMS!';
 CREATE TABLE IF NOT EXISTS `tournament` (
-    `tid` SMALLINT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    `tid` SMALLINT NOT NULL PRIMARY KEY AUTO_INCREMENT,
     `name` TEXT NOT NULL  COMMENT 'Tournament name',
     `created` DATETIME(6) NOT NULL  COMMENT 'Created */\\'`/* datetime'
 ) CHARACTER SET utf8mb4 COMMENT='What Tournaments */\\'`/* we have';
 CREATE TABLE IF NOT EXISTS `event` (
-    `id` BIGINT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT COMMENT 'Event ID',
+    `id` BIGINT NOT NULL PRIMARY KEY AUTO_INCREMENT COMMENT 'Event ID',
     `name` TEXT NOT NULL UNIQUE,
     `modified` DATETIME(6) NOT NULL,
     `prize` DECIMAL(10,2),

--- a/tests/test_reconnect.py
+++ b/tests/test_reconnect.py
@@ -5,8 +5,8 @@ from tortoise.exceptions import DBConnectionError, TransactionManagementError
 from tortoise.transactions import in_transaction
 
 
+@test.requireCapability(daemon=True)
 class TestQueryset(test.IsolatedTestCase):
-    @test.requireCapability(daemon=True)
     async def test_reconnect(self):
         await Tournament.create(name="1")
 
@@ -20,7 +20,6 @@ class TestQueryset(test.IsolatedTestCase):
             ["{}:{}".format(a.id, a.name) for a in await Tournament.all()], ["1:1", "2:2"]
         )
 
-    @test.requireCapability(daemon=True)
     async def test_reconnect_fail(self):
         await Tournament.create(name="1")
 
@@ -33,7 +32,7 @@ class TestQueryset(test.IsolatedTestCase):
 
         Tortoise._connections["models"].port = realport
 
-    @test.requireCapability(daemon=True)
+    @test.requireCapability(supports_transactions=True)
     async def test_reconnect_transaction_start(self):
         async with in_transaction():
             await Tournament.create(name="1")
@@ -50,7 +49,7 @@ class TestQueryset(test.IsolatedTestCase):
                 ["{}:{}".format(a.id, a.name) for a in await Tournament.all()], ["1:1", "2:2"]
             )
 
-    @test.requireCapability(daemon=True)
+    @test.requireCapability(supports_transactions=True)
     async def test_reconnect_during_transaction_fails(self):
         await Tournament.create(name="1")
 

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -25,13 +25,13 @@ class TestRelations(test.TestCase):
         teamids = []
         async for team in event.participants:
             teamids.append(team.id)
-        self.assertEqual(teamids, [participants[0].id, participants[1].id])
+        self.assertEqual(set(teamids), {participants[0].id, participants[1].id})
 
         self.assertEqual(
-            [team.id for team in event.participants], [participants[0].id, participants[1].id]
+            set([team.id for team in event.participants]), {participants[0].id, participants[1].id}
         )
 
-        self.assertEqual(event.participants[0].id, participants[0].id)
+        self.assertIn(event.participants[0].id, {participants[0].id, participants[1].id})
 
         selected_events = await Event.filter(participants=participants[0].id).prefetch_related(
             "participants", "tournament"

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -17,6 +17,7 @@ async def atomic_decorated_func():
     return tournament
 
 
+@test.requireCapability(supports_transactions=True)
 class TestTransactions(test.TruncationTestCase):
     async def test_transactions(self):
         with self.assertRaises(SomeException):

--- a/tests/testmodels.py
+++ b/tests/testmodels.py
@@ -395,8 +395,8 @@ class Employee(Model):
 
 class StraightFields(Model):
     id = fields.IntField(pk=True, description="Da PK")
-    chars = fields.CharField(max_length=255, index=True, description="Some chars")
-    blip = fields.CharField(max_length=255, default="BLIP")
+    chars = fields.CharField(max_length=50, index=True, description="Some chars")
+    blip = fields.CharField(max_length=50, default="BLIP")
     fk = fields.ForeignKeyField(
         "models.StraightFields", related_name="fkrev", null=True, description="Tree!"
     )
@@ -412,9 +412,9 @@ class StraightFields(Model):
 class SourceFields(Model):
     id = fields.IntField(pk=True, source_field="sometable_id", description="Da PK")
     chars = fields.CharField(
-        max_length=255, source_field="some_chars_table", index=True, description="Some chars"
+        max_length=50, source_field="some_chars_table", index=True, description="Some chars"
     )
-    blip = fields.CharField(max_length=255, default="BLIP", source_field="da_blip")
+    blip = fields.CharField(max_length=50, default="BLIP", source_field="da_blip")
     fk = fields.ForeignKeyField(
         "models.SourceFields",
         related_name="fkrev",

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -669,4 +669,4 @@ def run_async(coro: Coroutine) -> None:
         loop.run_until_complete(Tortoise.close_connections())
 
 
-__version__ = "0.13.8"
+__version__ = "0.13.9"

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -285,8 +285,7 @@ class Tortoise:
             for model_name, model in app.items():
                 if model._meta._inited:
                     continue
-                else:
-                    model._meta._inited = True
+                model._meta._inited = True
                 if not model._meta.table:
                     model._meta.table = model.__name__.lower()
 
@@ -463,7 +462,7 @@ class Tortoise:
     def _get_config_from_config_file(cls, config_file: str) -> dict:
         _, extension = os.path.splitext(config_file)
         if extension in (".yml", ".yaml"):
-            import yaml
+            import yaml  # pylint: disable=C0415
 
             with open(config_file, "r") as f:
                 config = yaml.safe_load(f)

--- a/tortoise/backends/base/client.py
+++ b/tortoise/backends/base/client.py
@@ -37,7 +37,8 @@ class Capabilities:
         # Deficiencies to work around:
         safe_indexes: bool = True,
         requires_limit: bool = False,
-        inline_comment: bool = False
+        inline_comment: bool = False,
+        supports_transactions: bool = True
     ) -> None:
         super().__setattr__("_mutable", True)
 
@@ -46,6 +47,7 @@ class Capabilities:
         self.requires_limit = requires_limit
         self.safe_indexes = safe_indexes
         self.inline_comment = inline_comment
+        self.supports_transactions = supports_transactions
 
         super().__setattr__("_mutable", False)
 

--- a/tortoise/backends/base/config_generator.py
+++ b/tortoise/backends/base/config_generator.py
@@ -46,7 +46,7 @@ DB_LOOKUP = {
             "username": "user",
             "password": "password",
         },
-        "defaults": {"port": 3306, "charset": "utf8mb4"},  # "sql_mode": "STRICT_TRANS_TABLES"},
+        "defaults": {"port": 3306, "charset": "utf8mb4", "sql_mode": "STRICT_TRANS_TABLES"},
         "cast": {
             "minsize": int,
             "maxsize": int,

--- a/tortoise/backends/base/config_generator.py
+++ b/tortoise/backends/base/config_generator.py
@@ -46,7 +46,7 @@ DB_LOOKUP = {
             "username": "user",
             "password": "password",
         },
-        "defaults": {"port": 3306, "charset": "utf8mb4"},
+        "defaults": {"port": 3306, "charset": "utf8mb4"},  # "sql_mode": "STRICT_TRANS_TABLES"},
         "cast": {
             "minsize": int,
             "maxsize": int,

--- a/tortoise/backends/base/schema_generator.py
+++ b/tortoise/backends/base/schema_generator.py
@@ -1,5 +1,4 @@
 import logging
-import warnings
 from typing import List, Optional, Set  # noqa
 
 from tortoise import fields
@@ -46,9 +45,9 @@ class BaseSchemaGenerator:
     def _create_string(
         self, db_field: str, field_type: str, nullable: str, unique: str, is_pk: bool, comment: str
     ) -> str:
-        # children can override this function to customize thier sql queries
+        # children can override this function to customize their sql queries
 
-        field_creation_string = self.FIELD_TEMPLATE.format(
+        return self.FIELD_TEMPLATE.format(
             name=db_field,
             type=field_type,
             nullable=nullable,
@@ -57,7 +56,12 @@ class BaseSchemaGenerator:
             primary=" PRIMARY KEY" if is_pk else "",
         ).strip()
 
-        return field_creation_string
+    def _create_fk_string(
+        self, db_field: str, table: str, field: str, on_delete: str, comment: str
+    ) -> str:
+        return self.FK_TEMPLATE.format(
+            db_field=db_field, table=table, field=field, on_delete=on_delete, comment=comment
+        )
 
     def _get_primary_key_create_string(
         self, field_object: fields.Field, field_name: str, comment: str
@@ -177,7 +181,8 @@ class BaseSchemaGenerator:
                     unique=unique,
                     is_pk=field_object.pk,
                     comment="",
-                ) + self.FK_TEMPLATE.format(
+                ) + self._create_fk_string(
+                    db_field=db_field,
                     table=field_object.reference.type._meta.table,
                     field=field_object.reference.type._meta.db_pk_field,
                     on_delete=field_object.reference.on_delete,
@@ -238,19 +243,14 @@ class BaseSchemaGenerator:
 
         # Indexes.
         field_indexes_sqls = [
-            self._get_index_sql(model, [field_name], safe=safe) for field_name in fields_with_index
+            val
+            for val in [
+                self._get_index_sql(model, [field_name], safe=safe)
+                for field_name in fields_with_index
+            ]
+            if val
         ]
-        if safe and not self.client.capabilities.safe_indexes:
-            warnings.warn(
-                "Skipping creation of field indexes: safe index creation is not supported yet for "
-                "{dialect}. Please find the SQL queries to create the indexes in the logs.".format(
-                    dialect=self.client.capabilities.dialect
-                )
-            )
-            for fis in field_indexes_sqls:
-                logger.warning(fis)
-        else:
-            table_create_string = "\n".join([table_create_string, *field_indexes_sqls])
+        table_create_string = "\n".join([table_create_string, *field_indexes_sqls])
 
         table_create_string += self._post_table_hook()
 

--- a/tortoise/backends/mysql/client.py
+++ b/tortoise/backends/mysql/client.py
@@ -124,7 +124,9 @@ class MySQLClient(BaseDBAsyncClient):
             if isinstance(self._connection, aiomysql.Connection):
                 async with self._connection.cursor() as cursor:
                     if self.storage_engine:
-                        await cursor.execute("SET default_storage_engine='{}';".format(self.storage_engine))
+                        await cursor.execute(
+                            "SET default_storage_engine='{}';".format(self.storage_engine)
+                        )
                         if self.storage_engine.lower() != "innodb":
                             self.capabilities.__dict__["supports_transactions"] = False
 

--- a/tortoise/backends/mysql/client.py
+++ b/tortoise/backends/mysql/client.py
@@ -93,6 +93,7 @@ class MySQLClient(BaseDBAsyncClient):
         self.host = host
         self.port = int(port)  # make sure port is int type
         self.extra = kwargs.copy()
+        self.storage_engine = self.extra.pop("storage_engine", "")
         self.extra.pop("connection_name", None)
         self.extra.pop("fetch_inserted", None)
         self.extra.pop("db", None)
@@ -119,6 +120,14 @@ class MySQLClient(BaseDBAsyncClient):
         }
         try:
             self._connection = await aiomysql.connect(password=self.password, **self._template)
+
+            if isinstance(self._connection, aiomysql.Connection):
+                async with self._connection.cursor() as cursor:
+                    if self.storage_engine:
+                        await cursor.execute("SET storage_engine='{}';".format(self.storage_engine))
+                        if self.storage_engine.lower() != "innodb":
+                            self.capabilities.__dict__["supports_transactions"] = False
+
             self.log.debug(
                 "Created connection %s with params: %s", self._connection, self._template
             )

--- a/tortoise/backends/mysql/client.py
+++ b/tortoise/backends/mysql/client.py
@@ -124,7 +124,7 @@ class MySQLClient(BaseDBAsyncClient):
             if isinstance(self._connection, aiomysql.Connection):
                 async with self._connection.cursor() as cursor:
                     if self.storage_engine:
-                        await cursor.execute("SET storage_engine='{}';".format(self.storage_engine))
+                        await cursor.execute("SET default_storage_engine='{}';".format(self.storage_engine))
                         if self.storage_engine.lower() != "innodb":
                             self.capabilities.__dict__["supports_transactions"] = False
 

--- a/tortoise/backends/mysql/schema_generator.py
+++ b/tortoise/backends/mysql/schema_generator.py
@@ -5,9 +5,7 @@ from tortoise.backends.base.schema_generator import BaseSchemaGenerator
 
 
 class MySQLSchemaGenerator(BaseSchemaGenerator):
-    TABLE_CREATE_TEMPLATE = (
-        "CREATE TABLE {exists}`{table_name}` ({fields}__TAIL_STATEMENTS__){extra}{comment};"
-    )
+    TABLE_CREATE_TEMPLATE = "CREATE TABLE {exists}`{table_name}` ({fields}){extra}{comment};"
     INDEX_CREATE_TEMPLATE = "KEY `{index_name}` ({fields})"
     FIELD_TEMPLATE = "`{name}` {type} {nullable} {unique}{primary}{comment}"
     FK_TEMPLATE = (
@@ -77,17 +75,8 @@ class MySQLSchemaGenerator(BaseSchemaGenerator):
         )
         return comment
 
-    def _get_table_sql(self, model, safe=True) -> dict:
-        res = super()._get_table_sql(model, safe)
+    def _get_inner_statements(self) -> List[str]:
         extra = self._foreign_keys + self._field_indexes
-        if extra:
-            table_fields_string = ",\n    " + ",\n    ".join(extra) + "\n"
-        else:
-            table_fields_string = "\n"
-
-        res["table_creation_string"] = res["table_creation_string"].replace(
-            "\n__TAIL_STATEMENTS__", table_fields_string
-        )
         self._field_indexes.clear()
         self._foreign_keys.clear()
-        return res
+        return extra

--- a/tortoise/backends/mysql/schema_generator.py
+++ b/tortoise/backends/mysql/schema_generator.py
@@ -1,14 +1,18 @@
-from typing import Optional
+from typing import List, Optional
 
 from tortoise import fields
 from tortoise.backends.base.schema_generator import BaseSchemaGenerator
 
 
 class MySQLSchemaGenerator(BaseSchemaGenerator):
-    TABLE_CREATE_TEMPLATE = "CREATE TABLE {exists}`{table_name}` ({fields}){extra}{comment};"
-    INDEX_CREATE_TEMPLATE = "CREATE INDEX `{index_name}` ON `{table_name}` ({fields});"
+    TABLE_CREATE_TEMPLATE = (
+        "CREATE TABLE {exists}`{table_name}` ({fields}__TAIL_STATEMENTS__){extra}{comment};"
+    )
+    INDEX_CREATE_TEMPLATE = "KEY `{index_name}` ({fields})"
     FIELD_TEMPLATE = "`{name}` {type} {nullable} {unique}{primary}{comment}"
-    FK_TEMPLATE = "{comment} REFERENCES `{table}` (`{field}`) ON DELETE {on_delete}"
+    FK_TEMPLATE = (
+        "FOREIGN KEY (`{db_field}`) REFERENCES `{table}` (`{field}`) ON DELETE {on_delete}"
+    )
     M2M_TABLE_TEMPLATE = (
         "CREATE TABLE {exists}`{table_name}` (\n"
         "    `{backward_key}` {backward_type} NOT NULL,\n"
@@ -25,6 +29,11 @@ class MySQLSchemaGenerator(BaseSchemaGenerator):
         fields.DatetimeField: "DATETIME(6)",
         fields.TextField: "TEXT",
     }
+
+    def __init__(self, client) -> None:
+        super().__init__(client)
+        self._field_indexes = []  # type: List[str]
+        self._foreign_keys = []  # type: List[str]
 
     def _get_primary_key_create_string(
         self, field_object: fields.Field, field_name: str, comment: str
@@ -45,3 +54,40 @@ class MySQLSchemaGenerator(BaseSchemaGenerator):
 
     def _column_comment_generator(self, table: str, column: str, comment: str) -> str:
         return " COMMENT '{}'".format(self._escape_comment(comment))
+
+    def _get_index_sql(self, model, field_names: List[str], safe: bool) -> str:
+        """ Get index SQLs, but keep them for ourselves """
+        self._field_indexes.append(
+            self.INDEX_CREATE_TEMPLATE.format(
+                exists="IF NOT EXISTS " if safe else "",
+                index_name=self._generate_index_name(model, field_names),
+                table_name=model._meta.table,
+                fields=", ".join(["`" + f + "`" for f in field_names]),
+            )
+        )
+        return ""
+
+    def _create_fk_string(
+        self, db_field: str, table: str, field: str, on_delete: str, comment: str
+    ) -> str:
+        self._foreign_keys.append(
+            self.FK_TEMPLATE.format(
+                db_field=db_field, table=table, field=field, on_delete=on_delete
+            )
+        )
+        return comment
+
+    def _get_table_sql(self, model, safe=True) -> dict:
+        res = super()._get_table_sql(model, safe)
+        extra = self._foreign_keys + self._field_indexes
+        if extra:
+            table_fields_string = ",\n    " + ",\n    ".join(extra) + "\n"
+        else:
+            table_fields_string = "\n"
+
+        res["table_creation_string"] = res["table_creation_string"].replace(
+            "\n__TAIL_STATEMENTS__", table_fields_string
+        )
+        self._field_indexes.clear()
+        self._foreign_keys.clear()
+        return res

--- a/tortoise/backends/mysql/schema_generator.py
+++ b/tortoise/backends/mysql/schema_generator.py
@@ -28,17 +28,11 @@ class MySQLSchemaGenerator(BaseSchemaGenerator):
         self, field_object: fields.Field, field_name: str, comment: str
     ) -> Optional[str]:
         if isinstance(field_object, fields.SmallIntField):
-            return "`{}` SMALLINT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT{}".format(
-                field_name, comment
-            )
+            return "`{}` SMALLINT NOT NULL PRIMARY KEY AUTO_INCREMENT{}".format(field_name, comment)
         if isinstance(field_object, fields.IntField):
-            return "`{}` INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT{}".format(
-                field_name, comment
-            )
+            return "`{}` INT NOT NULL PRIMARY KEY AUTO_INCREMENT{}".format(field_name, comment)
         if isinstance(field_object, fields.BigIntField):
-            return "`{}` BIGINT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT{}".format(
-                field_name, comment
-            )
+            return "`{}` BIGINT NOT NULL PRIMARY KEY AUTO_INCREMENT{}".format(field_name, comment)
         return None
 
     def _table_generate_extra(self, table: str) -> str:

--- a/tortoise/backends/mysql/schema_generator.py
+++ b/tortoise/backends/mysql/schema_generator.py
@@ -11,10 +11,12 @@ class MySQLSchemaGenerator(BaseSchemaGenerator):
     FK_TEMPLATE = "{comment} REFERENCES `{table}` (`{field}`) ON DELETE {on_delete}"
     M2M_TABLE_TEMPLATE = (
         "CREATE TABLE {exists}`{table_name}` (\n"
-        "    `{backward_key}` {backward_type} NOT NULL REFERENCES `{backward_table}`"
-        " (`{backward_field}`) ON DELETE CASCADE,\n"
-        "    `{forward_key}` {forward_type} NOT NULL REFERENCES `{forward_table}`"
-        " (`{forward_field}`) ON DELETE CASCADE\n"
+        "    `{backward_key}` {backward_type} NOT NULL,\n"
+        "    `{forward_key}` {forward_type} NOT NULL,\n"
+        "    FOREIGN KEY (`{backward_key}`) REFERENCES `{backward_table}` (`{backward_field}`)"
+        " ON DELETE CASCADE,\n"
+        "    FOREIGN KEY (`{forward_key}`) REFERENCES `{forward_table}` (`{forward_field}`)"
+        " ON DELETE CASCADE\n"
         "){extra}{comment};"
     )
     FIELD_TYPE_MAP = {

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -213,8 +213,8 @@ class MetaInfo:
     def _generate_filters(self) -> None:
         get_overridden_filter_func = self.db.executor_class.get_overridden_filter_func
         for key, filter_info in self._filters.items():
-            overridden_operator = get_overridden_filter_func(  # type: ignore
-                filter_func=filter_info["operator"]
+            overridden_operator = get_overridden_filter_func(
+                filter_func=filter_info["operator"]  # type: ignore
             )
             if overridden_operator:
                 filter_info = copy(filter_info)

--- a/tortoise/query_utils.py
+++ b/tortoise/query_utils.py
@@ -116,9 +116,9 @@ class QueryModifier:
         joins: Optional[List[Tuple[Criterion, Criterion]]] = None,
         having_criterion: Optional[Criterion] = None,
     ):
-        self.where_criterion = where_criterion if where_criterion else EmptyCriterion()
+        self.where_criterion = where_criterion or EmptyCriterion()
         self.joins = joins if joins else []
-        self.having_criterion = having_criterion if having_criterion else EmptyCriterion()
+        self.having_criterion = having_criterion or EmptyCriterion()
 
     def __and__(self, other: "QueryModifier") -> "QueryModifier":
         return QueryModifier(

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -414,12 +414,9 @@ class QuerySet(AwaitableQuery):
                             first_level_field, self.model._meta.table
                         )
                     )
-                else:
-                    raise FieldError(
-                        "Relation {} for {} not found".format(
-                            first_level_field, self.model._meta.table
-                        )
-                    )
+                raise FieldError(
+                    "Relation {} for {} not found".format(first_level_field, self.model._meta.table)
+                )
             if first_level_field not in queryset._prefetch_map.keys():
                 queryset._prefetch_map[first_level_field] = set()
             forwarded_prefetch = "__".join(relation_split[1:])


### PR DESCRIPTION
This PR attempts to fix #197 

There is a possibility that our MySQL support was troublesome in part because we only tested `InnoDB` on `MariaDB`. Extend the testing to `MyISAM`.

Done:
* [x] Ensured that int PK's are not unsigned (we don't support unsigned ints at this stage)
* [x] Enable the MySQL db client to specify the testing engine
* [x] Test if engine is not InnoDB, then mark `transaction_support` as `False`
* [x] Skip any transaction-specific test cases when DB doesn't support transactions.
* [x] Added `MyISAM` engine to CI
* [x] Enable `STRICT_TRANS_TABLES` sql_mode by default as is recommended. (Apparently only needed for older versions, but supposedly fix many runtime issues. Django also does it.)
* [x] Investigate if in-line REFERENCES just works in MariaDB or also old MySQL? *Definitely needed*
* Refactor SQL schema generation by putting key/indexes into to bottom of create statement for MySQL to conform to recommended MySQL spec:
  * [x] For FK
  * [x] For M2M through tables
  * [x] Indexes as per https://github.com/tortoise/tortoise-orm/issues/8#issuecomment-534946871

Defer proper refactoring work to 0.14