### PR TITLE
Remove deprecations

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,7 +3,6 @@ branch = True
 source =
     tortoise
 omit =
-    tortoise/aggregation.py
     tortoise/contrib/pylint/*
     tortoise/contrib/test/nose2.py
     tortoise/contrib/quart/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 python:
   - 3.7
   - 3.8
-  - 3.9-dev
 env:
   global:
     TORTOISE_TEST_MODULES=tests.testmodels

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,13 @@
 language: python
 python:
-  - 3.6
   - 3.7
   - 3.8
+  - 3.9-dev
 env:
   global:
     TORTOISE_TEST_MODULES=tests.testmodels
 matrix:
   include:
-  - python: pypy3.6-7.1.1
-    install: pip install -r tests/requirements-pypy.txt
-    script: make _testall
-    env: PYTEST_ADDOPTS="--no-cov"
-    after_success: echo
   - python: 3.7
     env: TEST_RUNNER=green
     script: green

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,11 @@ Changelog
 
 0.16.0
 ------
+.. caution::
+   **This release drops support of Python 3.6:**
+
+   Tortoise ORM now requires a minimum of CPython 3.7
+
 New features:
 ^^^^^^^^^^^^^
 * Model docstrings and ``#:`` comments directly preceding Field definitions are now used as docstrings and DDL descriptions.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@ Changelog
 0.16.0
 ------
 .. caution::
-   **This release drops support of Python 3.6:**
+   **This release drops support for Python 3.6:**
 
    Tortoise ORM now requires a minimum of CPython 3.7
 
@@ -109,11 +109,11 @@ Bugfixes:
 
 Removals:
 ^^^^^^^^^
-- Removed ``import from tortoise.aggregation`` as this was deprecated since 0.14.0
+- Removed ``tortoise.aggregation`` as this was deprecated since 0.14.0
 - Removed ``start_transaction`` as it has been broken since 0.15.0
 - Removed support for Python 3.6 / PyPy-3.6, as it has been broken since 0.15.0
 
-  If you still need Python 3.6 support, you can install ``tortoise-orm<0.16`` as we will still push critical bugfixes to it for a while.
+  If you still need Python 3.6 support, you can install ``tortoise-orm<0.16`` as we will still backport critical bugfixes to the 0.15 branch for a while.
 
 .. rst-class:: emphasize-children
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -104,7 +104,11 @@ Bugfixes:
 
 Removals:
 ^^^^^^^^^
+- Removed ``import from tortoise.aggregation`` as this was deprecated since 0.14.0
+- Removed ``start_transaction`` as it has been broken since 0.15.0
+- Removed support for Python 3.6 / PyPy-3.6, as it has been broken since 0.15.0
 
+  If you still need Python 3.6 support, you can install ``tortoise-orm<0.16`` as we will still push critical bugfixes to it for a while.
 
 .. rst-class:: emphasize-children
 

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,8 @@ help:
 	@echo  "    style       Auto-formats the code"
 
 up:
-	cd tests && CUSTOM_COMPILE_COMMAND="make up" pip-compile -o requirements-pypy.txt requirements-pypy.in -U
-	cd tests && CUSTOM_COMPILE_COMMAND="make up" pip-compile -o requirements.txt requirements.in -U
-	cat tests/extra_requirements.txt >> tests/requirements-pypy.txt
-	cat tests/extra_requirements.txt >> tests/requirements.txt
+	#cd tests && CUSTOM_COMPILE_COMMAND="make up" pip-compile -o requirements-pypy.txt requirements-pypy.in -U
+	cd tests && CUSTOM_COMPILE_COMMAND="make up" pip-compile -o requirements.txt requirements.in -Uv
 	sed -i "s/^-e .*/-e ./" tests/requirements.txt
 
 deps:

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ help:
 	@echo  "    style       Auto-formats the code"
 
 up:
-	#cd tests && CUSTOM_COMPILE_COMMAND="make up" pip-compile -o requirements-pypy.txt requirements-pypy.in -U
-	cd tests && CUSTOM_COMPILE_COMMAND="make up" pip-compile -o requirements.txt requirements.in -Uv
+	cd tests && CUSTOM_COMPILE_COMMAND="make up" pip-compile -o requirements-pypy.txt requirements-pypy.in -U
+	cd tests && CUSTOM_COMPILE_COMMAND="make up" pip-compile -o requirements.txt requirements.in -U
 	sed -i "s/^-e .*/-e ./" tests/requirements.txt
 
 deps:

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ You can find docs at `ReadTheDocs <http://tortoise-orm.readthedocs.io/en/latest/
    Tortoise ORM is young project and breaking changes are to be expected.
    We keep a `Changelog <http://tortoise-orm.readthedocs.io/en/latest/CHANGELOG.html>`_ and it will have possible breakage clearly documented.
 
