### PR TITLE
Fix SQL for multiple FK links to same model

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 
 Changelog
 =========
+0.15.9
+------
+- Alias Foreign Key joins as we can have both self-referencing and duplicate joins to the same table.
+  This generates SQL that differentiates between which instance of the table to work with.
+
 0.15.8
 ------
 - ``TextField`` now recommends usage of ``CharField`` if wanting unique indexing instead of just saying "indexing not supported"

--- a/tests/test_q.py
+++ b/tests/test_q.py
@@ -96,57 +96,57 @@ class TestQ(_TestCase):
 class TestQCall(TestCase):
     def test_q_basic(self):
         q = Q(id=8)
-        r = q.resolve(IntFields, {}, {})
+        r = q.resolve(IntFields, {}, {}, IntFields._meta.basequery)
         self.assertEqual(r.where_criterion.get_sql(), '"id"=8')
 
     def test_q_basic_and(self):
         q = Q(join_type="AND", id=8)
-        r = q.resolve(IntFields, {}, {})
+        r = q.resolve(IntFields, {}, {}, IntFields._meta.basequery)
         self.assertEqual(r.where_criterion.get_sql(), '"id"=8')
 
     def test_q_basic_or(self):
         q = Q(join_type="OR", id=8)
-        r = q.resolve(IntFields, {}, {})
+        r = q.resolve(IntFields, {}, {}, IntFields._meta.basequery)
         self.assertEqual(r.where_criterion.get_sql(), '"id"=8')
 
     def test_q_multiple_and(self):
         q = Q(join_type="AND", id__gt=8, id__lt=10)
-        r = q.resolve(IntFields, {}, {})
+        r = q.resolve(IntFields, {}, {}, IntFields._meta.basequery)
         self.assertEqual(r.where_criterion.get_sql(), '"id">8 AND "id"<10')
 
     def test_q_multiple_or(self):
         q = Q(join_type="OR", id__gt=8, id__lt=10)
-        r = q.resolve(IntFields, {}, {})
+        r = q.resolve(IntFields, {}, {}, IntFields._meta.basequery)
         self.assertEqual(r.where_criterion.get_sql(), '"id">8 OR "id"<10')
 
     def test_q_multiple_and2(self):
         q = Q(join_type="AND", id=8, intnum=80)
-        r = q.resolve(IntFields, {}, {})
+        r = q.resolve(IntFields, {}, {}, IntFields._meta.basequery)
         self.assertEqual(r.where_criterion.get_sql(), '"id"=8 AND "intnum"=80')
 
     def test_q_multiple_or2(self):
         q = Q(join_type="OR", id=8, intnum=80)
-        r = q.resolve(IntFields, {}, {})
+        r = q.resolve(IntFields, {}, {}, IntFields._meta.basequery)
         self.assertEqual(r.where_criterion.get_sql(), '"id"=8 OR "intnum"=80')
 
     def test_q_complex_int(self):
         q = Q(Q(intnum=80), Q(id__lt=5, id__gt=50, join_type="OR"), join_type="AND")
-        r = q.resolve(IntFields, {}, {})
+        r = q.resolve(IntFields, {}, {}, IntFields._meta.basequery)
         self.assertEqual(r.where_criterion.get_sql(), '"intnum"=80 AND ("id"<5 OR "id">50)')
 
     def test_q_complex_int2(self):
         q = Q(Q(intnum="80"), Q(Q(id__lt="5"), Q(id__gt="50"), join_type="OR"), join_type="AND")
-        r = q.resolve(IntFields, {}, {})
+        r = q.resolve(IntFields, {}, {}, IntFields._meta.basequery)
         self.assertEqual(r.where_criterion.get_sql(), '"intnum"=80 AND ("id"<5 OR "id">50)')
 
     def test_q_complex_int3(self):
         q = Q(Q(id__lt=5, id__gt=50, join_type="OR"), join_type="AND", intnum=80)
