### PR TITLE
Support config of loop and connection class to asyncpg

### DIFF
--- a/tortoise/backends/asyncpg/client.py
+++ b/tortoise/backends/asyncpg/client.py
@@ -50,6 +50,8 @@ class AsyncpgDBClient(BaseDBAsyncClient):
     executor_class = AsyncpgExecutor
     schema_generator = AsyncpgSchemaGenerator
     capabilities = Capabilities("postgres")
+    connection_class = asyncpg.connection.Connection
+    loop = None
 
     def __init__(
         self, user: str, password: str, database: str, host: str, port: SupportsInt, **kwargs: Any
@@ -65,8 +67,8 @@ class AsyncpgDBClient(BaseDBAsyncClient):
         self.schema = self.extra.pop("schema", None)
         self.extra.pop("connection_name", None)
         self.extra.pop("fetch_inserted", None)
-        self.extra.pop("loop", None)
-        self.extra.pop("connection_class", None)
+        self.loop = self.extra.pop("loop", None)
+        self.connection_class = self.extra.pop("connection_class", self.connection_class)
         self.pool_minsize = int(self.extra.pop("minsize", 1))
         self.pool_maxsize = int(self.extra.pop("maxsize", 5))
 
@@ -82,6 +84,8 @@ class AsyncpgDBClient(BaseDBAsyncClient):
             "database": self.database if with_db else None,
             "min_size": self.pool_minsize,
             "max_size": self.pool_maxsize,
+            "connection_class": self.connection_class,
+            "loop": self.loop,
             **self.extra,
         }
         if self.schema:


### PR DESCRIPTION
Allows configuration of the asyncpg connection class and asyncio event loop used by `AsyncpgDBClient` by passing them through the `config` option.

## Motivation and Context

Needed to enable SQL logging of the models.

## How Has This Been Tested?

My test suite passes and the app runs but I did not spin up on the Tortoise tests because these changes are pretty surgical and I am short on time.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

