### PR TITLE
Support FK's to unique key.

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -24,6 +24,7 @@ Contributors
 * Sina Sohangir ``@sinaso``
 * Weiming Dong ``@dongweiming``
 * Jinlong Peng ``@long2ice``
+* Sang-Heon Jeon ``@lntuition``
 
 Special Thanks
 ==============

--- a/docs/examples/basic.rst
+++ b/docs/examples/basic.rst
@@ -89,6 +89,15 @@ Relations
 
 .. _example_relations_recursive:
 
+Relations with Unique field
+=========
+.. literalinclude::  ../../examples/relations_with_unique.py
+
+
+.. rst-class:: html-toggle
+
+.. _example_relations_with_unique:
+
 Recursive Relations
 ===================
 .. literalinclude::  ../../examples/relations_recursive.py

--- a/examples/relations_with_unique.py
+++ b/examples/relations_with_unique.py
@@ -1,0 +1,43 @@
+"""
+This example shows how relations between models work.
+
+Key points in this example are use of ForeignKeyField and ManyToManyField
+to declare relations and use of .prefetch_related() and .fetch_related()
+to get this related objects
+"""
+from tortoise import Tortoise, fields, run_async
+from tortoise.models import Model
+
+
+class Tournament(Model):
+    id = fields.IntField(uk=True)
+    name = fields.CharField(max_length=100, pk=True)
+
+    events: fields.ReverseRelation["Event"]
+
+    def __str__(self):
+        return self.name
+
+
+class Event(Model):
+    id = fields.IntField(pk=True)
+    name = fields.TextField()
+    tournament: fields.ForeignKeyRelation[Tournament] = fields.ForeignKeyField(
+        "models.Tournament", related_name="events", to_field="name",
+    )
+
+    def __str__(self):
+        return self.name
+
+
+async def run():
+    await Tortoise.init(db_url="sqlite://:memory:", modules={"models": ["__main__"]})
+    await Tortoise.generate_schemas()
+
+    tournament = Tournament(id=1, name="New Tournament")
+    await tournament.save()
+    await Event(name="Without participants", tournament_id=tournament.name).save()
+
+
+if __name__ == "__main__":
+    run_async(run())

--- a/examples/relations_with_unique.py
+++ b/examples/relations_with_unique.py
@@ -8,6 +8,7 @@ to get this related objects
 import logging
 
 from tortoise import Tortoise, fields, run_async
+from tortoise.functions import Count
 from tortoise.models import Model
 
 logging.basicConfig(level=logging.DEBUG)
@@ -25,7 +26,7 @@ class Student(Model):
     id = fields.IntField(pk=True)
     name = fields.TextField()
     school: fields.ForeignKeyRelation[School] = fields.ForeignKeyField(
-        "models.School", related_name="students", to_field="id",
+        "models.School", related_name="students", to_field="id"
     )
 
 
@@ -34,10 +35,13 @@ async def run():
     await Tortoise.generate_schemas()
 
     school = await School.create(id=1024, name="School")
-    student = await Student.create(name="Sang-Heon Jeon", school=school)
+    student1 = await Student.create(name="Sang-Heon Jeon1", school=school)
+    student2 = await Student.create(name="Sang-Heon Jeon2", school_id=school.id)
 
-    student = await Student.get(id=student.id)
-    print(await student.school)
+    await School.filter(students__id=student1.id).values("id", "name", student="students__name")
+    await Student.filter(id=student2.id).values("id", "name", school="school__name")
+    queryset = School.all().annotate(count=Count("students"))
+    await queryset.filter(name="School").first()
 
 
 if __name__ == "__main__":

--- a/examples/relations_with_unique.py
+++ b/examples/relations_with_unique.py
@@ -33,7 +33,7 @@ async def run():
 
     company = Company(id=1, name="First Company")
     await company.save()
-    # await Employee(name="Sang-Heon Jeon", company_id=company.uuid).save()
+    await Employee(name="Sang-Heon Jeon", company_id=company.uuid).save()
 
 
 if __name__ == "__main__":

--- a/examples/relations_with_unique.py
+++ b/examples/relations_with_unique.py
@@ -1,17 +1,12 @@
 """
-This example shows how relations between models work.
+This example shows how relations between models especially unique field work.
 
-Key points in this example are use of ForeignKeyField and ManyToManyField
-to declare relations and use of .prefetch_related() and .fetch_related()
-to get this related objects
+Key points in this example are use of ForeignKeyField and OneToOneField has to_field.
+For other basic parts, it is the same as relation exmaple.
 """
-import logging
-
 from tortoise import Tortoise, fields, run_async
-from tortoise.functions import Count
 from tortoise.models import Model
-
-logging.basicConfig(level=logging.DEBUG)
+from tortoise.query_utils import Prefetch
 
 
 class School(Model):
@@ -20,6 +15,7 @@ class School(Model):
     id = fields.IntField(unique=True)
 
     students: fields.ReverseRelation["Student"]
+    principal: fields.ReverseRelation["Principal"]
 
 
 class Student(Model):
@@ -30,18 +26,47 @@ class Student(Model):
     )
 
 
+class Principal(Model):
+    id = fields.IntField(pk=True)
+    name = fields.TextField()
+    school: fields.OneToOneRelation[School] = fields.OneToOneField(
+        "models.School", on_delete=fields.CASCADE, related_name="principal", to_field="id"
+    )
+
+
 async def run():
     await Tortoise.init(db_url="sqlite://:memory:", modules={"models": ["__main__"]})
     await Tortoise.generate_schemas()
 
-    school = await School.create(id=1024, name="School")
-    student1 = await Student.create(name="Sang-Heon Jeon1", school=school)
-    student2 = await Student.create(name="Sang-Heon Jeon2", school_id=school.id)
+    school1 = await School.create(id=1024, name="School1")
+    student1 = await Student.create(name="Sang-Heon Jeon1", school_id=school1.id)
 
-    await School.filter(students__id=student1.id).values("id", "name", student="students__name")
-    await Student.filter(id=student2.id).values("id", "name", school="school__name")
-    queryset = School.all().annotate(count=Count("students"))
-    await queryset.filter(name="School").first()
+    student_schools = await Student.filter(name="Sang-Heon Jeon1").values("name", "school__name")
+    print(student_schools[0])
+
+    await Student.create(name="Sang-Heon Jeon2", school=school1)
+    school_with_filtered = (
+        await School.all()
+        .prefetch_related(Prefetch("students", queryset=Student.filter(name="Sang-Heon Jeon1")))
+        .first()
+    )
+    school_without_filtered = await School.first().prefetch_related("students")
+    print(len(school_with_filtered.students))
+    print(len(school_without_filtered.students))
+
+    school2 = await School.create(id=2048, name="School2")
+    await Student.all().update(school=school2)
+    student = await Student.first()
+    print(student.school_id)
+
+    await Student.filter(id=student1.id).update(school=school1)
+    schools = await School.all().order_by("students__name")
+    print([school.name for school in schools])
+
+    fetched_principal = await Principal.create(name="Sang-Heon Jeon3", school=school1)
+    print(fetched_principal.name)
+    fetched_school = await School.filter(name="School1").prefetch_related("principal").first()
+    print(fetched_school.name)
 
 
 if __name__ == "__main__":

