### PR TITLE
Many small performance tweaks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ New features:
     - Enabled by default for databases that support it (mysql and postgres) with a minimum pool size of 1, and a maximum of 5
     - Not supported by sqlite
     - Can be changed by passing the ``minsize`` and ``maxsize`` connection parameters
+- Many small performance tweaks reducing overhead by about ~6%
 
 Deprecations:
 ^^^^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,14 +10,20 @@ New features:
     - Enabled by default for databases that support it (mysql and postgres) with a minimum pool size of 1, and a maximum of 5
     - Not supported by sqlite
     - Can be changed by passing the ``minsize`` and ``maxsize`` connection parameters
-- Many small performance tweaks reducing filter query generation overhead by about ~5%
-- Bulk inserts are ensured to be wrapped in a transaction for >50% speedup
-- PostgreSQL prepared queries now use a LRU cache for significant >2x speedup on inserts/updates/deletes
+- Many small performance tweaks:
+    - Overhead of query generation has been reduced by about 6%
+    - Bulk inserts are ensured to be wrapped in a transaction for >50% speedup
+    - PostgreSQL prepared queries now use a LRU cache for significant >2x speedup on inserts/updates/deletes
 
 Deprecations:
 ^^^^^^^^^^^^^
 - ``start_transaction`` is deprecated, please use ``@atomic()`` or ``async with in_transaction():`` instead.
+- **This release brings with it, deprecation of Python 3.6 / PyPy-3.6:**
 
+  This is due to small differences with how the backported ``aiocontextvars`` behaves
+  in comparison to the built-in in Python 3.7+.
+
+  There is a known context confusion, specifically regarding nested transactions.
 
 0.14.2
 ------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,9 @@ New features:
     - Enabled by default for databases that support it (mysql and postgres) with a minimum pool size of 1, and a maximum of 5
     - Not supported by sqlite
     - Can be changed by passing the ``minsize`` and ``maxsize`` connection parameters
-- Many small performance tweaks reducing overhead by about ~6%
+- Many small performance tweaks reducing filter query generation overhead by about ~5%
+- Bulk inserts are ensured to be wrapped in a transaction for >50% speedup
+- PostgreSQL prepared queries now use a LRU cache for significant >2x speedup on inserts/updates/deletes
 
 Deprecations:
 ^^^^^^^^^^^^^

--- a/tests/test_two_databases.py
+++ b/tests/test_two_databases.py
@@ -31,7 +31,7 @@ class TestTwoDatabases(test.SimpleTestCase):
             await self.db.execute_query("SELECT * FROM eventtwo")
 
         results = await self.second_db.execute_query("SELECT * FROM eventtwo")
-        self.assertEqual(dict(results[0].items()), {"id": 1, "name": "Event", "tournament_id": 1})
+        self.assertEqual(dict(results[0]), {"id": 1, "name": "Event", "tournament_id": 1})
 
     async def test_two_databases_relation(self):
         tournament = await Tournament.create(name="Tournament")
@@ -41,7 +41,7 @@ class TestTwoDatabases(test.SimpleTestCase):
             await self.db.execute_query("SELECT * FROM eventtwo")
 
         results = await self.second_db.execute_query("SELECT * FROM eventtwo")
-        self.assertEqual(dict(results[0].items()), {"id": 1, "name": "Event", "tournament_id": 1})
+        self.assertEqual(dict(results[0]), {"id": 1, "name": "Event", "tournament_id": 1})
 
         teams = []
         for i in range(2):

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -7,6 +7,8 @@ from copy import deepcopy
 from inspect import isclass
 from typing import Any, Coroutine, Dict, List, Optional, Tuple, Type, Union, cast
 
+from pypika import Table
+
 from tortoise import fields
 from tortoise.backends.base.client import BaseDBAsyncClient
 from tortoise.backends.base.config_generator import expand_db_url, generate_config
@@ -466,6 +468,7 @@ class Tortoise:
         for app in cls.apps.values():
             for model in app.values():
                 model._meta.finalise_model()
