### PR TITLE
Add clarification for parameter 'default' to docstring of base Field

### DIFF
--- a/tortoise/fields/base.py
+++ b/tortoise/fields/base.py
@@ -38,6 +38,7 @@ class Field(metaclass=_FieldMeta):
     :param null: Is this field nullable?
     :param default: A default value for the field if not specified on Model creation.
         This can also be a callable for dynamic defaults in which case we will call it.
+        The default value will not be part of the schema.
     :param unique: Is this field unique?
     :param index: Should this field be indexed by itself?
     :param description: Field description. Will also appear in ``Tortoise.describe_model()``


### PR DESCRIPTION
I was wondering why the value of the default parameter was not part of the schema. This clarification would have been useful.