### PR TITLE
Fix auto_now_add AttributeError in SQLite backend

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 
 Changelog
 =========
+0.15.2
+------
+- The ``auto_now_add`` argument of ``DatetimeField`` is handled correctly in the SQLite backend.
+
 0.15.1
 ------
 - Handle OR'ing a blank ``Q()`` correctly (#240)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -20,6 +20,7 @@ Contributors
 * Vladimir Urushev ``@pilat``
 * Adam Wallner ``@wallneradam``
 * Zoltán Szeredi ``@zoliszeredi``
+* Rebecca Klauser ``@svms1``
 
 Special Thanks
 ==============

--- a/tortoise/backends/sqlite/executor.py
+++ b/tortoise/backends/sqlite/executor.py
@@ -30,7 +30,7 @@ def to_db_datetime(self, value: Optional[datetime.datetime], instance) -> Option
         value = datetime.datetime.utcnow()
         setattr(instance, self.model_field_name, value)
         return value.isoformat(" ")
-    if self.auto_now_add and getattr(instance, self.model_field_name) is None:
+    if self.auto_now_add and getattr(instance, self.model_field_name, None) is None:
         value = datetime.datetime.utcnow()
         setattr(instance, self.model_field_name, value)
         return value.isoformat(" ")


### PR DESCRIPTION
The SQLite backend contains a bug if the `auto_now_add` argument is used with a `DatetimeField`. Since `getattr` raises an `AttributeError` if the attribute doesn't exist, the attribute is never actually set. I fixed this by setting the `default` argument of `getattr` to `None`, which results in the desired behavior.



