### PR TITLE
fix: "sqlite://:memory:" in Windows

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,10 @@ Changelog
 
 0.16
 ====
+0.16.11
+-------
+- fix: ``sqlite://:memory:`` in Windows thrown ``OSError: [WinError 123]``
+
 0.16.10
 -------
 - Fix bad import of ``basestring``

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -29,6 +29,7 @@ Contributors
 * Jong-Yeop Park ``@pjongy``
 * ``@sm0k``
 * Lev Gorodetskiy ``@droserasprout``
+* Hao Gong  ``@dongfangtianyu``
 
 Special Thanks
 ==============

--- a/tortoise/backends/sqlite/client.py
+++ b/tortoise/backends/sqlite/client.py
@@ -91,6 +91,9 @@ class SqliteClient(BaseDBAsyncClient):
             os.remove(self.filename)
         except FileNotFoundError:  # pragma: nocoverage
             pass
+        except OSError as e:
+            if e.errno != 22:  # fix: "sqlite://:memory:" in Windows
+                raise e
 
     def acquire_connection(self) -> ConnectionWrapper:
         return ConnectionWrapper(self._connection, self._lock)


### PR DESCRIPTION
## Description
Catch OSError and OSError.errno ==22

## Motivation and Context
When use `"sqlite://:memory:" ` in Windows, 
```
OSError: [WinError 123] The filename, directory name, or volume label syntax is 
incorrect
```

## How Has This Been Tested?
I  tested it on my own computer
Only Linux in Travis Ci, which may not be automatically verified. 
But it's easy to test on all Windows .


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

