### PR TITLE
(WIP) Add .sql() (#95)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Changelog
 - Make ``Field.default`` effect on db level when generate table
 - Add converters instead of importing from pymysql
 - Fix postgres BooleanField default value convent
+- Add ``.sql()`` method on ``QuerySet``
 
 0.16.11
 -------

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -30,6 +30,7 @@ Contributors
 * ``@sm0k``
 * Lev Gorodetskiy ``@droserasprout``
 * Hao Gong  ``@dongfangtianyu``
+* Peng Gao ``@Priestch``
 
 Special Thanks
 ==============

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -317,4 +317,4 @@ class TestQueryset(test.TestCase):
 
     async def test_get_raw_sql(self):
         sql = IntFields.all().sql()
-        self.assertRegex(sql, r'^SELECT.+FROM.+')
+        self.assertRegex(sql, r"^SELECT.+FROM.+")

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -317,4 +317,4 @@ class TestQueryset(test.TestCase):
 
     async def test_get_raw_sql(self):
         sql = IntFields.all().sql()
-        self.assertGreater(len(sql), 10)
+        self.assertRegex(sql, r'^SELECT.+FROM.+')

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -314,3 +314,7 @@ class TestQueryset(test.TestCase):
     async def test_order_by_bad_value(self):
         with self.assertRaisesRegex(FieldError, "Unknown field badid for model IntFields"):
             await IntFields.all().order_by("badid").values_list()
+
+    async def test_get_raw_sql(self):
+        sql = IntFields.all().sql()
+        self.assertGreater(len(sql), 10)

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -218,6 +218,12 @@ class AwaitableQuery(Generic[MODEL]):
 
         return any(info["field"].is_aggregate for info in annotation_info.values())
 
+    def sql(self) -> str:
+        """Return the actual SQL.
+        """
+        self._make_query()
+        return self.query.get_sql()
+
     def _make_query(self) -> None:
         raise NotImplementedError()  # pragma: nocoverage
 
@@ -656,12 +662,6 @@ class QuerySet(AwaitableQuery[MODEL]):
         return await self._db.executor_class(model=self.model, db=self._db).execute_explain(
             self.query
         )
-
-    async def sql(self) -> str:
-        """Return the actual SQL.
-        """
-        self._make_query()
-        return self.query.get_sql()
 
     def using_db(self, _db: BaseDBAsyncClient) -> "QuerySet[MODEL]":
         """

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -657,6 +657,12 @@ class QuerySet(AwaitableQuery[MODEL]):
             self.query
         )
 
+    async def sql(self) -> str:
+        """Return the actual SQL.
+        """
+        self._make_query()
+        return self.query.get_sql()
+
     def using_db(self, _db: BaseDBAsyncClient) -> "QuerySet[MODEL]":
         """
         Executes query in provided db client.


### PR DESCRIPTION
## Description
Add .sql() method for instance of QuerySet to get the actual SQL be executed.

## Motivation and Context
Sometimes we just want to make sure that the SQL generated by the ORM is correct, or for debugging usage as described in #95 

## How Has This Been Tested?
I'm not sure how to add related test code, maybe current test is enough?

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