--- a/examples/relations_with_unique.py
+++ b/examples/relations_with_unique.py
@@ -5,25 +5,38 @@ Key points in this example are use of ForeignKeyField and ManyToManyField
 to declare relations and use of .prefetch_related() and .fetch_related()
 to get this related objects
 """
-from uuid import uuid4
+import logging
 
 from tortoise import Tortoise, fields, run_async
 from tortoise.models import Model
 
+logging.basicConfig(level=logging.DEBUG)
 
-class Company(Model):
+
+class School(Model):
+    uuid = fields.UUIDField(pk=True)
+    name = fields.TextField()
+    id = fields.IntField(unique=True)
+
+    students: fields.ReverseRelation["Student"]
+
+
+class Club(Model):
+    uuid = fields.UUIDField(pk=True)
+    name = fields.TextField()
+    club_id = fields.IntField(unique=True, source_field="club")
+
+    students: fields.ReverseRelation["Student"]
+
+
+class Student(Model):
     id = fields.IntField(pk=True)
     name = fields.TextField()
-    uuid = fields.UUIDField(unique=True, default=uuid4)
-
-    employees: fields.ReverseRelation["Employee"]
-
-
-class Employee(Model):
-    id = fields.IntField(pk=True)
-    name = fields.TextField()
-    company: fields.ForeignKeyRelation[Company] = fields.ForeignKeyField(
-        "models.Company", related_name="employees", to_field="uuid",
+    school: fields.ForeignKeyRelation[School] = fields.ForeignKeyField(
+        "models.School", related_name="students", to_field="id",
+    )
+    club: fields.ForeignKeyRelation[Club] = fields.ForeignKeyField(
+        "models.Club", related_name="students", to_field="club_id",
     )
 
 
@@ -31,9 +44,13 @@ async def run():
     await Tortoise.init(db_url="sqlite://:memory:", modules={"models": ["__main__"]})
     await Tortoise.generate_schemas()
 
-    company = Company(id=1, name="First Company")
-    await company.save()
-    await Employee(name="Sang-Heon Jeon", company_id=company.uuid).save()
+    school = await School.create(id=1024, name="School")
+    club = await Club.create(club_id=128, name="Club")
+    student = await Student.create(name="Sang-Heon Jeon", school=school, club=club)
+    await student.fetch_related("school", "club")
+    print(student.school == school)
+    print(student.club == club)
+    print((await school.students.all())[0] == student)
 
 
 if __name__ == "__main__":

--- a/examples/relations_with_unique.py
+++ b/examples/relations_with_unique.py
@@ -21,22 +21,11 @@ class School(Model):
     students: fields.ReverseRelation["Student"]
 
 
-class Club(Model):
-    uuid = fields.UUIDField(pk=True)
-    name = fields.TextField()
-    club_id = fields.IntField(unique=True, source_field="club")
-
-    students: fields.ReverseRelation["Student"]
-
-
 class Student(Model):
     id = fields.IntField(pk=True)
     name = fields.TextField()
     school: fields.ForeignKeyRelation[School] = fields.ForeignKeyField(
         "models.School", related_name="students", to_field="id",
-    )
-    club: fields.ForeignKeyRelation[Club] = fields.ForeignKeyField(
-        "models.Club", related_name="students", to_field="club_id",
     )
 
 
@@ -45,12 +34,10 @@ async def run():
     await Tortoise.generate_schemas()
 
     school = await School.create(id=1024, name="School")
-    club = await Club.create(club_id=128, name="Club")
-    student = await Student.create(name="Sang-Heon Jeon", school=school, club=club)
-    await student.fetch_related("school", "club")
-    print(student.school == school)
-    print(student.club == club)
-    print((await school.students.all())[0] == student)
+    student = await Student.create(name="Sang-Heon Jeon", school=school)
+
+    student = await Student.get(id=student.id)
+    print(await student.school)
 
 
 if __name__ == "__main__":

--- a/tests/fields/test_fk_with_unique.py
+++ b/tests/fields/test_fk_with_unique.py
@@ -1,6 +1,5 @@
 from tests import testmodels
 from tortoise.contrib import test
-from tortoise.exceptions import IntegrityError, NoValuesFetched, OperationalError
 from tortoise.queryset import QuerySet
 
 
@@ -43,3 +42,28 @@ class TestForeignKeyFieldWithUnique(test.TestCase):
         student = await testmodels.Student.get(id=student.id)
         self.assertEqual(await student.school, school)
         self.assertEqual((await school.students.all())[0], student)
+
+    async def test_update_by_name(self):
+        school = await testmodels.School.create(id=1024, name="School1")
+        school2 = await testmodels.School.create(id=2048, name="School2")
+        student0 = await testmodels.Student.create(name="Sang-Heon Jeon", school=school)
+
+        await testmodels.Student.filter(id=student0.id).update(school=school2)
+        student = await testmodels.Student.get(id=student0.id)
+
+        await student.fetch_related("school")
+        self.assertEqual(student.school, school2)
+        self.assertEqual(await school.students.all(), [])
+        self.assertEqual((await school2.students.all())[0], student)
+
+    async def test_update_by_id(self):
+        school = await testmodels.School.create(id=1024, name="School1")
+        school2 = await testmodels.School.create(id=2048, name="School2")
+        student0 = await testmodels.Student.create(name="Sang-Heon Jeon", school_id=school.id)
+
+        await testmodels.Student.filter(id=student0.id).update(school_id=school2.id)
+        student = await testmodels.Student.get(id=student0.id)
+
+        self.assertEqual(student.school_id, school2.id)
+        self.assertEqual(await school.students.all(), [])
+        self.assertEqual((await school2.students.all())[0], student)

--- a/tests/fields/test_fk_with_unique.py
+++ b/tests/fields/test_fk_with_unique.py
@@ -1,43 +1,44 @@
 from tests import testmodels
 from tortoise.contrib import test
+from tortoise.exceptions import NoValuesFetched, OperationalError
 from tortoise.queryset import QuerySet
 
 
 class TestForeignKeyFieldWithUnique(test.TestCase):
     async def test_student__create_by_id(self):
-        school = await testmodels.School.create(id=1024, name="School")
+        school = await testmodels.School.create(id=1024, name="School1")
         student = await testmodels.Student.create(name="Sang-Heon Jeon", school_id=school.id)
         self.assertEqual(student.school_id, school.id)
         self.assertEqual((await school.students.all())[0], student)
 
     async def test_student__create_by_name(self):
-        school = await testmodels.School.create(id=1024, name="School")
+        school = await testmodels.School.create(id=1024, name="School1")
         student = await testmodels.Student.create(name="Sang-Heon Jeon", school=school)
         await student.fetch_related("school")
         self.assertEqual(student.school, school)
         self.assertEqual((await school.students.all())[0], student)
 
     async def test_student__by_name__created_prefetched(self):
-        school = await testmodels.School.create(id=1024, name="School")
+        school = await testmodels.School.create(id=1024, name="School1")
         student = await testmodels.Student.create(name="Sang-Heon Jeon", school=school)
         self.assertEqual(student.school, school)
         self.assertEqual((await school.students.all())[0], student)
 
     async def test_student__by_name__unfetched(self):
-        school = await testmodels.School.create(id=1024, name="School")
+        school = await testmodels.School.create(id=1024, name="School1")
         student = await testmodels.Student.create(name="Sang-Heon Jeon", school=school)
         student = await testmodels.Student.get(id=student.id)
         self.assertIsInstance(student.school, QuerySet)
 
     async def test_student__by_name__re_awaited(self):
-        school = await testmodels.School.create(id=1024, name="School")
+        school = await testmodels.School.create(id=1024, name="School1")
         student = await testmodels.Student.create(name="Sang-Heon Jeon", school=school)
         await student.fetch_related("school")
         self.assertEqual(student.school, school)
         self.assertEqual(await student.school, school)
 
     async def test_student__by_name__awaited(self):
-        school = await testmodels.School.create(id=1024, name="School")
+        school = await testmodels.School.create(id=1024, name="School1")
         student = await testmodels.Student.create(name="Sang-Heon Jeon", school=school)
         student = await testmodels.Student.get(id=student.id)
         self.assertEqual(await student.school, school)
@@ -67,3 +68,89 @@ class TestForeignKeyFieldWithUnique(test.TestCase):
         self.assertEqual(student.school_id, school2.id)
         self.assertEqual(await school.students.all(), [])
         self.assertEqual((await school2.students.all())[0], student)
+
+    async def test_student__uninstantiated_create(self):
+        school = await testmodels.School(id=1024, name="School1")
+        with self.assertRaisesRegex(OperationalError, "You should first call .save()"):
+            await testmodels.Student.create(name="Sang-Heon Jeon", school=school)
+
+    async def test_student__uninstantiated_iterate(self):
+        school = await testmodels.School(id=1024, name="School1")
+        with self.assertRaisesRegex(
+            OperationalError, "This objects hasn't been instanced, call .save()"
+        ):
+            async for _ in school.students:
+                pass
+
+    async def test_student__uninstantiated_await(self):
+        school = await testmodels.School(id=1024, name="School1")
+        with self.assertRaisesRegex(
+            OperationalError, "This objects hasn't been instanced, call .save()"
+        ):
+            await school.students
+
+    async def test_student__unfetched_contains(self):
+        school = await testmodels.School.create(id=1024, name="School1")
+        with self.assertRaisesRegex(
+            NoValuesFetched,
+            "No values were fetched for this relation," " first use .fetch_related()",
+        ):
+            "a" in school.students  # pylint: disable=W0104
+
+    async def test_stduent__unfetched_iter(self):
+        school = await testmodels.School.create(id=1024, name="School1")
+        with self.assertRaisesRegex(
+            NoValuesFetched,
+            "No values were fetched for this relation," " first use .fetch_related()",
+        ):
+            for _ in school.students:
+                pass
+
+    async def test_student__unfetched_len(self):
+        school = await testmodels.School.create(id=1024, name="School1")
+        with self.assertRaisesRegex(
+            NoValuesFetched,
+            "No values were fetched for this relation," " first use .fetch_related()",
+        ):
+            len(school.students)
+
+    async def test_student__unfetched_bool(self):
+        school = await testmodels.School.create(id=1024, name="School1")
+        with self.assertRaisesRegex(
+            NoValuesFetched,
+            "No values were fetched for this relation," " first use .fetch_related()",
+        ):
+            bool(school.students)
+
+    async def test_student__unfetched_getitem(self):
+        school = await testmodels.School.create(id=1024, name="School1")
+        with self.assertRaisesRegex(
+            NoValuesFetched,
+            "No values were fetched for this relation," " first use .fetch_related()",
+        ):
+            school.students[0]  # pylint: disable=W0104
+
+    async def test_student__instantiated_create(self):
+        school = await testmodels.School.create(id=1024, name="School1")
+        await testmodels.Student.create(name="Sang-Heon Jeon", school=school)
+
+    async def test_student__instantiated_iterate(self):
+        school = await testmodels.School.create(id=1024, name="School1")
+        async for _ in school.students:
+            pass
+
+    async def test_student__instantiated_await(self):
+        school = await testmodels.School.create(id=1024, name="School1")
+        await school.students
+
+    async def test_student__fetched_contains(self):
+        school = await testmodels.School.create(id=1024, name="School1")
+        student = await testmodels.Student.create(name="Sang-Heon Jeon", school=school)
+        await school.fetch_related("students")
+        self.assertTrue(student in school.students)
+
+    async def test_student__fetched_iter(self):
+        school = await testmodels.School.create(id=1024, name="School1")
+        student = await testmodels.Student.create(name="Sang-Heon Jeon", school=school)
+        await school.fetch_related("students")
+        self.assertEqual(list(school.students), [student])

--- a/tests/fields/test_fk_with_unique.py
+++ b/tests/fields/test_fk_with_unique.py
@@ -1,0 +1,45 @@
+from tests import testmodels
+from tortoise.contrib import test
+from tortoise.exceptions import IntegrityError, NoValuesFetched, OperationalError
+from tortoise.queryset import QuerySet
+
+
+class TestForeignKeyFieldWithUnique(test.TestCase):
+    async def test_student__create_by_id(self):
+        school = await testmodels.School.create(id=1024, name="School")
+        student = await testmodels.Student.create(name="Sang-Heon Jeon", school_id=school.id)
+        self.assertEqual(student.school_id, school.id)
+        self.assertEqual((await school.students.all())[0], student)
+
+    async def test_student__create_by_name(self):
+        school = await testmodels.School.create(id=1024, name="School")
+        student = await testmodels.Student.create(name="Sang-Heon Jeon", school=school)
+        await student.fetch_related("school")
+        self.assertEqual(student.school, school)
+        self.assertEqual((await school.students.all())[0], student)
+
+    async def test_student__by_name__created_prefetched(self):
+        school = await testmodels.School.create(id=1024, name="School")
+        student = await testmodels.Student.create(name="Sang-Heon Jeon", school=school)
+        self.assertEqual(student.school, school)
+        self.assertEqual((await school.students.all())[0], student)
+
+    async def test_student__by_name__unfetched(self):
+        school = await testmodels.School.create(id=1024, name="School")
+        student = await testmodels.Student.create(name="Sang-Heon Jeon", school=school)
+        student = await testmodels.Student.get(id=student.id)
+        self.assertIsInstance(student.school, QuerySet)
+
+    async def test_student__by_name__re_awaited(self):
+        school = await testmodels.School.create(id=1024, name="School")
+        student = await testmodels.Student.create(name="Sang-Heon Jeon", school=school)
+        await student.fetch_related("school")
+        self.assertEqual(student.school, school)
+        self.assertEqual(await student.school, school)
+
+    async def test_student__by_name__awaited(self):
+        school = await testmodels.School.create(id=1024, name="School")
+        student = await testmodels.Student.create(name="Sang-Heon Jeon", school=school)
+        student = await testmodels.Student.get(id=student.id)
+        self.assertEqual(await student.school, school)
+        self.assertEqual((await school.students.all())[0], student)

--- a/tests/fields/test_o2o_with_unique.py
+++ b/tests/fields/test_o2o_with_unique.py
@@ -1,0 +1,86 @@
+from tests import testmodels
+from tortoise.contrib import test
+from tortoise.exceptions import IntegrityError, OperationalError
+from tortoise.queryset import QuerySet
+
+
+class TestForeignKeyFieldWithUnique(test.TestCase):
+    async def test_principal__empty(self):
+        with self.assertRaises(IntegrityError):
+            await testmodels.Principal.create()
+
+    async def test_principal__create_by_id(self):
+        school = await testmodels.School.create(id=1024, name="School1")
+        principal = await testmodels.Principal.create(name="Sang-Heon Jeon", school_id=school.id)
+        self.assertEqual(principal.school_id, school.id)
+        self.assertEqual(await school.principal, principal)
+
+    async def test_principal__create_by_name(self):
+        school = await testmodels.School.create(id=1024, name="School1")
+        principal = await testmodels.Principal.create(name="Sang-Heon Jeon", school=school)
+        await principal.fetch_related("school")
+        self.assertEqual(principal.school, school)
+        self.assertEqual(await school.principal, principal)
+
+    async def test_principal__by_name__created_prefetched(self):
+        school = await testmodels.School.create(id=1024, name="School1")
+        principal = await testmodels.Principal.create(name="Sang-Heon Jeon", school=school)
+        self.assertEqual(principal.school, school)
+        self.assertEqual(await school.principal, principal)
+
+    async def test_principal__by_name__unfetched(self):
+        school = await testmodels.School.create(id=1024, name="School1")
+        principal = await testmodels.Principal.create(name="Sang-Heon Jeon", school=school)
+        principal = await testmodels.Principal.get(id=principal.id)
+        self.assertIsInstance(principal.school, QuerySet)
+
+    async def test_principal__by_name__re_awaited(self):
+        school = await testmodels.School.create(id=1024, name="School1")
+        principal = await testmodels.Principal.create(name="Sang-Heon Jeon", school=school)
+        await principal.fetch_related("school")
+        self.assertEqual(principal.school, school)
+        self.assertEqual(await principal.school, school)
+
+    async def test_principal__by_name__awaited(self):
+        school = await testmodels.School.create(id=1024, name="School1")
+        principal = await testmodels.Principal.create(name="Sang-Heon Jeon", school=school)
+        principal = await testmodels.Principal.get(id=principal.id)
+        self.assertEqual(await principal.school, school)
+        self.assertEqual(await school.principal, principal)
+
+    async def test_update_by_name(self):
+        school = await testmodels.School.create(id=1024, name="School1")
+        school2 = await testmodels.School.create(id=2048, name="School2")
+        principal0 = await testmodels.Principal.create(name="Sang-Heon Jeon", school=school)
+
+        await testmodels.Principal.filter(id=principal0.id).update(school=school2)
+        principal = await testmodels.Principal.get(id=principal0.id)
+
+        await principal.fetch_related("school")
+        self.assertEqual(principal.school, school2)
+        self.assertEqual(await school.principal, None)
+        self.assertEqual(await school2.principal, principal)
+
+    async def test_update_by_id(self):
+        school = await testmodels.School.create(id=1024, name="School1")
+        school2 = await testmodels.School.create(id=2048, name="School2")
+        principal0 = await testmodels.Principal.create(name="Sang-Heon Jeon", school_id=school.id)
+
+        await testmodels.Principal.filter(id=principal0.id).update(school_id=school2.id)
+        principal = await testmodels.Principal.get(id=principal0.id)
+
+        self.assertEqual(principal.school_id, school2.id)
+        self.assertEqual(await school.principal, None)
+        self.assertEqual(await school2.principal, principal)
+
+    async def test_delete_by_name(self):
+        school = await testmodels.School.create(id=1024, name="School1")
+        principal = await testmodels.Principal.create(name="Sang-Heon Jeon", school=school)
+        del principal.school
+        with self.assertRaises(IntegrityError):
+            await principal.save()
+
+    async def test_principal__uninstantiated_create(self):
+        school = await testmodels.School(id=1024, name="School1")
+        with self.assertRaisesRegex(OperationalError, "You should first call .save()"):
+            await testmodels.Principal.create(name="Sang-Heon Jeon", school=school)

--- a/tests/model_setup/model_bad_rel6.py
+++ b/tests/model_setup/model_bad_rel6.py
@@ -1,0 +1,14 @@
+"""
+Testing Models for a bad/wrong relation reference
+Wrong reference. fk field parameter `to_field` with non unique field.
+"""
+from tortoise import fields
+from tortoise.models import Model
+
+
+class Tournament(Model):
+    uuid = fields.UUIDField(unique=False)
+
+
+class Event(Model):
+    tournament = fields.ForeignKeyField("models.Tournament", related_name="events", to_field="uuid")

--- a/tests/model_setup/model_bad_rel7.py
+++ b/tests/model_setup/model_bad_rel7.py
@@ -1,0 +1,16 @@
+"""
+Testing Models for a bad/wrong relation reference
+Wrong reference. fk field parameter `to_field` with non exist field.
+"""
+from tortoise import fields
+from tortoise.models import Model
+
+
+class Tournament(Model):
+    uuid = fields.UUIDField(unique=True)
+
+
+class Event(Model):
+    tournament = fields.ForeignKeyField(
+        "models.Tournament", related_name="events", to_field="uuids"
+    )

--- a/tests/model_setup/model_bad_rel8.py
+++ b/tests/model_setup/model_bad_rel8.py
@@ -1,0 +1,14 @@
+"""
+Testing Models for a bad/wrong relation reference
+Wrong reference. o2o field parameter `to_field` with non unique field.
+"""
+from tortoise import fields
+from tortoise.models import Model
+
+
+class Tournament(Model):
+    uuid = fields.UUIDField(unique=False)
+
+
+class Event(Model):
+    tournament = fields.OneToOneField("models.Tournament", related_name="events", to_field="uuid")

--- a/tests/model_setup/model_bad_rel9.py
+++ b/tests/model_setup/model_bad_rel9.py
@@ -1,0 +1,14 @@
+"""
+Testing Models for a bad/wrong relation reference
+Wrong reference. o2o field parameter `to_field` with non exist field.
+"""
+from tortoise import fields
+from tortoise.models import Model
+
+
+class Tournament(Model):
+    uuid = fields.UUIDField(unique=True)
+
+
+class Event(Model):
+    tournament = fields.OneToOneField("models.Tournament", related_name="events", to_field="uuids")

--- a/tests/model_setup/test_bad_relation_reference.py
+++ b/tests/model_setup/test_bad_relation_reference.py
@@ -119,3 +119,88 @@ class TestBadReleationReferenceErrors(test.SimpleTestCase):
                     },
                 }
             )
+
+    async def test_non_unique_field_in_fk_reference_init(self):
+        with self.assertRaisesRegex(
+            ConfigurationError, 'field "uuid" in model "Tournament" is not unique'
+        ):
+            await Tortoise.init(
+                {
+                    "connections": {
+                        "default": {
+                            "engine": "tortoise.backends.sqlite",
+                            "credentials": {"file_path": ":memory:"},
+                        }
+                    },
+                    "apps": {
+                        "models": {
+                            "models": ["tests.model_setup.model_bad_rel6"],
+                            "default_connection": "default",
+                        }
+                    },
+                }
+            )
+
+    async def test_non_exist_field_in_fk_reference_init(self):
+        with self.assertRaisesRegex(
+            ConfigurationError, 'there is no field named "uuids" in model "Tournament"'
+        ):
+            await Tortoise.init(
+                {
+                    "connections": {
+                        "default": {
+                            "engine": "tortoise.backends.sqlite",
+                            "credentials": {"file_path": ":memory:"},
+                        }
+                    },
+                    "apps": {
+                        "models": {
+                            "models": ["tests.model_setup.model_bad_rel7"],
+                            "default_connection": "default",
+                        }
+                    },
+                }
+            )
+
+    async def test_non_unique_field_in_o2o_reference_init(self):
+        with self.assertRaisesRegex(
+            ConfigurationError, 'field "uuid" in model "Tournament" is not unique'
+        ):
+            await Tortoise.init(
+                {
+                    "connections": {
+                        "default": {
+                            "engine": "tortoise.backends.sqlite",
+                            "credentials": {"file_path": ":memory:"},
+                        }
+                    },
+                    "apps": {
+                        "models": {
+                            "models": ["tests.model_setup.model_bad_rel8"],
+                            "default_connection": "default",
+                        }
+                    },
+                }
+            )
+
+    async def test_non_exist_field_in_o2o_reference_init(self):
+        with self.assertRaisesRegex(
+            ConfigurationError, 'there is no field named "uuids" in model "Tournament"'
+        ):
+            await Tortoise.init(
+                {
+                    "connections": {
+                        "default": {
+                            "engine": "tortoise.backends.sqlite",
+                            "credentials": {"file_path": ":memory:"},
+                        }
+                    },
+                    "apps": {
+                        "models": {
+                            "models": ["tests.model_setup.model_bad_rel9"],
+                            "default_connection": "default",
+                        }
+                    },
+                }
+            )
+

--- a/tests/model_setup/test_bad_relation_reference.py
+++ b/tests/model_setup/test_bad_relation_reference.py
@@ -203,4 +203,3 @@ class TestBadReleationReferenceErrors(test.SimpleTestCase):
                     },
                 }
             )
-

--- a/tests/schema/models_schema_create.py
+++ b/tests/schema/models_schema_create.py
@@ -1,6 +1,8 @@
 """
 This example demonstrates SQL Schema generation for each DB type supported.
 """
+from uuid import uuid4
+
 from tortoise import fields
 from tortoise.models import Model
 
@@ -82,6 +84,22 @@ class SourceFields(Model):
     class Meta:
         table = "sometable"
         indexes = [["chars"]]
+
+
+class Company(Model):
+    id = fields.IntField(pk=True)
+    name = fields.TextField()
+    uuid = fields.UUIDField(unique=True, default=uuid4)
+
+    employees: fields.ReverseRelation["Employee"]
+
+
+class Employee(Model):
+    id = fields.IntField(pk=True)
+    name = fields.TextField()
+    company: fields.ForeignKeyRelation[Company] = fields.ForeignKeyField(
+        "models.Company", related_name="employees", to_field="uuid",
+    )
 
 
 class DefaultPK(Model):

--- a/tests/schema/test_generate_schema.py
+++ b/tests/schema/test_generate_schema.py
@@ -142,9 +142,19 @@ class TestGenerateSchema(test.SimpleTestCase):
         self.assertEqual(
             sql.strip(),
             """
