### PR TITLE
Add trim, length, coalesce db functions.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Enhancements:
 - Models, Fields & QuerySets have significant type annotation improvements,
   leading to better IDE integration and more comprehensive static analysis.
 - Fetching records from the DB is now up to 25% faster.
+- Database functions added in aggregations ``Trim()``, ``Length()``, ``Coalesce()``.
 
 Bugfixes:
 ^^^^^^^^^

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -19,6 +19,7 @@ Contributors
 * Mateusz Bocian ``@mrstork``
 * Vladimir Urushev ``@pilat``
 * Adam Wallner ``@wallneradam``
+* Zoltán Szeredi ``@zoliszeredi``
 
 Special Thanks
 ==============

--- a/tortoise/aggregation.py
+++ b/tortoise/aggregation.py
@@ -1,23 +1,27 @@
 from pypika import Table
 from pypika.functions import Avg as PypikaAvg
+from pypika.functions import Coalesce as PypikaCoalesce
 from pypika.functions import Count as PypikaCount
+from pypika.functions import Length as PypikaLength
 from pypika.functions import Max as PypikaMax
 from pypika.functions import Min as PypikaMin
 from pypika.functions import Sum as PypikaSum
+from pypika.functions import Trim as PypikaTrim
 from pypika.terms import AggregateFunction
 
 from tortoise.exceptions import ConfigurationError
 
 
 class Aggregate:
-    __slots__ = ("field",)
+    __slots__ = ("field", "default_values")
 
     aggregation_func = AggregateFunction
 
-    def __init__(self, field) -> None:
+    def __init__(self, field, *default_values) -> None:
         self.field = field
+        self.default_values = default_values
 
-    def _resolve_field_for_model(self, field: str, model) -> dict:
+    def _resolve_field_for_model(self, model, field: str, *default_values) -> dict:
         field_split = field.split("__")
         if not field_split[1:]:
             aggregation_joins: list = []
@@ -26,11 +30,11 @@ class Aggregate:
                 join = (Table(model._meta.table), field_split[0], related_field)
                 aggregation_joins.append(join)
                 aggregation_field = self.aggregation_func(
-                    Table(related_field.field_type._meta.table).id
+                    Table(related_field.field_type._meta.table).id, *default_values
                 )
             else:
                 aggregation_field = self.aggregation_func(
-                    getattr(Table(model._meta.table), field_split[0])
+                    getattr(Table(model._meta.table), field_split[0]), *default_values
                 )
             return {"joins": aggregation_joins, "field": aggregation_field}
 
@@ -39,13 +43,13 @@ class Aggregate:
         related_field = model._meta.fields_map[field_split[0]]
         join = (Table(model._meta.table), field_split[0], related_field)
         aggregation = self._resolve_field_for_model(
-            "__".join(field_split[1:]), related_field.field_type
+            related_field.field_type, "__".join(field_split[1:]), *default_values
         )
         aggregation["joins"].append(join)
         return aggregation
 
     def resolve(self, model) -> dict:
-        aggregation = self._resolve_field_for_model(self.field, model)
+        aggregation = self._resolve_field_for_model(model, self.field, *self.default_values)
         aggregation["joins"] = reversed(aggregation["joins"])
         return aggregation
 
@@ -68,3 +72,15 @@ class Min(Aggregate):
 
 class Avg(Aggregate):
     aggregation_func = PypikaAvg
+
+
+class Trim(Aggregate):
+    aggregation_func = PypikaTrim
+
+
+class Length(Aggregate):
+    aggregation_func = PypikaLength
+
+
+class Coalesce(Aggregate):
+    aggregation_func = PypikaCoalesce


### PR DESCRIPTION
Add support for filtering via database functions: trim, string-length and coalesce with a non-field type default 

## Description
Solution is implemented by sub-classing the [Aggregate](https://github.com/tortoise/tortoise-orm/blob/0.13.12/tortoise/aggregation.py#L12) class and mapping the appropriate pypika [functions](https://github.com/kayak/pypika/blob/0.9.3/pypika/functions.py#L67). 

### Limitations
In this implementation the second argument in `COALESCE` will be considered a simple value based default and will not resolved to a field. 
This limitation impacts implementation for other functions like `CONCAT` can have many field terms.

## Motivation and Context
Resolves support for #217 

## How Has This Been Tested?
Unit tests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