-Tortoise ORM is supported on CPython >= 3.6 for SQLite, MySQL and PostgreSQL, and PyPy3.6 >= 7.1 for SQLite and MySQL only.
+Tortoise ORM is supported on CPython >= 3.7 for SQLite, MySQL and PostgreSQL.
 
 Why was Tortoise ORM built?
 ---------------------------

--- a/docs/CONTRIBUTING.rst
+++ b/docs/CONTRIBUTING.rst
@@ -99,7 +99,7 @@ Tortoise ORM follows a the following agreed upon style:
 * Always try to separate out terms clearly rather than concatenate words directly:
     * ``some_purpose`` instead of ``somepurpose``
     * ``SomePurpose`` instead of ``Somepurpose``
-* Keep in mind the targeted Python versions of ``>=3.6``:
+* Keep in mind the targeted Python versions of ``>=3.7``:
     * Do use f-strings
 * Please try and provide type annotations where you can, it will improve auto-completion in editors, and better static analysis.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,7 +13,7 @@ It's engraved in it's design that you are working not with just tables, you work
 
 Source & issue trackers are available at `<https://github.com/tortoise/tortoise-orm/>`_
 
-Tortoise ORM is supported on CPython >= 3.6 for SQLite, MySQL and PostgreSQL, and PyPy3.6 >= 7.1 for SQLite and MySQL only.
+Tortoise ORM is supported on CPython >= 3.7 for SQLite, MySQL and PostgreSQL.
 
 Introduction
 ============

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,3 @@ ciso8601>=2.1.2; sys_platform != "win32" and implementation_name == "cpython"
 iso8601>=0.1.12; sys_platform == "win32" or implementation_name != "cpython"
 aiosqlite>=0.11.0
 typing-extensions>=3.7
-
-# For Python3.6 compatibility
-aiocontextvars>=0.2.2;python_version<"3.7"

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,11 @@
 # coding: utf8
 import re
 import sys
-import warnings
 
 from setuptools import find_packages, setup
 
-if sys.version_info < (3, 6):
-    raise RuntimeError("Tortoise-ORM requires Python >= 3.6, 3.7+ is recommended")
-
 if sys.version_info < (3, 7):
-    warnings.warn("Tortoise-ORM will soon drop support for Python 3.6", DeprecationWarning)
+    raise RuntimeError("Tortoise-ORM requires Python >= 3.7")
 
 
 def version():

--- a/tests/extra_requirements.txt
+++ b/tests/extra_requirements.txt
@@ -1,4 +1,0 @@
-aiocontextvars==0.2.2 ; python_version < "3.7"
-contextvars==2.4 ; python_version < "3.7"
-immutables==0.9 ; python_version < "3.7"
-dataclasses==0.6 ; python_version<"3.7"

--- a/tests/requirements-pypy.in
+++ b/tests/requirements-pypy.in
@@ -1,9 +1,6 @@
 -r ../requirements.txt
 iso8601
 
-# Optional dependencies
-pyyaml>=4.2b1
-
 ## Database Drivers
 aiomysql
 

--- a/tests/requirements-pypy.txt
+++ b/tests/requirements-pypy.txt
@@ -22,10 +22,10 @@ idna==2.9                 # via requests
 importlib-metadata==1.5.0  # via pluggy, pytest
 iso8601==0.1.12           # via -r requirements-pypy.in
 more-itertools==8.2.0     # via pytest
-packaging==20.1           # via pytest
+packaging==20.3           # via pytest
 pluggy==0.13.1            # via pytest
 py==1.8.1                 # via pytest
-pycparser==2.19           # via cffi
+pycparser==2.20           # via cffi
 pydantic==1.4             # via -r requirements-pypy.in
 pymysql==0.9.2            # via aiomysql
 pyparsing==2.4.6          # via packaging
@@ -34,14 +34,9 @@ pytest-cov==2.8.1         # via -r requirements-pypy.in
 pytest-forked==1.1.3      # via pytest-xdist
 pytest-xdist==1.31.0      # via -r requirements-pypy.in
 pytest==5.3.5             # via -r requirements-pypy.in, pytest-cov, pytest-forked, pytest-xdist
-pyyaml==5.3               # via -r requirements-pypy.in
 requests==2.23.0          # via coveralls
 six==1.14.0               # via cryptography, packaging, pytest-xdist
 typing-extensions==3.7.4.1  # via -r ../requirements.txt
 urllib3==1.25.8           # via requests
 wcwidth==0.1.8            # via pytest
 zipp==3.1.0               # via importlib-metadata
-aiocontextvars==0.2.2 ; python_version < "3.7"
-contextvars==2.4 ; python_version < "3.7"
-immutables==0.9 ; python_version < "3.7"
-dataclasses==0.6 ; python_version<"3.7"

