### PR TITLE
Fix IntegrityError with unique field and get_or_create

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -74,6 +74,7 @@ future
 
 - Fix default type of ``JSONField``
 - Install on Windows does not require a C compiler any more.
+- Fix ``IntegrityError`` with unique field and ``get_or_create``
 
 0.15.17
 -------

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -29,7 +29,6 @@ class TestConcurrencyIsolated(test.IsolatedTestCase):
         for una in unas:
             self.assertEqual(una[0], unas[0][0])
 
-    @test.expectedFailure
     async def test_concurrent_get_or_create(self):
         unas = await asyncio.gather(*[UniqueName.get_or_create(name="d") for _ in range(10)])
         una_created = [una[1] for una in unas if una[1] is True]
@@ -76,7 +75,6 @@ class TestConcurrencyTransactioned(test.TestCase):
         for una in unas:
             self.assertEqual(una[0], unas[0][0])
 
-    @test.skip("Crashes with MySQL & PostgreSQL")
     async def test_concurrent_get_or_create(self):
         unas = await asyncio.gather(*[UniqueName.get_or_create(name="b") for _ in range(10)])
         una_created = [una[1] for una in unas if una[1] is True]

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -29,6 +29,7 @@ class TestConcurrencyIsolated(test.IsolatedTestCase):
         for una in unas:
             self.assertEqual(una[0], unas[0][0])
 
+    @test.skipIf(sys.version_info < (3, 7), "aiocontextvars backport not handling this well")
     async def test_concurrent_get_or_create(self):
         unas = await asyncio.gather(*[UniqueName.get_or_create(name="d") for _ in range(10)])
         una_created = [una[1] for una in unas if una[1] is True]
@@ -75,6 +76,7 @@ class TestConcurrencyTransactioned(test.TestCase):
         for una in unas:
             self.assertEqual(una[0], unas[0][0])
 
+    @test.skipIf(sys.version_info < (3, 7), "aiocontextvars backport not handling this well")
     async def test_concurrent_get_or_create(self):
         unas = await asyncio.gather(*[UniqueName.get_or_create(name="b") for _ in range(10)])
         una_created = [una[1] for una in unas if una[1] is True]

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -1,5 +1,3 @@
-import sys
-
 from tests.testmodels import IntFields, MinRelation, Tournament
 from tortoise.contrib import test
 from tortoise.exceptions import DoesNotExist, FieldError, IntegrityError, MultipleObjectsReturned
@@ -278,7 +276,6 @@ class TestQueryset(test.TestCase):
         ):
             await IntFields.all().values_list(flat=True)
 
-    @test.skipIf(sys.version_info < (3, 6), "Class fields not sorted in 3.5")
     async def test_all_values_list(self):
         data = await IntFields.all().order_by("id").values_list()
         self.assertEqual(data[2], (self.intfields[2].id, 16, None))

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -7,7 +7,7 @@ from typing import Any, Awaitable, Dict, Generator, List, Optional, Set, Tuple, 
 from pypika import Order, Query, Table
 
 from tortoise.backends.base.client import BaseDBAsyncClient
-from tortoise.exceptions import ConfigurationError, OperationalError
+from tortoise.exceptions import ConfigurationError, IntegrityError, OperationalError
 from tortoise.fields.base import Field
 from tortoise.fields.data import IntField
 from tortoise.fields.relational import (
@@ -22,7 +22,7 @@ from tortoise.fields.relational import (
 from tortoise.filters import get_filters_for_field
 from tortoise.functions import Function
 from tortoise.queryset import Q, QuerySet, QuerySetSingle
-from tortoise.transactions import current_transaction_map
+from tortoise.transactions import current_transaction_map, in_transaction
 
 MODEL = TypeVar("MODEL", bound="Model")
 # TODO: Define Filter type object. Possibly tuple?
@@ -752,10 +752,18 @@ class Model(metaclass=ModelMeta):
         """
         if not defaults:
             defaults = {}
-        instance = await cls.filter(**kwargs).first()
-        if instance:
-            return instance, False
-        return await cls.create(**defaults, **kwargs, using_db=using_db), True
+        db = using_db if using_db else cls._meta.db
+        async with in_transaction(connection_name=db.connection_name):
+            instance = await cls.filter(**kwargs).first()
+            if instance:
+                return instance, False
+            try:
+                return await cls.create(**defaults, **kwargs), True
+            except IntegrityError:
+                instance = await cls.filter(**kwargs).first()
+                if instance:
+                    return instance, False
+                raise
 
     @classmethod
     async def create(cls: Type[MODEL], **kwargs: Any) -> MODEL:


### PR DESCRIPTION
Fixes #140

Had to introduce an extra lock for nested transactions for DB's that support it to prevent network errors with both PostgreSQL & MySQL.
