### PR TITLE
Hotfix for aggregation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,7 @@ Changelog
   * ``maxLength`` for CharFields
   * ``minimum`` & ``maximum`` values for integer fields
 
-  To get Pydantic to handle nullable/defaulted fields correctly one should do a ``**user.dict(exclude_unset=True)`` when passing values to a Model class.
+  To get Pydantic to handle nullable/default fields correctly one should do a ``**user.dict(exclude_unset=True)`` when passing values to a Model class.
 
 * Added ``FastAPI`` helper that is based on the ``starlette`` helper but optionally adds helpers to catch and report with proper error ``DoesNotExist`` and ``IntegrityError`` Tortoise exceptions.
 * Allows a Pydantic model to exclude all read-only fields by setting ``exclude_readonly=True`` when calling ``pydantic_model_creator``.

--- a/tortoise/functions.py
+++ b/tortoise/functions.py
@@ -106,7 +106,6 @@ class Function:
 
         if isinstance(self.field, str):
             function = self._resolve_field_for_model(model, table, self.field, *self.default_values)
-            function["joins"] = reversed(function["joins"])
             return function
         else:
             field, field_object = F.resolver_arithmetic_expression(model, self.field)


### PR DESCRIPTION
We found #317 change `joins` order in aggregation. So removing reversed operation may fix this bug(and fortunately, it leads to better performance) Add more testcase to check aggregation. 

Special thank to detailed bug reporting @pjongy 
Fixed : #327 

- [x] Fix bug in join with aggregation
- [x] Add more testcase to aggregation 
- [x] Add Changelog