--- a/tests/requirements.in
+++ b/tests/requirements.in
@@ -1,8 +1,5 @@
 -e ..
 
-# Optional dependencies
-pyyaml>=4.2b1
-
 ## Database Drivers
 asyncpg
 aiomysql
@@ -45,12 +42,11 @@ python-rapidjson; implementation_name == "cpython"
 iso8601
 
 # Sample integration - Quart
-wsproto;python_version>="3.7"
-hypercorn;python_version>="3.7"
-quart;python_version>="3.7"
+quart
 
 # Sample integration - Sanic
 sanic
+ujson==1.35
 
 # Sample integration - Starlette
 starlette

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -49,7 +49,7 @@ hpack==3.0.0              # via h2
 hstspreload==2020.3.4     # via httpx
 httptools==0.1.1          # via sanic, uvicorn
 httpx==0.9.3              # via sanic
-hypercorn==0.9.2 ; python_version >= "3.7"  # via -r requirements.in, quart
+hypercorn==0.9.2          # via quart
 hyperframe==5.2.0         # via h2
 idna==2.9                 # via httpx, requests
 imagesize==1.2.0          # via sphinx
@@ -67,7 +67,7 @@ multidict==4.7.5          # via sanic
 mypy-extensions==0.4.3    # via mypy
 mypy==0.761               # via -r requirements.in
 nose2==0.9.2              # via -r requirements.in
-packaging==20.1           # via pytest, sphinx, tox
+packaging==20.3           # via pytest, sphinx, tox
 pathspec==0.7.0           # via black
 pbr==5.4.4                # via stevedore
 pip-tools==4.5.1          # via -r requirements.in
@@ -76,7 +76,7 @@ pluggy==0.13.1            # via pytest, tox
 priority==1.3.0           # via hypercorn
 py==1.8.1                 # via pytest, tox
 pycodestyle==2.5.0        # via flake8
-pycparser==2.19           # via cffi
+pycparser==2.20           # via cffi
 pydantic==1.4             # via -r requirements.in
 pyflakes==2.1.1           # via flake8
 pygments==2.3.1           # via -r ../docs/requirements.in, -r requirements.in, readme-renderer, sphinx
@@ -90,8 +90,8 @@ pytest-xdist==1.31.0      # via -r requirements.in
 pytest==5.3.5             # via -r requirements.in, pytest-cov, pytest-forked, pytest-xdist
 python-rapidjson==0.9.1 ; implementation_name == "cpython"  # via -r requirements.in
 pytz==2019.3              # via babel
-pyyaml==5.3               # via -r requirements.in, bandit
-quart==0.11.3 ; python_version >= "3.7"  # via -r requirements.in
+pyyaml==5.3               # via bandit
+quart==0.11.3             # via -r requirements.in
 readme-renderer==24.0     # via twine
 regex==2020.2.20          # via black
 requests-toolbelt==0.9.1  # via twine
@@ -113,23 +113,19 @@ tqdm==4.43.0              # via twine
 twine==1.15.0             # via -r requirements.in
 typed-ast==1.4.1          # via astroid, black, mypy
 typing-extensions==3.7.4.1  # via -r ../docs/../requirements.txt, hypercorn, mypy, tortoise-orm
-ujson==1.35               # via sanic
+ujson==1.35               # via -r requirements.in, sanic
 unidecode==1.1.1          # via green
 urllib3==1.25.8           # via requests
 uvicorn==0.11.3           # via -r requirements.in
 uvloop==0.14.0 ; sys_platform != "win32" and implementation_name == "cpython"  # via -r requirements.in, sanic, uvicorn
-virtualenv==20.0.7        # via tox
+virtualenv==20.0.8        # via tox
 wcwidth==0.1.8            # via pytest
 webencodings==0.5.1       # via bleach
 websockets==8.1           # via sanic, uvicorn
 werkzeug==1.0.0           # via quart
 wrapt==1.11.2             # via astroid
-wsproto==0.15.0 ; python_version >= "3.7"  # via -r requirements.in, hypercorn
+wsproto==0.15.0           # via hypercorn
 zipp==3.1.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
-aiocontextvars==0.2.2 ; python_version < "3.7"
-contextvars==2.4 ; python_version < "3.7"
-immutables==0.9 ; python_version < "3.7"
-dataclasses==0.6 ; python_version<"3.7"

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -1,7 +1,7 @@
 from tests.testmodels import Event, Team, Tournament
 from tortoise.contrib import test
 from tortoise.exceptions import OperationalError, TransactionManagementError
-from tortoise.transactions import atomic, in_transaction, start_transaction
+from tortoise.transactions import atomic, in_transaction
 
 
 class SomeException(Exception):
@@ -85,34 +85,6 @@ class TestTransactions(test.TruncationTestCase):
 
         with self.assertRaises(OperationalError):
             await bound_to_fall()
