### PR TITLE
Partial model .only(...) support 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,27 @@ Changelog
 
 0.16
 ====
+0.16.6
+------
+* Added support for partial models:
+
+  To create a partial model, one can do a ``.only(<fieldnames-as-strings>)`` as part of the QuerySet.
+  This will create model instances that only have those values fetched.
+
+  Persisting changes on the model is allowed only when:
+
+  * All the fields you want to update is specified in ``<model>.save(update_fields=[...])``
+  * You included the Model primary key in the `.only(...)``
+
+  To protect against common mistakes we ensure that errors get raised:
+
+  * If you access a field that is not specified, you will get an ``AttributeError``.
+  * If you do a ``<model>.save()`` a ``IncompleteInstanceError`` will be raised as the model is, as requested, incomplete.
+  * If you do a ``<model>.save(update_fields=[...])`` and you didn't include the primary key in the ``.only(...)``,
+    then ``IncompleteInstanceError`` will be raised indicating that updates can't be done without the primary key being known.
+  * If you do a ``<model>.save(update_fields=[...])`` and one of the fields in ``update_fields`` was not in the ``.only(...)``,
+    then ``IncompleteInstanceError`` as that field is not available to be updated.
+
 0.16.5
 ------
 * Moved ``Tortoise.describe_model(<MODEL>, ...)`` to ``<MODEL>.describe(...)``

--- a/tests/test_only.py
+++ b/tests/test_only.py
@@ -1,0 +1,49 @@
+from tests.testmodels import SourceFields, StraightFields
+from tortoise.contrib import test
+from tortoise.exceptions import IncompleteInstanceError
+
+
+class TestOnlyStraight(test.TestCase):
+    async def setUp(self) -> None:
+        self.model = StraightFields
+        self.instance = await self.model.create(chars="Test")
+
+    async def test_fetch(self):
+        instance_part = await self.model.get(chars="Test").only("chars", "blip")
+
+        self.assertEqual(instance_part.chars, "Test")
+        with self.assertRaises(AttributeError):
+            _ = instance_part.nullable
+
+    async def test_save(self):
+        instance_part = await self.model.get(chars="Test").only("chars", "blip")
+
+        with self.assertRaisesRegex(IncompleteInstanceError, " is a partial model"):
+            await instance_part.save()
+
+    async def test_partial_save(self):
+        instance_part = await self.model.get(chars="Test").only("chars", "blip")
+
+        with self.assertRaisesRegex(IncompleteInstanceError, "Partial update not available"):
+            await instance_part.save(update_fields=["chars"])
+
+    async def test_partial_save_with_pk_wrong_field(self):
+        instance_part = await self.model.get(chars="Test").only("chars", "eyedee")
+
+        with self.assertRaisesRegex(IncompleteInstanceError, "field 'nullable' is not available"):
+            await instance_part.save(update_fields=["nullable"])
+
+    async def test_partial_save_with_pk(self):
+        instance_part = await self.model.get(chars="Test").only("chars", "eyedee")
+
+        instance_part.chars = "Test1"
+        await instance_part.save(update_fields=["chars"])
+
+        instance2 = await self.model.get(pk=self.instance.pk)
+        self.assertEqual(instance2.chars, "Test1")
+
+
+class TestOnlySource(TestOnlyStraight):
+    async def setUp(self) -> None:
+        self.model = SourceFields  # type: ignore
+        self.instance = await self.model.create(chars="Test")

--- a/tests/test_only.py
+++ b/tests/test_only.py
@@ -8,8 +8,23 @@ class TestOnlyStraight(test.TestCase):
         self.model = StraightFields
         self.instance = await self.model.create(chars="Test")
 
-    async def test_fetch(self):
+    async def test_get(self):
         instance_part = await self.model.get(chars="Test").only("chars", "blip")
+
+        self.assertEqual(instance_part.chars, "Test")
+        with self.assertRaises(AttributeError):
+            _ = instance_part.nullable
+
+    async def test_filter(self):
+        instances = await self.model.filter(chars="Test").only("chars", "blip")
+
+        self.assertEqual(len(instances), 1)
+        self.assertEqual(instances[0].chars, "Test")
+        with self.assertRaises(AttributeError):
+            _ = instances[0].nullable
+
+    async def test_first(self):
+        instance_part = await self.model.filter(chars="Test").only("chars", "blip").first()
 
         self.assertEqual(instance_part.chars, "Test")
         with self.assertRaises(AttributeError):

--- a/tortoise/exceptions.py
+++ b/tortoise/exceptions.py
@@ -59,6 +59,12 @@ class DoesNotExist(OperationalError):
     """
 
 
+class IncompleteInstanceError(OperationalError):
+    """
+    The IncompleteInstanceError exception is raised when a partial model is attempted to be persisted.
+    """
+
+
 class DBConnectionError(BaseORMException, ConnectionError):
     """
     The DBConnectionError is raised when problems with connecting to db occurs

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -558,7 +558,21 @@ class QuerySet(AwaitableQuery[MODEL]):
 
     def only(self, *fields_for_select: str) -> "QuerySet[MODEL]":
         """
-        Fetch ONLY the specified fields.
+        Fetch ONLY the specified fields to create a partial model.
+
+        Persisting changes on the model is allowed only when:
+
+        * All the fields you want to update is specified in ``<model>.save(update_fields=[...])``
+        * You included the Model primary key in the `.only(...)``
+
+        To protect against common mistakes we ensure that errors get raised:
+
+        * If you access a field that is not specified, you will get an ``AttributeError``.
+        * If you do a ``<model>.save()`` a ``IncompleteInstanceError`` will be raised as the model is, as requested, incomplete.
+        * If you do a ``<model>.save(update_fields=[...])`` and you didn't include the primary key in the ``.only(...)``,
+          then ``IncompleteInstanceError`` will be raised indicating that updates can't be done without the primary key being known.
+        * If you do a ``<model>.save(update_fields=[...])`` and one of the fields in ``update_fields`` was not in the ``.only(...)``,
+          then ``IncompleteInstanceError`` as that field is not available to be updated.
         """
         queryset = self._clone()
         queryset._fields_for_select = fields_for_select


### PR DESCRIPTION
Fixes #125 

Done:
* [x] Populates model partially
* [x] raises ``AttributeError`` for unpopulated fields
* [x] raises ``IncompleteInstanceError`` when attempting to save field that isn't populated (meaning it works only when both PK and the ``update_fields`` are ALL available.
* [x] Works for ``source_field``'ed fields
* [x] Test for ``.filter()``, and not just ``.get()``
* [x] Document usage of ``.only()`` with caveats
* [x] Update changelog
