### PR TITLE
Allow filter to aggregate function

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ Changelog
 0.16
 ====
 
+0.16.8
+------
+- Allow `Q` expression to function with `_filter` parameter
+
 0.16.7
 ------
 - Added preliminary support for Python 3.9

--- a/examples/functions.py
+++ b/examples/functions.py
@@ -1,6 +1,7 @@
 from tortoise import Tortoise, fields, run_async
 from tortoise.functions import Coalesce, Count, Length, Lower, Min, Sum, Trim, Upper
 from tortoise.models import Model
+from tortoise.query_utils import Q
 
 
 class Tournament(Model):
@@ -57,6 +58,11 @@ async def run():
     await event.participants.add(participants[0], participants[1])
 
     print(await Tournament.all().annotate(events_count=Count("events")).filter(events_count__gte=1))
+    print(
+        await Tournament.all()
+        .annotate(events_count_with_filter=Count("events", _filter=Q(name="New Tournament")))
+        .filter(events_count_with_filter__gte=1)
+    )
 
     print(await Event.filter(id=event.id).first().annotate(lowest_team_id=Min("participants__id")))
 

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -94,20 +94,23 @@ class TestAggregation(test.TestCase):
 
     async def test_aggregation_with_filter(self):
         tournament = await Tournament.create(name="New Tournament")
-        await MinRelation.create(tournament=tournament)
-        await MinRelation.create(tournament=tournament)
+        await Event.create(name="Event 1", tournament=tournament)
+        await Event.create(name="Event 2", tournament=tournament)
+        await Event.create(name="Event 3", tournament=tournament)
 
         tournament_with_filter = (
             await Tournament.all()
             .annotate(
-                all=Count("minrelations", distinct=True, _filter=Q(name__in=["New Tournament"])),
-                no=Count("minrelations", _filter=Q(name__not="New Tournament")),
+                all=Count("events", _filter=Q(name="New Tournament")),
+                one=Count("events", _filter=Q(events__name="Event 1")),
+                two=Count("events", _filter=Q(events__name__not="Event 1")),
             )
             .first()
         )
 
-        self.assertEqual(tournament_with_filter.all, 2)
-        self.assertEqual(tournament_with_filter.no, 0)
+        self.assertEqual(tournament_with_filter.all, 3)
+        self.assertEqual(tournament_with_filter.one, 1)
+        self.assertEqual(tournament_with_filter.two, 2)
 
     async def test_group_aggregation(self):
         author = await Author.create(name="Some One")


### PR DESCRIPTION
Allow `Q` for filter of aggregate Functions.

Fixed : #309 

* [x] Allow `_filter` param to aggregate function
* [x] Add testcase
* [x] Add Example
* [x] Update Changelog