-        saved_event = await Tournament.filter(name="Test").first()
-        self.assertEqual(saved_event.id, tournament.id)
-        saved_event = await Tournament.filter(name="Updated name").first()
-        self.assertIsNone(saved_event)
-
-    @test.skip("start_transaction is dodgy")
-    async def test_transaction_manual_commit(self):
-        tournament = await Tournament.create(name="Test")
-
-        connection = await start_transaction()
-        await Tournament.filter(id=tournament.id).update(name="Updated name")
-        saved_event = await Tournament.filter(name="Updated name").first()
-        self.assertEqual(saved_event.id, tournament.id)
-        await connection.commit()
-
-        saved_event = await Tournament.filter(name="Updated name").first()
-        self.assertEqual(saved_event.id, tournament.id)
-
-    @test.skip("start_transaction is dodgy")
-    async def test_transaction_manual_rollback(self):
-        tournament = await Tournament.create(name="Test")
-
-        connection = await start_transaction()
-        await Tournament.filter(id=tournament.id).update(name="Updated name")
-        saved_event = await Tournament.filter(name="Updated name").first()
-        self.assertEqual(saved_event.id, tournament.id)
-        await connection.rollback()
-
         saved_event = await Tournament.filter(name="Test").first()
         self.assertEqual(saved_event.id, tournament.id)
         saved_event = await Tournament.filter(name="Updated name").first()

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import warnings
+from contextvars import ContextVar
 from copy import deepcopy
 from inspect import isclass
 from typing import Any, Coroutine, Dict, List, Optional, Tuple, Type, Union, cast
@@ -26,11 +27,6 @@ from tortoise.models import Model
 from tortoise.queryset import QuerySet
 from tortoise.transactions import current_transaction_map
 from tortoise.utils import generate_schema_for_client
-
-try:
-    from contextvars import ContextVar
-except ImportError:  # pragma: nocoverage
-    from aiocontextvars import ContextVar  # type: ignore
 
 logger = logging.getLogger("tortoise")
 

--- a/tortoise/aggregation.py
+++ b/tortoise/aggregation.py
@@ -1,7 +1,0 @@
-import warnings
-
-from tortoise.functions import Avg, Count, Function, Max, Min, Sum  # noqa
-
-warnings.warn(
-    "Please import from tortoise.functions instead of tortoise.aggregation", DeprecationWarning
-)

--- a/tortoise/contrib/pydantic/creator.py
+++ b/tortoise/contrib/pydantic/creator.py
@@ -231,7 +231,7 @@ def pydantic_model_creator(
         }
     )
 
-    # Sort field map (Python 3.6 has ordered dictionary keys)
+    # Sort field map (Python 3.7+ has guaranteed ordered dictionary keys)
     if _sort_fields:
         # Sort Alphabetically
         field_map = {k: field_map[k] for k in sorted(field_map)}

--- a/tortoise/transactions.py
+++ b/tortoise/transactions.py
@@ -1,4 +1,3 @@
-import warnings
 from functools import wraps
 from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, cast
 
@@ -9,7 +8,6 @@ current_transaction_map: dict = {}
 if TYPE_CHECKING:  # pragma: nocoverage
     from tortoise.backends.base.client import (
         BaseDBAsyncClient,
-        BaseTransactionWrapper,
         TransactionContext,
     )
 
@@ -68,34 +66,3 @@ def atomic(connection_name: Optional[str] = None) -> Callable[[F], F]:
         return cast(F, wrapped)
 
     return wrapper
-
-
-async def start_transaction(
-    connection_name: Optional[str] = None,
-) -> "BaseTransactionWrapper":  # pragma: nocoverage
-    """
-    Function to manually control your transaction.
-
-    .. warning::
-        **Deprecated, to be removed in v0.15**
-
-        ``start_transaction`` leaks context.
-        Please use ``@atomic()`` or ``async with in_transaction():`` instead.
-
-    Returns transaction object with ``.rollback()`` and ``.commit()`` methods.
-    All db calls in same coroutine context will run into transaction
-    before ending transaction with above methods.
-
-    :param connection_name: name of connection to run with, optional if you have only
-                            one db connection
-    """
-    warnings.warn(
-        "start_transaction leaks context,"
-        " please use '@atomic()' or 'async with in_transaction():' instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    connection = _get_connection(connection_name)
-    transaction = connection._in_transaction()
-    await transaction.connection.start()
-    return transaction.connection

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38},pypy3
+envlist = py{37,38}
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Fixes #303 

Done:
- [x] Removed ``import from tortoise.aggregation`` as this was deprecated since 0.14.0
- [x] Removed ``start_transaction`` as it has been broken since 0.15.0
- [x] Removed support for Python 3.6 / PyPy-3.6, as it has been broken since 0.15.0