+CREATE TABLE "company" (
+    "id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    "name" TEXT NOT NULL,
+    "uuid" CHAR(36) NOT NULL UNIQUE
+);
 CREATE TABLE "defaultpk" (
     "id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     "val" INT NOT NULL
+);
+CREATE TABLE "employee" (
+    "id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    "name" TEXT NOT NULL,
+    "company_id" CHAR(36) NOT NULL REFERENCES "company" ("uuid") ON DELETE CASCADE
 );
 CREATE TABLE "inheritedmodel" (
     "id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -219,9 +229,19 @@ CREATE TABLE "teamevents" (
         self.assertEqual(
             sql.strip(),
             """
+CREATE TABLE IF NOT EXISTS "company" (
+    "id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    "name" TEXT NOT NULL,
+    "uuid" CHAR(36) NOT NULL UNIQUE
+);
 CREATE TABLE IF NOT EXISTS "defaultpk" (
     "id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     "val" INT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS "employee" (
+    "id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    "name" TEXT NOT NULL,
+    "company_id" CHAR(36) NOT NULL REFERENCES "company" ("uuid") ON DELETE CASCADE
 );
 CREATE TABLE IF NOT EXISTS "inheritedmodel" (
     "id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -360,9 +380,20 @@ class TestGenerateSchemaMySQL(TestGenerateSchema):
         self.assertEqual(
             sql.strip(),
             """
+CREATE TABLE `company` (
+    `id` INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    `name` LONGTEXT NOT NULL,
+    `uuid` CHAR(36) NOT NULL UNIQUE
+) CHARACTER SET utf8mb4;
 CREATE TABLE `defaultpk` (
     `id` INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
     `val` INT NOT NULL
+) CHARACTER SET utf8mb4;
+CREATE TABLE `employee` (
+    `id` INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    `name` LONGTEXT NOT NULL,
+    `company_id` CHAR(36) NOT NULL,
+    CONSTRAINT `fk_employee_company_08999a42` FOREIGN KEY (`company_id`) REFERENCES `company` (`uuid`) ON DELETE CASCADE
 ) CHARACTER SET utf8mb4;
 CREATE TABLE `inheritedmodel` (
     `id` INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
@@ -449,9 +480,20 @@ CREATE TABLE `teamevents` (
         self.assertEqual(
             sql.strip(),
             """
+CREATE TABLE IF NOT EXISTS `company` (
+    `id` INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    `name` LONGTEXT NOT NULL,
+    `uuid` CHAR(36) NOT NULL UNIQUE
+) CHARACTER SET utf8mb4;
 CREATE TABLE IF NOT EXISTS `defaultpk` (
     `id` INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
     `val` INT NOT NULL
+) CHARACTER SET utf8mb4;
+CREATE TABLE IF NOT EXISTS `employee` (
+    `id` INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    `name` LONGTEXT NOT NULL,
+    `company_id` CHAR(36) NOT NULL,
+    CONSTRAINT `fk_employee_company_08999a42` FOREIGN KEY (`company_id`) REFERENCES `company` (`uuid`) ON DELETE CASCADE
 ) CHARACTER SET utf8mb4;
 CREATE TABLE IF NOT EXISTS `inheritedmodel` (
     `id` INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
@@ -582,9 +624,19 @@ class TestGenerateSchemaPostgresSQL(TestGenerateSchema):
         self.assertEqual(
             sql.strip(),
             """
+CREATE TABLE "company" (
+    "id" SERIAL NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "uuid" UUID NOT NULL UNIQUE
+);
 CREATE TABLE "defaultpk" (
     "id" SERIAL NOT NULL PRIMARY KEY,
     "val" INT NOT NULL
+);
+CREATE TABLE "employee" (
+    "id" SERIAL NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "company_id" UUID NOT NULL REFERENCES "company" ("uuid") ON DELETE CASCADE
 );
 CREATE TABLE "inheritedmodel" (
     "id" SERIAL NOT NULL PRIMARY KEY,
@@ -672,9 +724,19 @@ COMMENT ON TABLE "teamevents" IS 'How participants relate';
         self.assertEqual(
             sql.strip(),
             """
+CREATE TABLE IF NOT EXISTS "company" (
+    "id" SERIAL NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "uuid" UUID NOT NULL UNIQUE
+);
 CREATE TABLE IF NOT EXISTS "defaultpk" (
     "id" SERIAL NOT NULL PRIMARY KEY,
     "val" INT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS "employee" (
+    "id" SERIAL NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "company_id" UUID NOT NULL REFERENCES "company" ("uuid") ON DELETE CASCADE
 );
 CREATE TABLE IF NOT EXISTS "inheritedmodel" (
     "id" SERIAL NOT NULL PRIMARY KEY,

--- a/tests/test_relations_with_unique.py
+++ b/tests/test_relations_with_unique.py
@@ -1,13 +1,42 @@
-from tests.testmodels import School, Student
+from tests.testmodels import Principal, School, Student
 from tortoise.contrib import test
+from tortoise.query_utils import Prefetch
 
 
 class TestRelationsWithUnique(test.TestCase):
     async def test_relation_with_unique(self):
-        school = await School.create(id=1024, name="School")
-        await Student.create(name="Sang-Heon Jeon", school_id=school.id)
 
+        school1 = await School.create(id=1024, name="School1")
+        student1 = await Student.create(name="Sang-Heon Jeon1", school_id=school1.id)
+
+        student_schools = await Student.filter(name="Sang-Heon Jeon1").values(
+            "name", "school__name"
+        )
+        self.assertEqual(student_schools[0], {"name": "Sang-Heon Jeon1", "school__name": "School1"})
         student_schools = await Student.all().values(school="school__name")
-        self.assertEqual(student_schools[0]["school"], school.name)
+
+        self.assertEqual(student_schools[0]["school"], school1.name)
         student_schools = await Student.all().values_list("school__name")
-        self.assertEqual(student_schools[0][0], school.name)
+        self.assertEqual(student_schools[0][0], school1.name)
+
+        await Student.create(name="Sang-Heon Jeon2", school=school1)
+        school_with_filtered = (
+            await School.all()
+            .prefetch_related(Prefetch("students", queryset=Student.filter(name="Sang-Heon Jeon1")))
+            .first()
+        )
+        school_without_filtered = await School.first().prefetch_related("students")
+        self.assertEqual(len(school_with_filtered.students), 1)
+        self.assertEqual(len(school_without_filtered.students), 2)
+
+        student_direct_prefetch = await Student.first().prefetch_related("school")
+        self.assertEqual(student_direct_prefetch.school.id, school1.id)
+
+        school2 = await School.create(id=2048, name="School2")
+        await Student.all().update(school=school2)
+        student = await Student.first()
+        self.assertEqual(student.school_id, school2.id)
+
+        await Student.filter(id=student1.id).update(school=school1)
+        schools = await School.all().order_by("students__name")
+        self.assertEqual([school.name for school in schools], ["School1", "School2"])

--- a/tests/test_relations_with_unique.py
+++ b/tests/test_relations_with_unique.py
@@ -5,7 +5,6 @@ from tortoise.query_utils import Prefetch
 
 class TestRelationsWithUnique(test.TestCase):
     async def test_relation_with_unique(self):
-
         school1 = await School.create(id=1024, name="School1")
         student1 = await Student.create(name="Sang-Heon Jeon1", school_id=school1.id)
 
@@ -14,7 +13,6 @@ class TestRelationsWithUnique(test.TestCase):
         )
         self.assertEqual(student_schools[0], {"name": "Sang-Heon Jeon1", "school__name": "School1"})
         student_schools = await Student.all().values(school="school__name")
-
         self.assertEqual(student_schools[0]["school"], school1.name)
         student_schools = await Student.all().values_list("school__name")
         self.assertEqual(student_schools[0][0], school1.name)
@@ -40,3 +38,10 @@ class TestRelationsWithUnique(test.TestCase):
         await Student.filter(id=student1.id).update(school=school1)
         schools = await School.all().order_by("students__name")
         self.assertEqual([school.name for school in schools], ["School1", "School2"])
+        schools = await School.all().order_by("-students__name")
+        self.assertEqual([school.name for school in schools], ["School2", "School1"])
+
+        fetched_principal = await Principal.create(name="Sang-Heon Jeon3", school=school1)
+        self.assertEqual(fetched_principal.name, "Sang-Heon Jeon3")
+        fetched_school = await School.all().prefetch_related("principal").first()
+        self.assertEqual(fetched_school.name, "School1")

--- a/tests/test_relations_with_unique.py
+++ b/tests/test_relations_with_unique.py
@@ -43,5 +43,5 @@ class TestRelationsWithUnique(test.TestCase):
 
         fetched_principal = await Principal.create(name="Sang-Heon Jeon3", school=school1)
         self.assertEqual(fetched_principal.name, "Sang-Heon Jeon3")
-        fetched_school = await School.all().prefetch_related("principal").first()
+        fetched_school = await School.filter(name="School1").prefetch_related("principal").first()
         self.assertEqual(fetched_school.name, "School1")

--- a/tests/test_relations_with_unique.py
+++ b/tests/test_relations_with_unique.py
@@ -1,0 +1,13 @@
+from tests.testmodels import School, Student
+from tortoise.contrib import test
+
+
+class TestRelationsWithUnique(test.TestCase):
+    async def test_relation_with_unique(self):
+        school = await School.create(id=1024, name="School")
+        await Student.create(name="Sang-Heon Jeon", school_id=school.id)
+
+        student_schools = await Student.all().values(school="school__name")
+        self.assertEqual(student_schools[0]["school"], school.name)
+        student_schools = await Student.all().values_list("school__name")
+        self.assertEqual(student_schools[0][0], school.name)

--- a/tests/testmodels.py
+++ b/tests/testmodels.py
@@ -543,3 +543,19 @@ class DefaultOrderedInvalid(Model):
 
     class Meta:
         ordering = ["one", "third"]
+
+
+class School(Model):
+    uuid = fields.UUIDField(pk=True)
+    name = fields.TextField()
+    id = fields.IntField(unique=True)
+
+    students: fields.ReverseRelation["Student"]
+
+
+class Student(Model):
+    id = fields.IntField(pk=True)
+    name = fields.TextField()
+    school: fields.ForeignKeyRelation[School] = fields.ForeignKeyField(
+        "models.School", related_name="students", to_field="id",
+    )

--- a/tests/testmodels.py
+++ b/tests/testmodels.py
@@ -551,11 +551,20 @@ class School(Model):
     id = fields.IntField(unique=True)
 
     students: fields.ReverseRelation["Student"]
+    principal: fields.ReverseRelation["Principal"]
 
 
 class Student(Model):
     id = fields.IntField(pk=True)
     name = fields.TextField()
     school: fields.ForeignKeyRelation[School] = fields.ForeignKeyField(
-        "models.School", related_name="students", to_field="id",
+        "models.School", related_name="students", to_field="id"
+    )
+
+
+class Principal(Model):
+    id = fields.IntField(pk=True)
+    name = fields.TextField()
+    school: fields.OneToOneRelation[School] = fields.OneToOneField(
+        "models.School", on_delete=fields.CASCADE, related_name="principal", to_field="id"
     )

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -323,9 +323,8 @@ class Tortoise:
                         if related_field:
                             if related_field.unique:
                                 key_fk_object = deepcopy(related_field)
-                                fk_object.to_field = related_field.source_field
-                                if not fk_object.to_field:
-                                    fk_object.to_field = related_field.model_field_name
+                                fk_object.to_field_instance = related_field
+                                reverse_to_field = fk_object.to_field
                             else:
                                 raise ConfigurationError(
                                     f'field "{fk_object.to_field}" in model'
@@ -338,7 +337,8 @@ class Tortoise:
                             )
                     else:
                         key_fk_object = deepcopy(related_model._meta.pk)
-                        fk_object.to_field = related_model._meta.db_pk_field
+                        fk_object.to_field_instance = related_model._meta.pk
+                        reverse_to_field = "pk"
 
                     key_field = f"{field}_id"
                     key_fk_object.pk = False
@@ -368,7 +368,11 @@ class Tortoise:
                                 f" model {related_model_name}"
                             )
                         fk_relation = BackwardFKRelation(
-                            model, f"{field}_id", fk_object.null, fk_object.description
+                            model,
+                            f"{field}_id",
+                            fk_object.null,
+                            fk_object.description,
+                            to_field=reverse_to_field,
                         )
                         related_model._meta.add_field(
                             cast(str, backward_relation_name), fk_relation
@@ -387,9 +391,8 @@ class Tortoise:
                         if related_field:
                             if related_field.unique:
                                 key_o2o_object = deepcopy(related_field)
-                                o2o_object.to_field = related_field.source_field
-                                if not fk_object.to_field:
-                                    o2o_object.to_field = related_field.model_field_name
+                                o2o_object.to_field_instance = related_field
+                                reverse_to_field = o2o_object.to_field
                             else:
                                 raise ConfigurationError(
                                     f'field "{o2o_object.to_field}" in model'
@@ -402,7 +405,8 @@ class Tortoise:
                             )
                     else:
                         key_o2o_object = deepcopy(related_model._meta.pk)
-                        o2o_object.to_field = related_model._meta.db_pk_field
+                        o2o_object.to_field_instance = related_model._meta.pk
+                        reverse_to_field = "pk"
 
                     key_field = f"{field}_id"
                     key_o2o_object.pk = o2o_object.pk
@@ -432,7 +436,11 @@ class Tortoise:
                                 f" model {related_model_name}"
                             )
                         o2o_relation = BackwardOneToOneRelation(
-                            model, f"{field}_id", null=True, description=o2o_object.description
+                            model,
+                            f"{field}_id",
+                            null=True,
+                            description=o2o_object.description,
+                            to_field=reverse_to_field,
                         )
                         related_model._meta.add_field(
                             cast(str, backward_relation_name), o2o_relation

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -324,7 +324,6 @@ class Tortoise:
                             if related_field.unique:
                                 key_fk_object = deepcopy(related_field)
                                 fk_object.to_field_instance = related_field
-                                reverse_to_field = fk_object.to_field
                             else:
                                 raise ConfigurationError(
                                     f'field "{fk_object.to_field}" in model'
@@ -338,7 +337,6 @@ class Tortoise:
                     else:
                         key_fk_object = deepcopy(related_model._meta.pk)
                         fk_object.to_field_instance = related_model._meta.pk
-                        reverse_to_field = "pk"
 
                     key_field = f"{field}_id"
                     key_fk_object.pk = False
@@ -368,12 +366,9 @@ class Tortoise:
                                 f" model {related_model_name}"
                             )
                         fk_relation = BackwardFKRelation(
-                            model,
-                            f"{field}_id",
-                            fk_object.null,
-                            fk_object.description,
-                            to_field=reverse_to_field,
+                            model, f"{field}_id", fk_object.null, fk_object.description,
                         )
+                        fk_relation.to_field_instance = fk_object.to_field_instance
                         related_model._meta.add_field(
                             cast(str, backward_relation_name), fk_relation
                         )
@@ -392,7 +387,6 @@ class Tortoise:
                             if related_field.unique:
                                 key_o2o_object = deepcopy(related_field)
                                 o2o_object.to_field_instance = related_field
-                                reverse_to_field = o2o_object.to_field
                             else:
                                 raise ConfigurationError(
                                     f'field "{o2o_object.to_field}" in model'
@@ -406,7 +400,6 @@ class Tortoise:
                     else:
                         key_o2o_object = deepcopy(related_model._meta.pk)
                         o2o_object.to_field_instance = related_model._meta.pk
-                        reverse_to_field = "pk"
 
                     key_field = f"{field}_id"
                     key_o2o_object.pk = o2o_object.pk
@@ -436,12 +429,9 @@ class Tortoise:
                                 f" model {related_model_name}"
                             )
                         o2o_relation = BackwardOneToOneRelation(
-                            model,
-                            f"{field}_id",
-                            null=True,
-                            description=o2o_object.description,
-                            to_field=reverse_to_field,
+                            model, f"{field}_id", null=True, description=o2o_object.description,
                         )
+                        o2o_relation.to_field_instance = o2o_object.to_field_instance
                         related_model._meta.add_field(
                             cast(str, backward_relation_name), o2o_relation
                         )

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -337,6 +337,26 @@ class Tortoise:
                     model._meta.add_field(key_field, key_fk_object)
 
                     fk_object.model_class = related_model
+                    if fk_object.to_field:
+                        related_field = fk_object.model_class._meta.fields_map.get(
+                            fk_object.to_field, None
+                        )
+                        if related_field:
+                            if related_field.unique:
+                                fk_object.to_field = related_field
+                            else:
+                                raise ConfigurationError(
+                                    f'field "{fk_object.to_field}" in model "{related_model_name}" is not unique'
+                                )
+                        else:
+                            raise ConfigurationError(
+                                f'there is no field named "{fk_object.to_field}" in model "{related_model_name}"'
+                            )
+                    else:
+                        fk_object.to_field = fk_object.model_class._meta.fields_map[
+                            fk_object.model_class._meta.db_pk_field
+                        ]
+
                     backward_relation_name = fk_object.related_name
                     if backward_relation_name is not False:
                         if not backward_relation_name:

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -343,19 +343,19 @@ class Tortoise:
                         )
                         if related_field:
                             if related_field.unique:
-                                fk_object.to_field = related_field
+                                fk_object.to_field_instance = related_field
                             else:
                                 raise ConfigurationError(
-                                    f'field "{fk_object.to_field}" in model "{related_model_name}" is not unique'
+                                    f'field "{fk_object.to_field}" in model'
+                                    f' "{related_model_name}" is not unique'
                                 )
                         else:
                             raise ConfigurationError(
-                                f'there is no field named "{fk_object.to_field}" in model "{related_model_name}"'
+                                f'there is no field named "{fk_object.to_field}"'
+                                f' in model "{related_model_name}"'
                             )
                     else:
-                        fk_object.to_field = fk_object.model_class._meta.fields_map[
-                            fk_object.model_class._meta.db_pk_field
-                        ]
+                        fk_object.to_field_instance = fk_object.model_class._meta.pk
 
                     backward_relation_name = fk_object.related_name
                     if backward_relation_name is not False:
@@ -404,19 +404,19 @@ class Tortoise:
                         )
                         if related_field:
                             if related_field.unique:
-                                o2o_object.to_field = related_field
+                                o2o_object.to_field_instance = related_field
                             else:
                                 raise ConfigurationError(
-                                    f'field "{o2o_object.to_field}" in model "{related_model_name}" is not unique'
+                                    f'field "{o2o_object.to_field}" in model'
+                                    f' "{related_model_name}" is not unique'
                                 )
                         else:
                             raise ConfigurationError(
-                                f'there is no field named "{o2o_object.to_field}" in model "{related_model_name}"'
+                                f'there is no field named "{o2o_object.to_field}"'
+                                f' in model "{related_model_name}"'
                             )
                     else:
-                        o2o_object.to_field = o2o_object.model_class._meta.fields_map[
-                            o2o_object.model_class._meta.db_pk_field
-                        ]
+                        o2o_object.to_field_instance = o2o_object.model_class._meta.pk
 
                     backward_relation_name = o2o_object.related_name
                     if backward_relation_name is not False:

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -318,8 +318,29 @@ class Tortoise:
                     related_app_name, related_model_name = split_reference(reference)
                     related_model = get_related_model(related_app_name, related_model_name)
 
+                    if fk_object.to_field:
+                        related_field = related_model._meta.fields_map.get(fk_object.to_field, None)
+                        if related_field:
+                            if related_field.unique:
+                                key_fk_object = deepcopy(related_field)
+                                fk_object.to_field = related_field.source_field
+                                if not fk_object.to_field:
+                                    fk_object.to_field = related_field.model_field_name
+                            else:
+                                raise ConfigurationError(
+                                    f'field "{fk_object.to_field}" in model'
+                                    f' "{related_model_name}" is not unique'
+                                )
+                        else:
+                            raise ConfigurationError(
+                                f'there is no field named "{fk_object.to_field}"'
+                                f' in model "{related_model_name}"'
+                            )
+                    else:
+                        key_fk_object = deepcopy(related_model._meta.pk)
+                        fk_object.to_field = related_model._meta.db_pk_field
+
                     key_field = f"{field}_id"
-                    key_fk_object = deepcopy(related_model._meta.pk)
                     key_fk_object.pk = False
                     key_fk_object.unique = False
                     key_fk_object.index = fk_object.index
@@ -337,26 +358,6 @@ class Tortoise:
                     model._meta.add_field(key_field, key_fk_object)
 
                     fk_object.model_class = related_model
-                    if fk_object.to_field:
-                        related_field = fk_object.model_class._meta.fields_map.get(
-                            fk_object.to_field, None
-                        )
-                        if related_field:
-                            if related_field.unique:
-                                fk_object.to_field_instance = related_field
-                            else:
-                                raise ConfigurationError(
-                                    f'field "{fk_object.to_field}" in model'
-                                    f' "{related_model_name}" is not unique'
-                                )
-                        else:
-                            raise ConfigurationError(
-                                f'there is no field named "{fk_object.to_field}"'
-                                f' in model "{related_model_name}"'
-                            )
-                    else:
-                        fk_object.to_field_instance = fk_object.model_class._meta.pk
-
                     backward_relation_name = fk_object.related_name
                     if backward_relation_name is not False:
                         if not backward_relation_name:
@@ -379,8 +380,31 @@ class Tortoise:
                     related_app_name, related_model_name = split_reference(reference)
                     related_model = get_related_model(related_app_name, related_model_name)
 
+                    if o2o_object.to_field:
+                        related_field = related_model._meta.fields_map.get(
+                            o2o_object.to_field, None
+                        )
+                        if related_field:
+                            if related_field.unique:
+                                key_o2o_object = deepcopy(related_field)
+                                o2o_object.to_field = related_field.source_field
+                                if not fk_object.to_field:
+                                    o2o_object.to_field = related_field.model_field_name
+                            else:
+                                raise ConfigurationError(
+                                    f'field "{o2o_object.to_field}" in model'
+                                    f' "{related_model_name}" is not unique'
+                                )
+                        else:
+                            raise ConfigurationError(
+                                f'there is no field named "{o2o_object.to_field}"'
+                                f' in model "{related_model_name}"'
+                            )
+                    else:
+                        key_o2o_object = deepcopy(related_model._meta.pk)
+                        o2o_object.to_field = related_model._meta.db_pk_field
+
                     key_field = f"{field}_id"
-                    key_o2o_object = deepcopy(related_model._meta.pk)
                     key_o2o_object.pk = o2o_object.pk
                     key_o2o_object.index = o2o_object.index
                     key_o2o_object.default = o2o_object.default
@@ -398,26 +422,6 @@ class Tortoise:
                     model._meta.add_field(key_field, key_o2o_object)
 
                     o2o_object.model_class = related_model
-                    if o2o_object.to_field:
-                        related_field = o2o_object.model_class._meta.fields_map.get(
-                            o2o_object.to_field, None
-                        )
-                        if related_field:
-                            if related_field.unique:
-                                o2o_object.to_field_instance = related_field
-                            else:
-                                raise ConfigurationError(
-                                    f'field "{o2o_object.to_field}" in model'
-                                    f' "{related_model_name}" is not unique'
-                                )
-                        else:
-                            raise ConfigurationError(
-                                f'there is no field named "{o2o_object.to_field}"'
-                                f' in model "{related_model_name}"'
-                            )
-                    else:
-                        o2o_object.to_field_instance = o2o_object.model_class._meta.pk
-
                     backward_relation_name = o2o_object.related_name
                     if backward_relation_name is not False:
                         if not backward_relation_name:

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -398,6 +398,26 @@ class Tortoise:
                     model._meta.add_field(key_field, key_o2o_object)
 
                     o2o_object.model_class = related_model
+                    if o2o_object.to_field:
+                        related_field = o2o_object.model_class._meta.fields_map.get(
+                            o2o_object.to_field, None
+                        )
+                        if related_field:
+                            if related_field.unique:
+                                o2o_object.to_field = related_field
+                            else:
+                                raise ConfigurationError(
+                                    f'field "{o2o_object.to_field}" in model "{related_model_name}" is not unique'
+                                )
+                        else:
+                            raise ConfigurationError(
+                                f'there is no field named "{o2o_object.to_field}" in model "{related_model_name}"'
+                            )
+                    else:
+                        o2o_object.to_field = o2o_object.model_class._meta.fields_map[
+                            o2o_object.model_class._meta.db_pk_field
+                        ]
+
                     backward_relation_name = o2o_object.related_name
                     if backward_relation_name is not False:
                         if not backward_relation_name:

--- a/tortoise/backends/base/executor.py
+++ b/tortoise/backends/base/executor.py
@@ -349,7 +349,7 @@ class BaseExecutor:
     async def _prefetch_direct_relation(
         self, instance_list: "List[Model]", field: str, related_query: "QuerySet"
     ) -> "List[Model]":
-        related_objects_for_fetch = {}
+        related_objects_for_fetch: Dict[str, list] = {}
         relation_key_field = f"{field}_id"
         for instance in instance_list:
             if getattr(instance, relation_key_field):

--- a/tortoise/backends/base/schema_generator.py
+++ b/tortoise/backends/base/schema_generator.py
@@ -180,25 +180,30 @@ class BaseSchemaGenerator:
                     else ""
                 )
 
-                field_type = reference.to_field.get_for_dialect(self.DIALECT, "SQL_TYPE")
-                field_name = reference.to_field.source_field
-                if not field_name:
-                    field_name = reference.to_field.model_field_name
+                to_field_type = reference.to_field_instance.get_for_dialect(
+                    self.DIALECT, "SQL_TYPE"
+                )
+                to_field_name = reference.to_field_instance.source_field
+                if not to_field_name:
+                    to_field_name = reference.to_field_instance.model_field_name
 
                 field_creation_string = self._create_string(
                     db_field=db_field,
-                    field_type=field_type,
+                    field_type=to_field_type,
                     nullable=nullable,
                     unique=unique,
                     is_pk=field_object.pk,
                     comment="",
                 ) + self._create_fk_string(
                     constraint_name=self._generate_fk_name(
-                        model._meta.table, db_field, reference.model_class._meta.table, field_name,
+                        model._meta.table,
+                        db_field,
+                        reference.model_class._meta.table,
+                        to_field_name,
                     ),
                     db_field=db_field,
                     table=reference.model_class._meta.table,
-                    field=field_name,
+                    field=to_field_name,
                     on_delete=reference.on_delete,
                     comment=comment,
                 )

--- a/tortoise/backends/base/schema_generator.py
+++ b/tortoise/backends/base/schema_generator.py
@@ -179,23 +179,26 @@ class BaseSchemaGenerator:
                     if reference.description
                     else ""
                 )
+
+                field_type = reference.to_field.get_for_dialect(self.DIALECT, "SQL_TYPE")
+                field_name = reference.to_field.source_field
+                if not field_name:
+                    field_name = reference.to_field.model_field_name
+
                 field_creation_string = self._create_string(
                     db_field=db_field,
-                    field_type=field_object.get_for_dialect(self.DIALECT, "SQL_TYPE"),
+                    field_type=field_type,
                     nullable=nullable,
                     unique=unique,
                     is_pk=field_object.pk,
                     comment="",
                 ) + self._create_fk_string(
                     constraint_name=self._generate_fk_name(
-                        model._meta.table,
-                        db_field,
-                        reference.model_class._meta.table,
-                        reference.model_class._meta.db_pk_field,
+                        model._meta.table, db_field, reference.model_class._meta.table, field_name,
                     ),
                     db_field=db_field,
                     table=reference.model_class._meta.table,
-                    field=reference.model_class._meta.db_pk_field,
+                    field=field_name,
                     on_delete=reference.on_delete,
                     comment=comment,
                 )

--- a/tortoise/backends/base/schema_generator.py
+++ b/tortoise/backends/base/schema_generator.py
@@ -180,16 +180,9 @@ class BaseSchemaGenerator:
                     else ""
                 )
 
-                to_field_type = reference.to_field_instance.get_for_dialect(
-                    self.DIALECT, "SQL_TYPE"
-                )
-                to_field_name = reference.to_field_instance.source_field
-                if not to_field_name:
-                    to_field_name = reference.to_field_instance.model_field_name
-
                 field_creation_string = self._create_string(
                     db_field=db_field,
-                    field_type=to_field_type,
+                    field_type=field_object.get_for_dialect(self.DIALECT, "SQL_TYPE"),
                     nullable=nullable,
                     unique=unique,
                     is_pk=field_object.pk,
@@ -199,11 +192,11 @@ class BaseSchemaGenerator:
                         model._meta.table,
                         db_field,
                         reference.model_class._meta.table,
-                        to_field_name,
+                        cast("str", reference.to_field),
                     ),
                     db_field=db_field,
                     table=reference.model_class._meta.table,
-                    field=to_field_name,
+                    field=cast("str", reference.to_field),
                     on_delete=reference.on_delete,
                     comment=comment,
                 )

--- a/tortoise/backends/base/schema_generator.py
+++ b/tortoise/backends/base/schema_generator.py
@@ -180,6 +180,10 @@ class BaseSchemaGenerator:
                     else ""
                 )
 
+                to_field_name = reference.to_field_instance.source_field
+                if not to_field_name:
+                    to_field_name = reference.to_field_instance.model_field_name
+
                 field_creation_string = self._create_string(
                     db_field=db_field,
                     field_type=field_object.get_for_dialect(self.DIALECT, "SQL_TYPE"),
@@ -192,11 +196,11 @@ class BaseSchemaGenerator:
                         model._meta.table,
                         db_field,
                         reference.model_class._meta.table,
-                        cast("str", reference.to_field),
+                        to_field_name,
                     ),
                     db_field=db_field,
                     table=reference.model_class._meta.table,
-                    field=cast("str", reference.to_field),
+                    field=to_field_name,
                     on_delete=reference.on_delete,
                     comment=comment,
                 )

--- a/tortoise/fields/relational.py
+++ b/tortoise/fields/relational.py
@@ -284,7 +284,6 @@ class RelationalField(Field):
         super().__init__(**kwargs)
         self.model_class: "Type[Model]" = None  # type: ignore
         self.to_field = to_field
-        self.to_field_instance: "Field" = None  # type: ignore
 
 
 class ForeignKeyFieldInstance(RelationalField):

--- a/tortoise/fields/relational.py
+++ b/tortoise/fields/relational.py
@@ -402,6 +402,9 @@ def OneToOneField(
             ``field.SET_DEFAULT``:
                 Resets the field to ``default`` value in case the related model gets deleted.
                 Can only be set is field has a ``default`` set.
+    ``to_field``:
+        The attribute name on the related model to establish foreign key relationship.
+        If not set, pk is used
     """
 
     return OneToOneFieldInstance(model_name, related_name, on_delete, **kwargs)
@@ -442,6 +445,9 @@ def ForeignKeyField(
             ``field.SET_DEFAULT``:
                 Resets the field to ``default`` value in case the related model gets deleted.
                 Can only be set is field has a ``default`` set.
+    ``to_field``:
+        The attribute name on the related model to establish foreign key relationship.
+        If not set, pk is used
     """
 
     return ForeignKeyFieldInstance(model_name, related_name, on_delete, **kwargs)

--- a/tortoise/fields/relational.py
+++ b/tortoise/fields/relational.py
@@ -323,11 +323,13 @@ class OneToOneFieldInstance(ForeignKeyFieldInstance):
         model_name: str,
         related_name: Union[Optional[str], Literal[False]] = None,
         on_delete: str = CASCADE,
+        to_field: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
         if len(model_name.split(".")) != 2:
             raise ConfigurationError('OneToOneField accepts model name in format "app.Model"')
         super().__init__(model_name, related_name, on_delete, unique=True, **kwargs)
+        self.to_field = to_field
 
 
 class BackwardOneToOneRelation(BackwardFKRelation):
@@ -363,6 +365,7 @@ def OneToOneField(
     model_name: str,
     related_name: Union[Optional[str], Literal[False]] = None,
     on_delete: str = CASCADE,
+    to_field: Optional[str] = None,
     **kwargs: Any,
 ) -> OneToOneRelation:
     """
@@ -396,7 +399,7 @@ def OneToOneField(
                 Can only be set is field has a ``default`` set.
     """
 
-    return OneToOneFieldInstance(model_name, related_name, on_delete, **kwargs)
+    return OneToOneFieldInstance(model_name, related_name, on_delete, to_field, **kwargs)
 
 
 def ForeignKeyField(

--- a/tortoise/fields/relational.py
+++ b/tortoise/fields/relational.py
@@ -291,6 +291,7 @@ class ForeignKeyFieldInstance(RelationalField):
         model_name: str,
         related_name: Union[Optional[str], Literal[False]] = None,
         on_delete: str = CASCADE,
+        to_field: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -303,6 +304,7 @@ class ForeignKeyFieldInstance(RelationalField):
         if on_delete == SET_NULL and not bool(kwargs.get("null")):
             raise ConfigurationError("If on_delete is SET_NULL, then field must have null=True set")
         self.on_delete = on_delete
+        self.to_field = to_field
 
 
 class BackwardFKRelation(RelationalField):
@@ -401,6 +403,7 @@ def ForeignKeyField(
     model_name: str,
     related_name: Union[Optional[str], Literal[False]] = None,
     on_delete: str = CASCADE,
+    to_field: Optional[str] = None,
     **kwargs: Any,
 ) -> ForeignKeyRelation:
     """
@@ -434,7 +437,7 @@ def ForeignKeyField(
                 Can only be set is field has a ``default`` set.
     """
 
-    return ForeignKeyFieldInstance(model_name, related_name, on_delete, **kwargs)
+    return ForeignKeyFieldInstance(model_name, related_name, on_delete, to_field, **kwargs)
 
 
 def ManyToManyField(

--- a/tortoise/fields/relational.py
+++ b/tortoise/fields/relational.py
@@ -61,6 +61,7 @@ class ReverseRelation(Generic[MODEL]):
         self.relation_field = relation_field
         self.instance = instance
         self.to_field = to_field
+        self.from_field_instance: "Field" = None  # type: ignore
         self._fetched = False
         self._custom_query = False
         self.related_objects: List[MODEL] = []

--- a/tortoise/fields/relational.py
+++ b/tortoise/fields/relational.py
@@ -55,13 +55,12 @@ class ReverseRelation(Generic[MODEL]):
     """
 
     def __init__(
-        self, model: Type[MODEL], relation_field: str, instance: "Model", to_field: str,
+        self, model: Type[MODEL], relation_field: str, instance: "Model", from_field: str,
     ) -> None:
         self.model = model
         self.relation_field = relation_field
         self.instance = instance
-        self.to_field = to_field
-        self.from_field_instance: "Field" = None  # type: ignore
+        self.from_field = from_field
         self._fetched = False
         self._custom_query = False
         self.related_objects: List[MODEL] = []
@@ -72,7 +71,7 @@ class ReverseRelation(Generic[MODEL]):
             raise OperationalError(
                 "This objects hasn't been instanced, call .save() before calling related queries"
             )
-        return self.model.filter(**{self.relation_field: getattr(self.instance, self.to_field)})
+        return self.model.filter(**{self.relation_field: getattr(self.instance, self.from_field)})
 
     def __contains__(self, item: Any) -> bool:
         if not self._fetched:

--- a/tortoise/fields/relational.py
+++ b/tortoise/fields/relational.py
@@ -54,10 +54,13 @@ class ReverseRelation(Generic[MODEL]):
     Relation container for :func:`.ForeignKeyField`.
     """
 
-    def __init__(self, model: Type[MODEL], relation_field: str, instance: "Model") -> None:
+    def __init__(
+        self, model: Type[MODEL], relation_field: str, instance: "Model", to_field: str,
+    ) -> None:
         self.model = model
         self.relation_field = relation_field
         self.instance = instance
+        self.to_field = to_field
         self._fetched = False
         self._custom_query = False
         self.related_objects: List[MODEL] = []
@@ -68,7 +71,7 @@ class ReverseRelation(Generic[MODEL]):
             raise OperationalError(
                 "This objects hasn't been instanced, call .save() before calling related queries"
             )
-        return self.model.filter(**{self.relation_field: self.instance.pk})
+        return self.model.filter(**{self.relation_field: getattr(self.instance, self.to_field)})
 
     def __contains__(self, item: Any) -> bool:
         if not self._fetched:
@@ -159,7 +162,7 @@ class ManyToManyRelation(ReverseRelation[MODEL]):
     def __init__(
         self, model: Type[MODEL], instance: "Model", m2m_field: "ManyToManyFieldInstance"
     ) -> None:
-        super().__init__(model, m2m_field.related_name, instance)
+        super().__init__(model, m2m_field.related_name, instance, "pk")
         self.field = m2m_field
         self.model = m2m_field.model_class  # type: ignore
         self.instance = instance
@@ -284,6 +287,7 @@ class RelationalField(Field):
         super().__init__(**kwargs)
         self.model_class: "Type[Model]" = None  # type: ignore
         self.to_field = to_field
+        self.to_field_instance: "Field" = None  # type: ignore
 
 
 class ForeignKeyFieldInstance(RelationalField):
@@ -308,9 +312,14 @@ class ForeignKeyFieldInstance(RelationalField):
 
 class BackwardFKRelation(RelationalField):
     def __init__(
-        self, field_type: "Type[Model]", relation_field: str, null: bool, description: Optional[str]
+        self,
+        field_type: "Type[Model]",
+        relation_field: str,
+        null: bool,
+        description: Optional[str],
+        **kwargs: Any,
     ) -> None:
-        super().__init__(null=null)
+        super().__init__(null=null, **kwargs)
         self.model_class: "Type[Model]" = field_type
         self.relation_field: str = relation_field
         self.description: Optional[str] = description

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -67,13 +67,15 @@ def _fk_setter(
     setattr(self, _key, value)
 
 
-def _fk_getter(self: "Model", _key: str, ftype: "Type[Model]", relation_field: str) -> Awaitable:
+def _fk_getter(
+    self: "Model", _key: str, ftype: "Type[Model]", relation_field: str, to_field: str
+) -> Awaitable:
     try:
         return getattr(self, _key)
     except AttributeError:
-        _pk = getattr(self, relation_field)
-        if _pk:
-            return ftype.filter(pk=_pk).first()
+        value = getattr(self, relation_field)
+        if value:
+            return ftype.filter(**{to_field: value}).first()
         return NoneAwaitable
 
 
@@ -280,6 +282,7 @@ class MetaInfo:
                         _key=_key,
                         ftype=field_object.model_class,  # type: ignore
                         relation_field=relation_field,
+                        to_field=to_field,
                     ),
                     partial(
                         _fk_setter, _key=_key, relation_field=relation_field, to_field=to_field,
@@ -327,6 +330,7 @@ class MetaInfo:
                         _key=_key,
                         ftype=field_object.model_class,  # type: ignore
                         relation_field=relation_field,
+                        to_field=to_field,
                     ),
                     partial(
                         _fk_setter, _key=_key, relation_field=relation_field, to_field=to_field,

--- a/tortoise/query_utils.py
+++ b/tortoise/query_utils.py
@@ -48,9 +48,6 @@ def _get_joins_for_related_field(
 ) -> List[Tuple[Table, Criterion]]:
     required_joins = []
 
-    table_pk = related_field.model._meta.db_pk_field
-    related_table_pk = related_field.model_class._meta.db_pk_field
-
     related_table = (
         related_field.model_class._meta.basetable
     )  # .as_(f"{table.get_table_name()}__{related_field_name}")
@@ -59,21 +56,23 @@ def _get_joins_for_related_field(
         required_joins.append(
             (
                 through_table,
-                getattr(table, table_pk) == getattr(through_table, related_field.backward_key),
+                getattr(table, related_field.model._meta.db_pk_field)
+                == getattr(through_table, related_field.backward_key),
             )
         )
         required_joins.append(
             (
                 related_table,
                 getattr(through_table, related_field.forward_key)
-                == getattr(related_table, related_table_pk),
+                == getattr(related_table, related_field.model_class._meta.db_pk_field),
             )
         )
     elif isinstance(related_field, BackwardFKRelation):
         required_joins.append(
             (
                 related_table,
-                getattr(table, table_pk) == getattr(related_table, related_field.relation_field),
+                getattr(table, related_field.to_field_instance.model_field_name)
+                == getattr(related_table, related_field.relation_field),
             )
         )
     else:
@@ -81,7 +80,7 @@ def _get_joins_for_related_field(
         required_joins.append(
             (
                 related_table,
-                getattr(related_table, related_table_pk)
+                getattr(related_table, related_field.to_field_instance.model_field_name)
                 == getattr(table, f"{related_field_name}_id"),
             )
         )

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -652,7 +652,9 @@ class UpdateQuery(AwaitableQuery):
             if isinstance(field_object, (ForeignKeyFieldInstance, OneToOneFieldInstance)):
                 fk_field: str = field_object.source_field  # type: ignore
                 db_field = self.model._meta.fields_map[fk_field].source_field
-                value = executor.column_map[fk_field](value.pk, None)
+                value = executor.column_map[fk_field](
+                    getattr(value, field_object.to_field_instance.model_field_name), None
+                )
             else:
                 try:
                     db_field = self.model._meta.fields_db_projection[key]


### PR DESCRIPTION
## Description
Support FK's to unique key.
* [x] Add `to_field` and `to_field_instance` to `Relational_field(...)`
* [x] Add `from_field` to `ReverseRelation`
* [x] Add validation for condition of foreignkey and pass `to_field_instance` at `_init_relations`
* [x] Change SQL schema generator with `to_field_instance`
* [x] Check SQL schema generation work with multiple backend (e.g. sqlite, postgresql, mysql ... ) 
* [x] Change foreignkey and reverse foreign key get/setter with `to_field_instance`
* [x] Change prefetch relations with `to_field_instance`
* [x] Change update foreignkey with `to_field_instance`
* [x] Change join with related field with `to_field_instance`
* [x] Add testcase 
* [x] Add examples
* [x] Renew Document

Fixed : #281  