### PR TITLE
change pypika version to equal 0.36.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pypika>=0.36.5
+pypika==0.36.5
 ciso8601>=2.1.2; sys_platform != "win32" and implementation_name == "cpython"
 iso8601>=0.1.12; sys_platform == "win32" or implementation_name != "cpython"
 aiosqlite>=0.11.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
HOTFIX: change required version of pypika
## Description
<!--- Describe your changes in detail -->
Pypika has removed basestring from from pypika.terms in new version, requirements.txt is using the newest version and that cause fail build on Heroku. 
"""
ImportError: cannot import name 'basestring' from 'pypika.terms' (/app/.heroku/python/lib/python3.8/site-packages/pypika/terms.py)
"""

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