-        r = q.resolve(IntFields, {}, {})
+        r = q.resolve(IntFields, {}, {}, IntFields._meta.basequery)
         self.assertEqual(r.where_criterion.get_sql(), '"intnum"=80 AND ("id"<5 OR "id">50)')
 
     def test_q_complex_char(self):
         q = Q(Q(char_null=80), ~Q(char__lt=5, char__gt=50, join_type="OR"), join_type="AND")
-        r = q.resolve(CharFields, {}, {})
+        r = q.resolve(CharFields, {}, {}, CharFields._meta.basequery)
         self.assertEqual(
             r.where_criterion.get_sql(),
             "\"char_null\"='80' AND NOT (\"char\"<'5' OR \"char\">'50')",
@@ -158,7 +158,7 @@ class TestQCall(TestCase):
             ~Q(Q(char__lt="5"), Q(char__gt="50"), join_type="OR"),
             join_type="AND",
         )
-        r = q.resolve(CharFields, {}, {})
+        r = q.resolve(CharFields, {}, {}, CharFields._meta.basequery)
         self.assertEqual(
             r.where_criterion.get_sql(),
             "\"char_null\"='80' AND NOT (\"char\"<'5' OR \"char\">'50')",
@@ -166,7 +166,7 @@ class TestQCall(TestCase):
 
     def test_q_complex_char3(self):
         q = Q(~Q(char__lt=5, char__gt=50, join_type="OR"), join_type="AND", char_null=80)
-        r = q.resolve(CharFields, {}, {})
+        r = q.resolve(CharFields, {}, {}, CharFields._meta.basequery)
         self.assertEqual(
             r.where_criterion.get_sql(),
             "\"char_null\"='80' AND NOT (\"char\"<'5' OR \"char\">'50')",
@@ -174,30 +174,30 @@ class TestQCall(TestCase):
 
     def test_q_with_blank_and(self):
         q = Q(Q(id__gt=5), Q(), join_type=Q.AND)
-        r = q.resolve(CharFields, {}, {})
+        r = q.resolve(CharFields, {}, {}, CharFields._meta.basequery)
         self.assertEqual(r.where_criterion.get_sql(), '"id">5')
 
     def test_q_with_blank_or(self):
         q = Q(Q(id__gt=5), Q(), join_type=Q.OR)
-        r = q.resolve(CharFields, {}, {})
+        r = q.resolve(CharFields, {}, {}, CharFields._meta.basequery)
         self.assertEqual(r.where_criterion.get_sql(), '"id">5')
 
     def test_q_with_blank_and2(self):
         q = Q(id__gt=5) & Q()
-        r = q.resolve(CharFields, {}, {})
+        r = q.resolve(CharFields, {}, {}, CharFields._meta.basequery)
         self.assertEqual(r.where_criterion.get_sql(), '"id">5')
 
     def test_q_with_blank_or2(self):
         q = Q(id__gt=5) | Q()
-        r = q.resolve(CharFields, {}, {})
+        r = q.resolve(CharFields, {}, {}, CharFields._meta.basequery)
         self.assertEqual(r.where_criterion.get_sql(), '"id">5')
 
     def test_q_with_blank_and3(self):
         q = Q() & Q(id__gt=5)
-        r = q.resolve(CharFields, {}, {})
+        r = q.resolve(CharFields, {}, {}, CharFields._meta.basequery)
         self.assertEqual(r.where_criterion.get_sql(), '"id">5')
 
     def test_q_with_blank_or3(self):
         q = Q() | Q(id__gt=5)
-        r = q.resolve(CharFields, {}, {})
+        r = q.resolve(CharFields, {}, {}, CharFields._meta.basequery)
         self.assertEqual(r.where_criterion.get_sql(), '"id">5')

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -246,15 +246,15 @@ class TestRelations(test.TestCase):
 
 class TestDoubleFK(test.TestCase):
     select_match = r'SELECT [`"]doublefk[`"].[`"]name[`"] [`"]name[`"]'
-    select1_match = r'SELECT [`"]doublefk2[`"].[`"]name[`"] [`"]left__name[`"]'
-    select2_match = r'SELECT [`"]doublefk3[`"].[`"]name[`"] [`"]right__name[`"]'
+    select1_match = r'[`"]doublefk__left[`"].[`"]name[`"] [`"]left__name[`"]'
+    select2_match = r'[`"]doublefk__right[`"].[`"]name[`"] [`"]right__name[`"]'
     join1_match = (
-        r'LEFT OUTER JOIN [`"]doublefk[`"] [`"]doublefk2[`"] ON '
-        r'[`"]doublefk[`"].[`"]id[`"]=[`"]doublefk2[`"].[`"]left_id[`"]'
+        r'LEFT OUTER JOIN [`"]doublefk[`"] [`"]doublefk__left[`"] ON '
+        r'[`"]doublefk__left[`"].[`"]id[`"]=[`"]doublefk[`"].[`"]left_id[`"]'
     )
     join2_match = (
-        r'LEFT OUTER JOIN [`"]doublefk[`"] [`"]doublefk3[`"] ON '
-        r'[`"]doublefk[`"].[`"]id[`"]=[`"]doublefk3[`"].[`"]right_id[`"]'
+        r'LEFT OUTER JOIN [`"]doublefk[`"] [`"]doublefk__right[`"] ON '
+        r'[`"]doublefk__right[`"].[`"]id[`"]=[`"]doublefk[`"].[`"]right_id[`"]'
     )
 
     async def setUp(self) -> None:
@@ -266,9 +266,7 @@ class TestDoubleFK(test.TestCase):
         qset = DoubleFK.filter(left__name="one")
         result = await qset
         query = qset.query.get_sql()
-        print(query)
 
-        self.assertRegex(query, self.select_match)
         self.assertRegex(query, self.join1_match)
         self.assertEqual(result, [self.middle])
 
@@ -276,7 +274,6 @@ class TestDoubleFK(test.TestCase):
         qset = DoubleFK.filter(left__name="one").values("name")
         result = await qset
         query = qset.query.get_sql()
-        print(query)
 
         self.assertRegex(query, self.select_match)
         self.assertRegex(query, self.join1_match)
@@ -286,7 +283,6 @@ class TestDoubleFK(test.TestCase):
         qset = DoubleFK.filter(left__name="one").values("name", "left__name")
         result = await qset
         query = qset.query.get_sql()
-        print(query)
 
         self.assertRegex(query, self.select_match)
         self.assertRegex(query, self.select1_match)
@@ -297,9 +293,7 @@ class TestDoubleFK(test.TestCase):
         qset = DoubleFK.filter(left__name="one", right__name="two")
         result = await qset
         query = qset.query.get_sql()
-        print(query)
 
-        self.assertRegex(query, self.select_match)
         self.assertRegex(query, self.join1_match)
         self.assertRegex(query, self.join2_match)
         self.assertEqual(result, [self.middle])
@@ -308,7 +302,6 @@ class TestDoubleFK(test.TestCase):
         qset = DoubleFK.filter(left__name="one", right__name="two").values("name")
         result = await qset
         query = qset.query.get_sql()
-        print(query)
 
         self.assertRegex(query, self.select_match)
         self.assertRegex(query, self.join1_match)
@@ -321,7 +314,6 @@ class TestDoubleFK(test.TestCase):
         )
         result = await qset
         query = qset.query.get_sql()
-        print(query)
 
         self.assertRegex(query, self.select_match)
         self.assertRegex(query, self.select1_match)

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -1,4 +1,4 @@
-from tests.testmodels import Address, Employee, Event, Reporter, Team, Tournament
+from tests.testmodels import Address, DoubleFK, Employee, Event, Reporter, Team, Tournament
 from tortoise.contrib import test
 from tortoise.exceptions import FieldError, NoValuesFetched
 from tortoise.functions import Count
@@ -242,3 +242,62 @@ class TestRelations(test.TestCase):
 
         self.assertFalse(event1.reporter)
         self.assertTrue(event2.reporter)
+
+
+class TestDoubleFK(test.TestCase):
+    select_match = r'SELECT [`"]doublefk[`"].[`"]name[`"]'
+    join1_match = (
+        r'LEFT OUTER JOIN [`"]doublefk[`"] [`"]doublefk2[`"] ON '
+        r'[`"]doublefk[`"].[`"]id[`"]=[`"]doublefk2[`"].[`"]left_id[`"]'
+    )
+    join2_match = (
+        r'LEFT OUTER JOIN [`"]doublefk[`"] [`"]doublefk3[`"] ON '
+        r'[`"]doublefk[`"].[`"]id[`"]=[`"]doublefk3[`"].[`"]right_id[`"]'
+    )
+
+    async def setUp(self) -> None:
+        one = await DoubleFK.create(name="one")
+        two = await DoubleFK.create(name="two")
+        self.middle = await DoubleFK.create(name="middle", left=one, right=two)
+
+    async def test_doublefk_filter(self):
+        qset = DoubleFK.filter(left__name="one")
+        result = await qset
+        query = qset.query.get_sql()
+        print(query)
+
+        self.assertRegex(query, self.select_match)
+        self.assertRegex(query, self.join1_match)
+        self.assertEqual(result, [self.middle])
+
+    async def test_doublefk_filter_values(self):
+        qset = DoubleFK.filter(left__name="one").values("name")
+        result = await qset
+        query = qset.query.get_sql()
+        print(query)
+
+        self.assertRegex(query, self.select_match)
+        self.assertRegex(query, self.join1_match)
+        self.assertEqual(result, [{"name": "middle"}])
+
+    async def test_doublefk_filter_both(self):
+        qset = DoubleFK.filter(left__name="one", right__name="two")
+        result = await qset
+        query = qset.query.get_sql()
+        print(query)
+
+        self.assertRegex(query, self.select_match)
+        self.assertRegex(query, self.join1_match)
+        self.assertRegex(query, self.join2_match)
+        self.assertEqual(result, [self.middle])
+
+    async def test_doublefk_filter_both_values(self):
+        qset = DoubleFK.filter(left__name="one", right__name="two").values("name")
+        result = await qset
+        query = qset.query.get_sql()
+        print(query)
+
+        self.assertRegex(query, self.select_match)
+        self.assertRegex(query, self.join1_match)
+        self.assertRegex(query, self.join2_match)
+        self.assertEqual(result, [{"name": "middle"}])

--- a/tests/testmodels.py
+++ b/tests/testmodels.py
@@ -508,3 +508,9 @@ class Currency(str, Enum):
 class EnumFields(Model):
     service: Service = fields.IntEnumField(Service)
     currency: Currency = fields.CharEnumField(Currency, default=Currency.HUF)
+
+
+class DoubleFK(Model):
+    name = fields.CharField(max_length=50)
+    left = fields.ForeignKeyField("models.DoubleFK", null=True, related_name="left_rel")
+    right = fields.ForeignKeyField("models.DoubleFK", null=True, related_name="right_rel")

--- a/tortoise/backends/base/executor.py
+++ b/tortoise/backends/base/executor.py
@@ -291,6 +291,7 @@ class BaseExecutor:
                     model=related_query.model,
                     annotations=related_query._annotations,
                     custom_filters=related_query._custom_filters,
+                    table=related_query_table,
                 )
 
             where_criterion, joins, having_criterion = modifier.get_query_modifiers()


### PR DESCRIPTION
Fixes #275

Pass around table object so we can keep track of if table is aliased. Also alias all FK joins as they can have both self references, and duplicate references

Done:
- [x] Replicate the issues in test suite
- [x] Fix selecting from wrong alias on root table when using `.values()`
- [x] Fix selecting from wrong alias on join tables when using `.values()` 
- [x] Fix joining to wrong alias for self-referential join
- [x] Fix skipping join to second join table
- [x] Fix aggregates/functions to resolve the correct alias name
