### PR TITLE
Process URL encoded password in connection string (fixes #355)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,7 @@ Changelog
 
 - Fixed bad SQL generation when doing a ``.values()`` query over a Foreign Key
 - Added `<model>.update_from_dict({...})` that will mass update values safely from a dictionary
+- Fixed processing URL encoded password in connection string
 
 0.16.5
 ------

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -28,6 +28,7 @@ Contributors
 * Sang-Heon Jeon ``@lntuition``
 * Jong-Yeop Park ``@pjongy``
 * ``@sm0k``
+* Lev Gorodetskiy ``@droserasprout``
 
 Special Thanks
 ==============

--- a/docs/databases.rst
+++ b/docs/databases.rst
@@ -23,6 +23,14 @@ The form is:
 
 :samp:`{DB_TYPE}://{USERNAME}:{PASSWORD}@{HOST}:{PORT}/{DB_NAME}?{PARAM1}=value&{PARAM2}=value`
 
+If password contains special characters it need to be URL encoded:
+
+.. code-block::  python3
+
+    >>> import urllib.parse
+    >>> urllib.parse.quote_plus("kx%jj5/g")
+    'kx%25jj5%2Fg'
+
 The supported ``DB_TYPE``:
 
 ``sqlite``:

--- a/tests/backends/test_db_url.py
+++ b/tests/backends/test_db_url.py
@@ -108,6 +108,22 @@ class TestConfigGenerator(test.SimpleTestCase):
             },
         )
 
+    def test_postgres_encoded_password(self):
+        res = expand_db_url("postgres://postgres:kx%25jj5%2Fg@127.0.0.1:54321/test")
+        self.assertDictEqual(
+            res,
+            {
+                "engine": "tortoise.backends.asyncpg",
+                "credentials": {
+                    "database": "test",
+                    "host": "127.0.0.1",
+                    "password": "kx%jj5/g",
+                    "port": 54321,
+                    "user": "postgres",
+                },
+            },
+        )
+
     def test_postgres_no_db(self):
         res = expand_db_url("postgres://postgres:moo@127.0.0.1:54321")
         self.assertDictEqual(
@@ -191,6 +207,24 @@ class TestConfigGenerator(test.SimpleTestCase):
                     "database": "test",
                     "host": "127.0.0.1",
                     "password": "",
+                    "port": 33060,
+                    "user": "root",
+                    "charset": "utf8mb4",
+                    "sql_mode": "STRICT_TRANS_TABLES",
+                },
+            },
+        )
+
+    def test_mysql_encoded_password(self):
+        res = expand_db_url("mysql://root:kx%25jj5%2Fg@127.0.0.1:33060/test")
+        self.assertEqual(
+            res,
+            {
+                "engine": "tortoise.backends.mysql",
+                "credentials": {
+                    "database": "test",
+                    "host": "127.0.0.1",
+                    "password": "kx%jj5/g",
                     "port": 33060,
                     "user": "root",
                     "charset": "utf8mb4",

--- a/tortoise/backends/base/config_generator.py
+++ b/tortoise/backends/base/config_generator.py
@@ -106,7 +106,9 @@ def expand_db_url(db_url: str, testing: bool = False) -> dict:
     if vmap.get("password"):
         # asyncpg accepts None for password, but aiomysql not
         params[vmap["password"]] = (
-            None if (not url.password and db_backend == "postgres") else str(url.password or "")
+            None
+            if (not url.password and db_backend == "postgres")
+            else urlparse.unquote_plus(url.password or "")
         )
 
     return {"engine": db["engine"], "credentials": params}


### PR DESCRIPTION
Process URL encoded password in connection string.

## Description


## Motivation and Context
This fix allows to use passwords containing special characters.

## How Has This Been Tested?
Tests for `expand_db_url` function added.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

