### PR TITLE
Default ordering option

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 
 Changelog
 =========
+0.15.11
+-------
+- Added ``ordering`` option for model ``Meta`` class to apply default ordering
+
 0.15.10
 -------
 - Bumped requirements to cater for newer feature use (#282)

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -217,6 +217,17 @@ The ``Meta`` class
             indexes=(("field_a", "field_b"), )
             indexes=(("field_a", "field_b"), ("field_c", "field_d", "field_e")
 
+    .. attribute:: ordering
+        :annotation: = None
+
+        Specify ``ordering`` to set up default ordering for given model.
+        It should be iterable of strings formatted in same way as ``.order_by(...)`` receives.
+        If query is built with ``GROUP_BY`` clause using ``.annotate(...)`` default ordering is not applied.
+
+        .. code-block:: python3
+
+            ordering = ["name", "-score"]
+
 ``ForeignKeyField``
 -------------------
 

--- a/tests/test_order_by.py
+++ b/tests/test_order_by.py
@@ -1,7 +1,14 @@
-from tests.testmodels import Event, Tournament
+from tests.testmodels import (
+    DefaultOrdered,
+    DefaultOrderedDesc,
+    DefaultOrderedInvalid,
+    Event,
+    FKToDefaultOrdered,
+    Tournament,
+)
 from tortoise.contrib import test
-from tortoise.exceptions import FieldError
-from tortoise.functions import Count
+from tortoise.exceptions import ConfigurationError, FieldError
+from tortoise.functions import Count, Sum
 
 
 class TestOrderBy(test.TestCase):
@@ -74,3 +81,34 @@ class TestOrderBy(test.TestCase):
             "-events_count"
         )
         self.assertEqual([t.name for t in tournaments], ["1", "2"])
+
+
+class TestDefaultOrdering(test.TestCase):
+    async def test_default_order(self):
+        await DefaultOrdered.create(one="2", second=1)
+        await DefaultOrdered.create(one="1", second=1)
+
+        instance_list = await DefaultOrdered.all()
+        self.assertEqual([i.one for i in instance_list], ["1", "2"])
+
+    async def test_default_order_desc(self):
+        await DefaultOrderedDesc.create(one="1", second=1)
+        await DefaultOrderedDesc.create(one="2", second=1)
+
+        instance_list = await DefaultOrderedDesc.all()
+        self.assertEqual([i.one for i in instance_list], ["2", "1"])
+
+    async def test_default_order_invalid(self):
+        await DefaultOrderedInvalid.create(one="1", second=1)
+        await DefaultOrderedInvalid.create(one="2", second=1)
+
+        with self.assertRaises(ConfigurationError):
+            await DefaultOrderedInvalid.all()
+
+    async def test_default_order_annotated_query(self):
+        instance = await DefaultOrdered.create(one="2", second=1)
+        await FKToDefaultOrdered.create(link=instance, value=10)
+        await DefaultOrdered.create(one="1", second=1)
+
+        instance_list = await DefaultOrdered.all().annotate(res=Sum("related__value"))
+        self.assertEqual([i.one for i in instance_list], ["2", "1"])

--- a/tests/test_order_by.py
+++ b/tests/test_order_by.py
@@ -110,5 +110,7 @@ class TestDefaultOrdering(test.TestCase):
         await FKToDefaultOrdered.create(link=instance, value=10)
         await DefaultOrdered.create(one="1", second=1)
 
-        instance_list = await DefaultOrdered.all().annotate(res=Sum("related__value"))
-        self.assertEqual([i.one for i in instance_list], ["2", "1"])
+        queryset = DefaultOrdered.all().annotate(res=Sum("related__value"))
+        queryset._make_query()
+        query = queryset.query.get_sql()
+        self.assertTrue("order by" not in query.lower())

--- a/tests/testmodels.py
+++ b/tests/testmodels.py
@@ -514,3 +514,32 @@ class DoubleFK(Model):
     name = fields.CharField(max_length=50)
     left = fields.ForeignKeyField("models.DoubleFK", null=True, related_name="left_rel")
     right = fields.ForeignKeyField("models.DoubleFK", null=True, related_name="right_rel")
+
+
+class DefaultOrdered(Model):
+    one = fields.TextField()
+    second = fields.IntField()
+
+    class Meta:
+        ordering = ["one", "second"]
+
+
+class FKToDefaultOrdered(Model):
+    link = fields.ForeignKeyField("models.DefaultOrdered", related_name="related")
+    value = fields.IntField()
+
+
+class DefaultOrderedDesc(Model):
+    one = fields.TextField()
+    second = fields.IntField()
+
+    class Meta:
+        ordering = ["-one"]
+
+
+class DefaultOrderedInvalid(Model):
+    one = fields.TextField()
+    second = fields.IntField()
+
+    class Meta:
+        ordering = ["one", "third"]

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -739,4 +739,4 @@ def run_async(coro: Coroutine) -> None:
         loop.run_until_complete(Tortoise.close_connections())
 
 
-__version__ = "0.15.10"
+__version__ = "0.15.11"

--- a/tortoise/fields/base.py
+++ b/tortoise/fields/base.py
@@ -153,7 +153,7 @@ class Field(metaclass=_FieldMeta):
         self.model_field_name = ""
         self.description = description
         # TODO: consider making this not be set from constructor
-        self.model: "Model" = model  # type: ignore
+        self.model: Type["Model"] = model  # type: ignore
         # TODO: consider moving this to RelationalField
         self.reference = reference
 


### PR DESCRIPTION
Adds default `ordering` option for `Meta` class in models

## Description
It should work as per https://docs.djangoproject.com/en/3.0/ref/models/options/#ordering

## Motivation and Context
Some users are confused that this familiar option is not present in Tortoise

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

