### PR TITLE
Check whether charset name is available

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 
 Changelog
 =========
+Unreleased
+------
+- Check whether charset name is available
+
 0.15.4
 ------
 - Don't generate a schema if there is no models (#254)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -22,6 +22,7 @@ Contributors
 * Zoltán Szeredi ``@zoliszeredi``
 * Rebecca Klauser ``@svms1``
 * Sina Sohangir ``@sinaso``
+* Weiming Dong ``@dongweiming``
 
 Special Thanks
 ==============

--- a/tortoise/backends/mysql/client.py
+++ b/tortoise/backends/mysql/client.py
@@ -4,6 +4,7 @@ from typing import List, Optional, SupportsInt, Union
 
 import aiomysql
 import pymysql
+from pymysql.charset import charset_by_name
 from pypika import MySQLQuery
 
 from tortoise.backends.base.client import (
@@ -76,6 +77,8 @@ class MySQLClient(BaseDBAsyncClient):
         self._connection = None
 
     async def create_connection(self, with_db: bool) -> None:
+        if charset_by_name(self.charset) is None:  # type: ignore
+            raise DBConnectionError(f"Unknown charset {self.charset}")
         self._template = {
             "host": self.host,
             "port": self.port,


### PR DESCRIPTION
If i use an unsupported or wrong charset name, an error will be reported:

```python
...
  File "/Users/dongwm/tortoise-orm/tortoise/backends/mysql/client.py", line 91, in create_connection
    self._pool = await aiomysql.create_pool(password=self.password, **self._template)
  File "/Users/dongwm/lyanna/venv/lib/python3.7/site-packages/aiomysql/pool.py", line 29, in _create_pool
    await pool._fill_free_pool(False)
  File "/Users/dongwm/lyanna/venv/lib/python3.7/site-packages/aiomysql/pool.py", line 168, in _fill_free_pool
    **self._conn_kwargs)
  File "/Users/dongwm/lyanna/venv/lib/python3.7/site-packages/aiomysql/connection.py", line 74, in _connect
    conn = Connection(*args, **kwargs)
  File "/Users/dongwm/lyanna/venv/lib/python3.7/site-packages/aiomysql/connection.py", line 206, in __init__
    self._encoding = charset_by_name(self._charset).encoding
AttributeError: 'NoneType' object has no attribute 'encoding'
Exception ignored in: <function Connection.__del__ at 0x10cb2bb70>
Traceback (most recent call last):
  File "/Users/dongwm/lyanna/venv/lib/python3.7/site-packages/aiomysql/connection.py", line 1069, in __del__
AttributeError: 'Connection' object has no attribute '_writer'
```
it is very strange, if tortoise check the charset name will be more explicit:

```python
  File "/Users/dongwm/tortoise-orm/tortoise/__init__.py", line 643, in init
    await cls._init_connections(connections_config, _create_db)
  File "/Users/dongwm/tortoise-orm/tortoise/__init__.py", line 483, in _init_connections
    connection = client_class(**db_params)  # type: ignore
  File "/Users/dongwm/tortoise-orm/tortoise/backends/mysql/client.py", line 82, in __init__
    raise FieldError(f"Unknown charset {self.charset}")
tortoise.exceptions.FieldError: Unknown charset utf-8
```