### PR TITLE
Include py.typed in source ditribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include LICENSE.txt
 include README.rst
 include requirements.txt
 include requirements-accel.txt
+include tortoise/py.typed

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setup(
     zip_safe=True,
     # Include additional files into the package
     include_package_data=True,
-    package_data={"tortoise": ["py.typed"]},
     # Details
     url="https://github.com/tortoise/tortoise-orm",
     description="Easy async ORM for python, built with relations in mind",


### PR DESCRIPTION

## Description
When `include_package_data=True`, only files listed in MANIFEST.in are
included and the `package_data` option is ignored.

> If using the setuptools-specific include_package_data argument, files
> specified by package_data will not be automatically added to the manifest
> unless they are listed in the MANIFEST.in file.

see:
  - https://setuptools.readthedocs.io/en/latest/setuptools.html#including-data-files
  - https://github.com/pypa/setuptools/issues/1461

## Motivation and Context
fixes #439


## How Has This Been Tested?
```sh
python setup.py sdist
tar -tvf dist/tortoise-orm-0.16.13.tar.gz | grep py.typed
# -> tortoise-orm-0.16.13/tortoise/py.typed
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

