### PR TITLE
move DB test passwords to env vars, add some test docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,9 +51,9 @@ test: deps
 
 _testall:
 	$(py_warn) TORTOISE_TEST_DB=sqlite://:memory: py.test --cov-report=
-	python -V | grep PyPy || $(py_warn) TORTOISE_TEST_DB=postgres://postgres:@127.0.0.1:5432/test_\{\} py.test --cov-append --cov-report=
-	$(py_warn) TORTOISE_TEST_DB="mysql://root:@127.0.0.1:3306/test_\{\}?storage_engine=MYISAM" py.test --cov-append --cov-report=
-	$(py_warn) TORTOISE_TEST_DB="mysql://root:@127.0.0.1:3306/test_\{\}" py.test --cov-append
+	python -V | grep PyPy || $(py_warn) TORTOISE_TEST_DB=postgres://postgres:$(TORTOISE_POSTGRESS_PASS)@127.0.0.1:5432/test_\{\} py.test --cov-append --cov-report=
+	$(py_warn) TORTOISE_TEST_DB="mysql://root:$(TORTOISE_MYSQL_PASS)@127.0.0.1:3306/test_\{\}?storage_engine=MYISAM" py.test --cov-append --cov-report=
+	$(py_warn) TORTOISE_TEST_DB="mysql:$(TORTOISE_MYSQL_PASS)//root:@127.0.0.1:3306/test_\{\}" py.test --cov-append
 
 testall: deps _testall
 

--- a/docs/CONTRIBUTING.rst
+++ b/docs/CONTRIBUTING.rst
@@ -102,3 +102,15 @@ Tortoise ORM follows a the following agreed upon style:
 * Please try and provide type annotations where you can, it will improve auto-completion in editors, and better static analysis.
 
 
+Running tests
+================
+Running tests natively on windows isn't supported (yet). Best way to run them atm is by using WSL.
+Postrgress uses the default ``postrgress`` user, mysql uses ``root``. If either of them has a password you can set it with the ``TORTOISE_POSTGRESS_PASS`` and ``TORTOISE_MYSQL_PASS`` env variables respectively.
+
+
+Different types of tests
+-----------------------------
+- ``make test``: most basic quick test. only runs the tests on in an memory sqlite database
+- ``make testall``: runs the tests on all 4 database types: sqlite (in memory), postgress, MySQL-MyISAM and MySQL-InnoDB
+- ``green``: runs the same tests as ``make test``, ensures the green plugin works
+- ``nose2 --plugin tortoise.contrib.test.nose2 --db-module tests.testmodels --db-url sqlite://:memory: ``: same test as ``make test`` , ensures the nose2 plugin works


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
when installing postgress on windows it doesn't allow for blank passwords, nor is it currently possible to run the tests on windows

also listed the 4 different test types and what they do

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

