### PR TITLE
Hotfix with get_or_none in Model classmethod

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,10 @@
 Changelog
 =========
 
+0.15.17
+-------
+- Now ``get_or_none(...)``, classmethod of ``Model`` class, works in the same way as ``queryset``
+
 0.15.16
 -------
 - ``get_or_none(...)`` now raises ``MultipleObjectsReturned`` if multiple object fetched. (#298)

--- a/tests/test_model_methods.py
+++ b/tests/test_model_methods.py
@@ -155,6 +155,11 @@ class TestModelMethods(test.TestCase):
         mdl = await self.cls.get_or_none(name="Test2")
         self.assertEqual(mdl, None)
 
+        await self.cls.create(name="Test")
+
+        with self.assertRaises(MultipleObjectsReturned):
+            await self.cls.get_or_none(name="Test")
+
 
 class TestModelMethodsNoID(TestModelMethods):
     async def setUp(self):

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -844,7 +844,7 @@ class Model(metaclass=ModelMeta):
         :param args:
         :param kwargs:
         """
-        return QuerySet(cls).filter(*args, **kwargs).first()
+        return QuerySet(cls).get_or_none(*args, **kwargs)
 
     @classmethod
     async def fetch_for_list(


### PR DESCRIPTION
## Description
Hotfix of #298, After applying this patch `get_or_none`, classmethod of `Model` class works in the same way as `queryset`

* [x]  Fix classmethod in Model class with `get_or_none`
* [x] Add negative test to test suite
* [x] Add description to CHANGELOG.rst