### PR TITLE
Set field types by 2nd base class

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,10 @@
 Changelog
 =========
 
+0.13.9
+- Fields can have 2nd base class which makes IDEs know python type (str, int, datetime...) of the field.
+- The ``type`` parameter of ``Field.__init__`` is removed, instead we use the 2nd base class
+
 0.13.8
 ------
 - Fixed bug in schema creation for MySQL where non-int PK did not get declared properly (#195)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 =========
 
 0.13.9
+------
 - Fields can have 2nd base class which makes IDEs know python type (str, int, datetime...) of the field.
 - The ``type`` parameter of ``Field.__init__`` is removed, instead we use the 2nd base class
 

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -18,6 +18,7 @@ Contributors
 * Nguyễn Hồng Quân ``@hongquan``
 * Mateusz Bocian ``@mrstork``
 * Vladimir Urushev ``@pilat``
+* Adam Wallner ``@wallneradam``
 
 Special Thanks
 ==============

--- a/tortoise/backends/base/schema_generator.py
+++ b/tortoise/backends/base/schema_generator.py
@@ -124,10 +124,13 @@ class BaseSchemaGenerator:
 
     def _get_field_type(self, field_object) -> str:
         field_object_type = type(field_object)
-        while field_object_type.__bases__ and field_object_type not in self.FIELD_TYPE_MAP:
+        while (
+            field_object_type.__bases__
+            and field_object_type not in self.FIELD_TYPE_MAP  # type: ignore
+        ):
             field_object_type = field_object_type.__bases__[0]
 
-        field_type = self.FIELD_TYPE_MAP[field_object_type]
+        field_type = self.FIELD_TYPE_MAP[field_object_type]  # type: ignore
 
         if isinstance(field_object, fields.DecimalField):
             field_type = field_type.format(field_object.max_digits, field_object.decimal_places)

--- a/tortoise/fields.py
+++ b/tortoise/fields.py
@@ -172,7 +172,7 @@ class TextField(Field, str):
     __slots__ = ()
 
 
-class BooleanField(Field, bool):
+class BooleanField(Field, bool):  # pylint: disable=E0239  # It is intentiona to sublass bool
     """
     Boolean field.
     """

--- a/tortoise/fields.py
+++ b/tortoise/fields.py
@@ -172,12 +172,15 @@ class TextField(Field, str):
     __slots__ = ()
 
 
-class BooleanField(Field, bool):  # pylint: disable=E0239  # It is intentiona to sublass bool
+class BooleanField(Field):
     """
     Boolean field.
     """
 
     __slots__ = ()
+
+    # Bool is not subclassable, so we specify type here
+    type = bool
 
 
 class DecimalField(Field, Decimal):


### PR DESCRIPTION
## Description
This makes IDEs happy by seeing fields acts as a base class (like int, str, float...), and bit more intuitive to set the Python class of a Field subclass.

## Motivation and Context
It is discussed in #196

## How Has This Been Tested?
I tested it in my application only.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.

