### PR TITLE
Fix documentation link for functions.

### DIFF
--- a/docs/examples/basic.rst
+++ b/docs/examples/basic.rst
@@ -42,11 +42,11 @@ Transactions
 
 .. rst-class:: html-toggle
 
-.. _example_aggregation:
+.. _example_functions:
 
-Aggregation
-===========
-.. literalinclude::  ../../examples/aggregation.py
+Functions
+=========
+.. literalinclude::  ../../examples/functions.py
 
 
 .. rst-class:: html-toggle


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Documentation link for aggregation is [broken](https://tortoise-orm.readthedocs.io/en/latest/examples/basic.html#aggregation). It refers to renamed file.

## Motivation and Context
- fixes docs to render functions examples


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.


