### PR TITLE
Correct SQL code generation for functions in annotations.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,12 +14,13 @@ Enhancements:
 - Models, Fields & QuerySets have significant type annotation improvements,
   leading to better IDE integration and more comprehensive static analysis.
 - Fetching records from the DB is now up to 25% faster.
-- Database functions added in aggregations ``Trim()``, ``Length()``, ``Coalesce()``.
+- Database functions ``Trim()``, ``Length()``, ``Coalesce()`` added to tortoise.functions module.
 - Annotations can be selected inside ``Queryset.values()`` and ``Queryset.values_list()`` expressions.
 
 Bugfixes:
 ^^^^^^^^^
 - The generated index name now has significantly lower chance of collision.
+- The compiled SQL query contains HAVING and GROUP BY only for aggragation functions.
 
 Breaking Changes:
 ^^^^^^^^^^^^^^^^^

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -1,6 +1,7 @@
 from tests.testmodels import Event, IntFields, Reporter, Team, Tournament
-from tortoise.aggregation import Coalesce, Count, Length, Trim
+from tortoise.aggregation import Count
 from tortoise.contrib import test
+from tortoise.functions import Coalesce, Length, Trim
 from tortoise.query_utils import Q
 
 

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -303,6 +303,33 @@ class TestFiltering(test.TestCase):
             {(i.intnum_null, i.clean_intnum_null) for i in ints}, {(None, 0), (10, 10)}
         )
 
+    async def test_filter_by_aggregation_field_comparison_coalesce_numeric(self):
+        await IntFields.create(intnum=3, intnum_null=10)
+        await IntFields.create(intnum=1, intnum_null=4)
+        await IntFields.create(intnum=2)
+
+        ints = await IntFields.annotate(clean_intnum_null=Coalesce("intnum_null", 0)).filter(
+            clean_intnum_null__gt=0
+        )
+        self.assertEqual(len(ints), 2)
+        self.assertSetEqual({i.clean_intnum_null for i in ints}, {10, 4})
+
+    async def test_filter_by_aggregation_field_comparison_length(self):
+        t1 = await Tournament.create(name="Tournament")
+        await Event.create(name="event1", tournament=t1)
+        await Event.create(name="event2", tournament=t1)
+        t2 = await Tournament.create(name="contest")
+        await Event.create(name="event3", tournament=t2)
+        await Tournament.create(name="Championship")
+        t4 = await Tournament.create(name="local")
+        await Event.create(name="event4", tournament=t4)
+        await Event.create(name="event5", tournament=t4)
+        tournaments = await Tournament.annotate(
+            name_len=Length("name"), event_count=Count("events")
+        ).filter(name_len__gt=5, event_count=2)
+        self.assertEqual(len(tournaments), 1)
+        self.assertSetEqual({t.name for t in tournaments}, {"Tournament"})
+
     async def test_values_select_relation(self):
         with self.assertRaises(ValueError):
             tournament = await Tournament.create(name="New Tournament")

--- a/tests/test_values.py
+++ b/tests/test_values.py
@@ -1,7 +1,7 @@
 from tests.testmodels import Event, Team, Tournament
-from tortoise.aggregation import Length, Trim
 from tortoise.contrib import test
 from tortoise.exceptions import FieldError
+from tortoise.functions import Length, Trim
 
 
 class TestValues(test.TestCase):

--- a/tortoise/aggregation.py
+++ b/tortoise/aggregation.py
@@ -1,58 +1,13 @@
-from pypika import Table
+import warnings
+
 from pypika.functions import Avg as PypikaAvg
-from pypika.functions import Coalesce as PypikaCoalesce
 from pypika.functions import Count as PypikaCount
-from pypika.functions import Length as PypikaLength
 from pypika.functions import Max as PypikaMax
 from pypika.functions import Min as PypikaMin
 from pypika.functions import Sum as PypikaSum
-from pypika.functions import Trim as PypikaTrim
 from pypika.terms import AggregateFunction
-from pypika.terms import Function as BaseFunction
 