+                model._meta.basetable = Table(model._meta.table)
                 model._meta.basequery = model._meta.db.query_class.from_(model._meta.table)
                 model._meta.basequery_all_fields = model._meta.basequery.select(
                     *model._meta.db_fields

--- a/tortoise/backends/asyncpg/client.py
+++ b/tortoise/backends/asyncpg/client.py
@@ -148,8 +148,7 @@ class AsyncpgDBClient(BaseDBAsyncClient):
         async with self.acquire_connection() as connection:
             self.log.debug("%s: %s", query, values)
             # TODO: Cache prepared statement
-            stmt = await connection.prepare(query)
-            return await stmt.fetchrow(*values)
+            return await connection.fetchrow(query, *values)
 
     @retry_connection
     async def execute_many(self, query: str, values: list) -> None:
@@ -172,8 +171,7 @@ class AsyncpgDBClient(BaseDBAsyncClient):
             self.log.debug("%s: %s", query, values)
             if values:
                 # TODO: Cache prepared statement
-                stmt = await connection.prepare(query)
-                return await stmt.fetch(*values)
+                return await connection.fetch(query, *values)
             return await connection.fetch(query)
 
     @retry_connection

--- a/tortoise/backends/asyncpg/executor.py
+++ b/tortoise/backends/asyncpg/executor.py
@@ -2,7 +2,7 @@ import uuid
 from typing import List, Optional
 
 import asyncpg
-from pypika import Parameter, Table
+from pypika import Parameter
 
 from tortoise import Model
 from tortoise.backends.base.executor import BaseExecutor
@@ -17,7 +17,7 @@ class AsyncpgExecutor(BaseExecutor):
 
     def _prepare_insert_statement(self, columns: List[str]) -> str:
         query = (
-            self.db.query_class.into(Table(self.model._meta.table))
+            self.db.query_class.into(self.model._meta.basetable)
             .columns(*columns)
             .insert(*[self.Parameter(i) for i in range(len(columns))])
         )

--- a/tortoise/backends/base/executor.py
+++ b/tortoise/backends/base/executor.py
@@ -50,7 +50,7 @@ class BaseExecutor:
                 else:
                     self.column_map[column] = field_object.to_db_value
 
-            table = Table(self.model._meta.table)
+            table = self.model._meta.basetable
             self.delete_query = str(
                 self.model._meta.basequery.where(
                     table[self.model._meta.db_pk_field] == self.Parameter(0)
@@ -110,7 +110,7 @@ class BaseExecutor:
         # Each db has it's own methods for it, so each implementation should
         # go to descendant executors
         return str(
-            self.db.query_class.into(Table(self.model._meta.table))
+            self.db.query_class.into(self.model._meta.basetable)
             .columns(*columns)
             .insert(*[self.Parameter(i) for i in range(len(columns))])
         )
@@ -148,7 +148,7 @@ class BaseExecutor:
         if key in self.update_cache:
             return self.update_cache[key]
 
-        table = Table(self.model._meta.table)
+        table = self.model._meta.basetable
         query = self.db.query_class.update(table)
         count = 0
         for field in update_fields or self.model._meta.fields_db_projection.keys():
@@ -224,7 +224,7 @@ class BaseExecutor:
             .where(through_table[field_object.backward_key].isin(instance_id_set))
         )
 
-        related_query_table = Table(related_query.model._meta.table)
+        related_query_table = related_query.model._meta.basetable
         related_pk_field = related_query.model._meta.db_pk_field
         query = (
             related_query.query.join(subquery)

--- a/tortoise/backends/mysql/client.py
+++ b/tortoise/backends/mysql/client.py
@@ -31,35 +31,27 @@ def retry_connection(func):
     @wraps(func)
     async def retry_connection_(self, *args):
         try:
-            return await func(self, *args)
-        except (
-            RuntimeError,
-            pymysql.err.OperationalError,
-            pymysql.err.InternalError,
-            pymysql.err.InterfaceError,
-        ):
-            # Here we assume that a connection error has happened
-            # Re-create connection and re-try the function call once only.
-            if getattr(self, "_finalized", None) is False:
-                raise TransactionManagementError("Connection gone away during transaction")
-            logging.info("Attempting reconnect")
             try:
-                async with self.acquire_connection() as connection:
-                    await connection.ping()
-                    logging.info("Reconnected")
-            except Exception as e:
-                raise DBConnectionError("Failed to reconnect: %s", str(e))
+                return await func(self, *args)
+            except (
+                RuntimeError,
+                pymysql.err.OperationalError,
+                pymysql.err.InternalError,
+                pymysql.err.InterfaceError,
+            ):
+                # Here we assume that a connection error has happened
+                # Re-create connection and re-try the function call once only.
+                if getattr(self, "_finalized", None) is False:
+                    raise TransactionManagementError("Connection gone away during transaction")
+                logging.info("Attempting reconnect")
+                try:
+                    async with self.acquire_connection() as connection:
+                        await connection.ping()
+                        logging.info("Reconnected")
+                except Exception as e:
+                    raise DBConnectionError("Failed to reconnect: %s", str(e))
 
-            return await func(self, *args)
-
-    return retry_connection_
-
-
-def translate_exceptions(func):
-    @wraps(func)
-    async def translate_exceptions_(self, *args):
-        try:
-            return await func(self, *args)
+                return await func(self, *args)
         except (
             pymysql.err.OperationalError,
             pymysql.err.ProgrammingError,
@@ -71,7 +63,7 @@ def translate_exceptions(func):
         except pymysql.err.IntegrityError as exc:
             raise IntegrityError(exc)
 
-    return translate_exceptions_
+    return retry_connection_
 
 
 class MySQLClient(BaseDBAsyncClient):
@@ -163,7 +155,6 @@ class MySQLClient(BaseDBAsyncClient):
     def _in_transaction(self) -> "TransactionContext":
         return TransactionContextPooled(TransactionWrapper(self))
 
-    @translate_exceptions
     @retry_connection
     async def execute_insert(self, query: str, values: list) -> int:
         async with self.acquire_connection() as connection:
@@ -172,7 +163,6 @@ class MySQLClient(BaseDBAsyncClient):
                 await cursor.execute(query, values)
                 return cursor.lastrowid  # return auto-generated id
 
-    @translate_exceptions
     @retry_connection
     async def execute_many(self, query: str, values: list) -> None:
         async with self.acquire_connection() as connection:
@@ -190,7 +180,6 @@ class MySQLClient(BaseDBAsyncClient):
                 else:
                     await cursor.executemany(query, values)
 
-    @translate_exceptions
     @retry_connection
     async def execute_query(
         self, query: str, values: Optional[list] = None
@@ -201,7 +190,6 @@ class MySQLClient(BaseDBAsyncClient):
                 await cursor.execute(query, values)
                 return await cursor.fetchall()
 
-    @translate_exceptions
     @retry_connection
     async def execute_script(self, query: str) -> None:
         async with self.acquire_connection() as connection:
@@ -229,7 +217,6 @@ class TransactionWrapper(MySQLClient, BaseTransactionWrapper):
     def acquire_connection(self) -> ConnectionWrapper:
         return ConnectionWrapper(self._connection, self._lock)
 
-    @translate_exceptions
     @retry_connection
     async def execute_many(self, query: str, values: list) -> None:
         async with self.acquire_connection() as connection:

--- a/tortoise/functions.py
+++ b/tortoise/functions.py
@@ -1,4 +1,3 @@
-from pypika import Table
 from pypika.functions import Avg as PypikaAvg
 from pypika.functions import Coalesce as PypikaCoalesce
 from pypika.functions import Count as PypikaCount
@@ -34,21 +33,22 @@ class Function:
             function_joins: list = []
             if field_split[0] in model._meta.fetch_fields:
                 related_field = model._meta.fields_map[field_split[0]]
-                join = (Table(model._meta.table), field_split[0], related_field)
+                related_field_meta = related_field.field_type._meta
+                join = (model._meta.basetable, field_split[0], related_field)
                 function_joins.append(join)
                 function_field = self.database_func(
-                    Table(related_field.field_type._meta.table).id, *default_values
+                    related_field_meta.basetable[related_field_meta.db_pk_field], *default_values
                 )
             else:
                 function_field = self.database_func(
-                    getattr(Table(model._meta.table), field_split[0]), *default_values
+                    model._meta.basetable[field_split[0]], *default_values
                 )
             return {"joins": function_joins, "field": function_field}
 
         if field_split[0] not in model._meta.fetch_fields:
             raise ConfigurationError(f"{field} not resolvable")
         related_field = model._meta.fields_map[field_split[0]]
-        join = (Table(model._meta.table), field_split[0], related_field)
+        join = (model._meta.basetable, field_split[0], related_field)
         function = self._resolve_field_for_model(
             related_field.field_type, "__".join(field_split[1:]), *default_values
         )

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -224,6 +224,10 @@ class MetaInfo:
             )
 
     def _generate_db_fields(self) -> None:
+        self.db_default_fields.clear()
+        self.db_complex_fields.clear()
+        self.db_native_fields.clear()
+
         for key in self.db_fields:
             model_field = self.fields_db_projection_reverse[key]
             field = self.fields_map[model_field]

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -2,7 +2,7 @@ from copy import copy, deepcopy
 from functools import partial
 from typing import Any, Dict, Generator, List, Optional, Set, Tuple, Type, TypeVar
 
-from pypika import Query
+from pypika import Query, Table
 
 from tortoise import fields
 from tortoise.backends.base.client import BaseDBAsyncClient
@@ -74,6 +74,7 @@ class MetaInfo:
         "default_connection",
         "basequery",
         "basequery_all_fields",
+        "basetable",
         "_filters",
         "unique_together",
         "indexes",
@@ -109,6 +110,7 @@ class MetaInfo:
         self.default_connection: Optional[str] = None
         self.basequery: Query = Query()
         self.basequery_all_fields: Query = Query()
+        self.basetable: Table = Table("")
         self.pk_attr: str = getattr(meta, "pk_attr", "")
         self.generated_db_fields: Tuple[str] = None  # type: ignore
         self._model: "Model" = None  # type: ignore

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -77,7 +77,7 @@ class AwaitableQuery(QuerySetIterable[MODEL]):
                 self._joined_tables.append(join[0])
 
     def resolve_ordering(self, model, orderings, annotations) -> None:
-        table = Table(model._meta.table)
+        table = model._meta.basetable
         for ordering in orderings:
             field_name = ordering[0]
             if field_name in model._meta.fetch_fields:
@@ -473,7 +473,7 @@ class QuerySet(AwaitableQuery[MODEL]):
     def _resolve_annotate(self) -> None:
         if not self._annotations:
             return
-        table = Table(self.model._meta.table)
+        table = self.model._meta.basetable
         if any(
             annotation.resolve(self.model)["field"].is_aggregate
             for annotation in self._annotations.values()
@@ -544,7 +544,7 @@ class UpdateQuery(AwaitableQuery):
         self._db = db
 
     def _make_query(self) -> None:
-        table = Table(self.model._meta.table)
+        table = self.model._meta.basetable
         self.query = self._db.query_class.update(table)
         self.resolve_filters(
             model=self.model,
@@ -656,7 +656,7 @@ class FieldSelectQuery(AwaitableQuery):
     def _join_table_with_forwarded_fields(
         self, model, field: str, forwarded_fields: str
     ) -> Tuple[Table, str]:
-        table = Table(model._meta.table)
+        table = model._meta.basetable
         if field in model._meta.fields_db_projection and not forwarded_fields:
             return table, model._meta.fields_db_projection[field]
 
@@ -683,7 +683,7 @@ class FieldSelectQuery(AwaitableQuery):
         )
 
     def add_field_to_select_query(self, field, return_as) -> None:
-        table = Table(self.model._meta.table)
+        table = self.model._meta.basetable
         if field in self.model._meta.fields_db_projection:
             db_field = self.model._meta.fields_db_projection[field]
             self.query._select_field(getattr(table, db_field).as_(return_as))


### PR DESCRIPTION
After extending the benchmarks to also test PostgreSQL/MySQL and a profiling+optimizing run I got the following changes in the benchmark suite:
* SQLite is about 6% faster
* PostgreSQL is about 20-30% faster
* MySQL is about 5-15% faster

After all this tweaks, I also compared our mean performance to the best results for each test:
* SQLite is about 71-82% of best
* PostgreSQL is about 84-90% of best
* MySQL is about 50-54% of best

SQLite perf is basically due to known overhead with query creation & SQLAlchemy/Pony doing something smart for updates/deletes.
PostgreSQL perf is surprisingly good, and profiling indicates that the `asyncpg` driver is really fast.
I can't get much more out of MySQL as it is spending the majority of the time in PyMySQL escaping parameters to SQL strings!!! (why???)