### PR TITLE
docs: add test code to FastAPI Examples

### DIFF
--- a/docs/examples/fastapi.rst
+++ b/docs/examples/fastapi.rst
@@ -22,6 +22,9 @@ models.py
 ---------
 .. literalinclude::  ../../examples/fastapi/models.py
 
+tests.py
+-------
+.. literalinclude::  ../../examples/fastapi/_tests.py
 main.py
 -------
 .. literalinclude::  ../../examples/fastapi/main.py

--- a/examples/fastapi/_tests.py
+++ b/examples/fastapi/_tests.py
@@ -1,0 +1,40 @@
+# mypy: no-disallow-untyped-decorators
+# pylint: disable=E0611
+import asyncio
+from typing import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from main import app
+from models import Users
+from tortoise.contrib.test import finalizer, initializer
+
+
+@pytest.fixture(scope="module")
+def client() -> Generator:
+    initializer(["models"])
+    with TestClient(app) as c:
+        yield c
+    finalizer()
+
+
+@pytest.fixture(scope="module")
+def event_loop(client: TestClient) -> Generator:
+    yield client.task.get_loop()
+
+
+def test_create_user(client: TestClient, event_loop: asyncio.AbstractEventLoop):  # nosec
+    response = client.post("/users", json={"username": "admin"})
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["username"] == "admin"
+    assert "id" in data
+    user_id = data["id"]
+
+    async def get_user_by_db():
+        user = await Users.get(id=user_id)
+        return user
+
+    user_obj = event_loop.run_until_complete(get_user_by_db())
+    assert user_obj.id == user_id


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Create an coroutine in the synchronization code ，and give it to the event loop of FastAPI app to run. 
In this way, API, DB and TestCase will use the same event loop to avoid many problems

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This may not be the best option, but it's worth documenting so others can continue to improve : )

## How Has This Been Tested?
```bash
cd examples/fastapi
pip install tortoise-orm fastapi  pytest requests asynctest
pytest tests.py
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