-from tortoise.exceptions import ConfigurationError
-
-
-class Function:
-    __slots__ = ("field", "default_values")
-
-    database_func = BaseFunction
-
-    def __init__(self, field, *default_values) -> None:
-        self.field = field
-        self.default_values = default_values
-
-    def _resolve_field_for_model(self, model, field: str, *default_values) -> dict:
-        field_split = field.split("__")
-        if not field_split[1:]:
-            function_joins: list = []
-            if field_split[0] in model._meta.fetch_fields:
-                related_field = model._meta.fields_map[field_split[0]]
-                join = (Table(model._meta.table), field_split[0], related_field)
-                function_joins.append(join)
-                function_field = self.database_func(
-                    Table(related_field.field_type._meta.table).id, *default_values
-                )
-            else:
-                function_field = self.database_func(
-                    getattr(Table(model._meta.table), field_split[0]), *default_values
-                )
-            return {"joins": function_joins, "field": function_field}
-
-        if field_split[0] not in model._meta.fetch_fields:
-            raise ConfigurationError(f"{field} not resolvable")
-        related_field = model._meta.fields_map[field_split[0]]
-        join = (Table(model._meta.table), field_split[0], related_field)
-        function = self._resolve_field_for_model(
-            related_field.field_type, "__".join(field_split[1:]), *default_values
-        )
-        function["joins"].append(join)
-        return function
-
-    def resolve(self, model) -> dict:
-        function = self._resolve_field_for_model(model, self.field, *self.default_values)
-        function["joins"] = reversed(function["joins"])
-        return function
+from tortoise.functions import Function
 
 
 class Aggregate(Function):
@@ -75,17 +30,8 @@ class Min(Aggregate):
     database_func = PypikaMin
 
 
-class Avg(Function):
+class Avg(Aggregate):
     database_func = PypikaAvg
 
 
-class Trim(Function):
-    database_func = PypikaTrim
-
-
-class Length(Function):
-    database_func = PypikaLength
-
-
-class Coalesce(Function):
-    database_func = PypikaCoalesce
+warnings.warn("Trim, Length, Coalesce have been moved to tortoise.functions", DeprecationWarning)

--- a/tortoise/functions.py
+++ b/tortoise/functions.py
@@ -1,0 +1,61 @@
+from pypika import Table
+from pypika.functions import Coalesce as PypikaCoalesce
+from pypika.functions import Length as PypikaLength
+from pypika.functions import Trim as PypikaTrim
+from pypika.terms import Function as BaseFunction
+
+from tortoise.exceptions import ConfigurationError
+
+
+class Function:
+    __slots__ = ("field", "default_values")
+
+    database_func = BaseFunction
+
+    def __init__(self, field, *default_values) -> None:
+        self.field = field
+        self.default_values = default_values
+
+    def _resolve_field_for_model(self, model, field: str, *default_values) -> dict:
+        field_split = field.split("__")
+        if not field_split[1:]:
+            function_joins: list = []
+            if field_split[0] in model._meta.fetch_fields:
+                related_field = model._meta.fields_map[field_split[0]]
+                join = (Table(model._meta.table), field_split[0], related_field)
+                function_joins.append(join)
+                function_field = self.database_func(
+                    Table(related_field.field_type._meta.table).id, *default_values
+                )
+            else:
+                function_field = self.database_func(
+                    getattr(Table(model._meta.table), field_split[0]), *default_values
+                )
+            return {"joins": function_joins, "field": function_field}
+
+        if field_split[0] not in model._meta.fetch_fields:
+            raise ConfigurationError(f"{field} not resolvable")
+        related_field = model._meta.fields_map[field_split[0]]
+        join = (Table(model._meta.table), field_split[0], related_field)
+        function = self._resolve_field_for_model(
+            related_field.field_type, "__".join(field_split[1:]), *default_values
+        )
+        function["joins"].append(join)
+        return function
+
+    def resolve(self, model) -> dict:
+        function = self._resolve_field_for_model(model, self.field, *self.default_values)
+        function["joins"] = reversed(function["joins"])
+        return function
+
+
+class Trim(Function):
+    database_func = PypikaTrim
+
+
+class Length(Function):
+    database_func = PypikaLength
+
+
+class Coalesce(Function):
+    database_func = PypikaCoalesce


### PR DESCRIPTION

## Description
- Correct the SQL generation for annotation arguments based on their type.
- Refactor tortoise/aggregation.py module to separate the two annotation types
- Replace ``aggreagation_info`` references to ``annotation_info``

## Motivation and Context
- addresses #223 

## How Has This Been Tested?
- unit tests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

