### PR TITLE
Nested order_by path + unittest

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,10 @@ Changelog
 
 0.16
 ====
+0.16.3
+------
+* Fix bug with order_by on nested fields
+
 0.16.2
 ------
 * Default ``values()`` & ``values_list()`` now includes annotations.

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -27,6 +27,7 @@ Contributors
 * Jinlong Peng ``@long2ice``
 * Sang-Heon Jeon ``@lntuition``
 * Jong-Yeop Park ``@pjongy``
+* ``@sm0k``
 
 Special Thanks
 ==============

--- a/tests/test_order_by_nested.py
+++ b/tests/test_order_by_nested.py
@@ -1,0 +1,25 @@
+from tests.testmodels import Event, Tournament
+from tortoise.contrib import test
+
+
+class TestOrderByNested(test.TestCase):
+    async def test_basic(self):
+        await Event.create(
+            name="Event 1", tournament=await Tournament.create(name="Tournament 1", desc="B")
+        )
+        await Event.create(
+            name="Event 2", tournament=await Tournament.create(name="Tournament 2", desc="A")
+        )
+
+        self.assertEqual(
+            await Event.all().prefetch_related("tournament").values("tournament__desc"),
+            [{"tournament__desc": "B"}, {"tournament__desc": "A"}],
+        )
+
+        self.assertEqual(
+            await Event.all()
+            .prefetch_related("tournament")
+            .order_by("tournament__desc")
+            .values("tournament__desc"),
+            [{"tournament__desc": "A"}, {"tournament__desc": "B"}],
+        )

--- a/tests/test_order_by_nested.py
+++ b/tests/test_order_by_nested.py
@@ -13,7 +13,7 @@ class TestOrderByNested(test.TestCase):
 
         self.assertEqual(
             await Event.all().order_by("-name").values("name"),
-            [{'name': "Event 2"}, {'name': "Event 1"}],
+            [{"name": "Event 2"}, {"name": "Event 1"}],
         )
 
         self.assertEqual(

--- a/tests/test_order_by_nested.py
+++ b/tests/test_order_by_nested.py
@@ -12,6 +12,11 @@ class TestOrderByNested(test.TestCase):
         )
 
         self.assertEqual(
+            await Event.all().order_by("-name").values("name"),
+            [{'name': "Event 2"}, {'name': "Event 1"}],
+        )
+
+        self.assertEqual(
             await Event.all().prefetch_related("tournament").values("tournament__desc"),
             [{"tournament__desc": "B"}, {"tournament__desc": "A"}],
         )

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -184,10 +184,7 @@ class AwaitableQuery(Generic[MODEL]):
                 annotation_info = annotation.resolve(self.model, table)
                 self.query = self.query.orderby(annotation_info["field"], order=ordering[1])
             else:
-                if self.model != model:
-                    field_object = model._meta.fields_map.get(field_name)
-                else:
-                    field_object = self.model._meta.fields_map.get(field_name)
+                field_object = model._meta.fields_map.get(field_name)
 
                 if not field_object:
                     raise FieldError(f"Unknown field {field_name} for model {self.model.__name__}")

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -187,7 +187,7 @@ class AwaitableQuery(Generic[MODEL]):
                 field_object = model._meta.fields_map.get(field_name)
 
                 if not field_object:
-                    raise FieldError(f"Unknown field {field_name} for model {self.model.__name__}")
+                    raise FieldError(f"Unknown field {field_name} for model {model.__name__}")
                 field_name = field_object.source_field or field_name
                 field = getattr(table, field_name)
 

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -184,7 +184,11 @@ class AwaitableQuery(Generic[MODEL]):
                 annotation_info = annotation.resolve(self.model, table)
                 self.query = self.query.orderby(annotation_info["field"], order=ordering[1])
             else:
-                field_object = self.model._meta.fields_map.get(field_name)
+                if self.model != model:
+                    field_object = model._meta.fields_map.get(field_name)
+                else:
+                    field_object = self.model._meta.fields_map.get(field_name)
+
                 if not field_object:
                     raise FieldError(f"Unknown field {field_name} for model {self.model.__name__}")
                 field_name = field_object.source_field or field_name


### PR DESCRIPTION
Patch for order_by method on nested field

## Description
`field_object = self.model._meta.fields_map.get(field_name)`
Becomes
`field_object = model._meta.fields_map.get(field_name) if self.model != model else self.model._meta.fields_map.get(field_name)`
in queryset.py

## Motivation and Context
https://github.com/tortoise/tortoise-orm/issues/326

## How Has This Been Tested?
See py.test tests/test_order_by_nested.py

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

