### PR TITLE
Provide support for annotations in values

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Enhancements:
   leading to better IDE integration and more comprehensive static analysis.
 - Fetching records from the DB is now up to 25% faster.
 - Database functions added in aggregations ``Trim()``, ``Length()``, ``Coalesce()``.
+- Annotations can be selected inside ``Queryset.values()`` and ``Queryset.values_list()`` expressions.
 
 Bugfixes:
 ^^^^^^^^^


### PR DESCRIPTION
Implements #219 

## Description
- Improves `FieldSelectQuery.add_field_to_select_query` to add annotations to the select query
- Returns annotations columns to the values query

## Motivation and Context
- Values and ValuesList are a great way to get fields as pure data, currently, annotations raise an error when provided.
- fixes #219 

## How Has This Been Tested?
- wrote unit-tests for the annotation aggregation functions
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

