### PR TITLE
Field multiple inheritence fix

### DIFF
--- a/tortoise/fields.py
+++ b/tortoise/fields.py
@@ -28,13 +28,12 @@ JSON_LOADS = json.loads
 
 class _FieldMeta(type):
     def __new__(mcs, name, bases, attrs):
-        if len(bases) > 1:
-            if bases[0] == Field:
-                # Instantiate class with only the 1st base class (should be Field)
-                cls = type.__new__(mcs, name, (bases[0],), attrs)  # type: Type[Field]
-                # All other base classes are our meta types, we store them in class attributes
-                cls.type = bases[1] if len(bases) == 2 else bases[1:]
-                return cls
+        if len(bases) > 1 and bases[0] is Field:
+            # Instantiate class with only the 1st base class (should be Field)
+            cls = type.__new__(mcs, name, (bases[0],), attrs)  # type: Type[Field]
+            # All other base classes are our meta types, we store them in class attributes
+            cls.type = bases[1] if len(bases) == 2 else bases[1:]
+            return cls
         return type.__new__(mcs, name, bases, attrs)
 
 

--- a/tortoise/fields.py
+++ b/tortoise/fields.py
@@ -29,11 +29,12 @@ JSON_LOADS = json.loads
 class _FieldMeta(type):
     def __new__(mcs, name, bases, attrs):
         if len(bases) > 1:
-            # Instantiate class with only the 1st base class (should be Field)
-            cls = type.__new__(mcs, name, (bases[0],), attrs)  # type: Type[Field]
-            # All other base classes are our meta types, we store them in class attributes
-            cls.type = bases[1] if len(bases) == 2 else bases[1:]
-            return cls
+            if bases[0] == Field:
+                # Instantiate class with only the 1st base class (should be Field)
+                cls = type.__new__(mcs, name, (bases[0],), attrs)  # type: Type[Field]
+                # All other base classes are our meta types, we store them in class attributes
+                cls.type = bases[1] if len(bases) == 2 else bases[1:]
+                return cls
         return type.__new__(mcs, name, bases, attrs)
 
 
@@ -89,6 +90,7 @@ class Field(metaclass=_FieldMeta):
         self.model = model
         self.reference = reference
         self.description = description
+        super().__init__(**kwargs)  # type: ignore # mypy issue 4335
 
     def to_db_value(self, value: Any, instance) -> Any:
         if value is None or type(value) == self.type:  # pylint: disable=C0123


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

There were some small problems with my last PR. It can't work well with inherited fields have mixins.

## Description
<!--- Describe your changes in detail -->

```python
class VirtualField:
    def __init__(self, *args, **kwargs) -> None:
        super().__init__(*args, **kwargs)

class VirtualIntField(fields.IntField, VirtualField):
    pass
```

1. The _FieldMeta class hasn't checked if the 1st base class was Field. So if I used a field class in the above way, only IntField was preserved.
2. Field class hasn't called the `super().__init__`, so the `__init__` of 2nd base class of VirtualIntField was never reached.

## Motivation and Context
It is a fix for #202 

## How Has This Been Tested?
I tested with the above code

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.

