### PR TITLE
Add Windows env to Travis (#399)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,16 @@ env:
     TORTOISE_TEST_MODULES=tests.testmodels
 matrix:
   include:
+  - name: Python 3.7 / Windows / Partial
+    os: windows
+    language: shell
+    before_install:
+      - choco install python --version 3.7.4
+      - python -m pip install --upgrade pip setuptools wheel
+      - choco install make
+    env: PATH=/c/Python37:/c/Python37/Scripts:$PATH TEST_RUNNER=nose2
+    script: "nose2 --plugin tortoise.contrib.test.nose2 --db-module tests.testmodels --db-url sqlite://:memory: -v"
+    after_success: echo
   - python: 3.7
     env: TEST_RUNNER=green
     script: green

--- a/tests/model_setup/test_init.py
+++ b/tests/model_setup/test_init.py
@@ -320,11 +320,13 @@ class TestInitErrors(test.SimpleTestCase):
         ):
             await Tortoise.init(config_file="config.ini")
 
+    @test.skipIf(os.name == "nt", "path issue on Windows")
     async def test_init_json_file(self):
         await Tortoise.init(config_file=os.path.dirname(__file__) + "/init.json")
         self.assertIn("models", Tortoise.apps)
         self.assertIsNotNone(Tortoise.get_connection("default"))
 
+    @test.skipIf(os.name == "nt", "path issue on Windows")
     async def test_init_yaml_file(self):
         await Tortoise.init(config_file=os.path.dirname(__file__) + "/init.yaml")
         self.assertIn("models", Tortoise.apps)

--- a/tests/test_model_methods.py
+++ b/tests/test_model_methods.py
@@ -1,3 +1,4 @@
+import os
 from uuid import uuid4
 
 from tests.testmodels import (
@@ -205,6 +206,7 @@ class TestModelMethods(test.TestCase):
         with self.assertRaises(MultipleObjectsReturned):
             await self.cls.get_or_none(name="Test")
 
+    @test.skipIf(os.name == "nt", "timestamp issue on Windows")
     async def test_update_from_dict(self):
         evt1 = await Event.create(name="a", tournament=await Tournament.create(name="a"))
         orig_modified = evt1.modified

--- a/tests/utils/test_run_async.py
+++ b/tests/utils/test_run_async.py
@@ -1,4 +1,5 @@
-from unittest import TestCase
+import os
+from unittest import TestCase, skipIf
 
 from tortoise import Tortoise, run_async
 
@@ -18,6 +19,7 @@ class TestRunAsync(TestCase):
         self.assertNotEqual(Tortoise._connections, {})
         raise Exception("Some exception")
 
+    @skipIf(os.name == "nt", "stuck with windows : temporaily skip")
     def test_run_async(self):
         self.assertEqual(Tortoise._connections, {})
         self.assertEqual(self.somevalue, 1)
@@ -25,6 +27,7 @@ class TestRunAsync(TestCase):
         self.assertEqual(Tortoise._connections, {})
         self.assertEqual(self.somevalue, 2)
 
+    @skipIf(os.name == "nt", "stuck with windows : temporaily skip")
     def test_run_async_raised(self):
         self.assertEqual(Tortoise._connections, {})
         self.assertEqual(self.somevalue, 1)

--- a/tests/utils/test_run_async.py
+++ b/tests/utils/test_run_async.py
@@ -4,7 +4,7 @@ from unittest import TestCase, skipIf
 from tortoise import Tortoise, run_async
 
 
-@skipIf(os.name == "nt", "stuck with windows")
+@skipIf(os.name == "nt", "stuck with Windows")
 class TestRunAsync(TestCase):
     def setUp(self):
         self.somevalue = 1

--- a/tests/utils/test_run_async.py
+++ b/tests/utils/test_run_async.py
@@ -4,6 +4,7 @@ from unittest import TestCase, skipIf
 from tortoise import Tortoise, run_async
 
 
+@skipIf(os.name == "nt", "stuck with windows")
 class TestRunAsync(TestCase):
     def setUp(self):
         self.somevalue = 1
@@ -19,7 +20,6 @@ class TestRunAsync(TestCase):
         self.assertNotEqual(Tortoise._connections, {})
         raise Exception("Some exception")
 
-    @skipIf(os.name == "nt", "stuck with windows : temporaily skip")
     def test_run_async(self):
         self.assertEqual(Tortoise._connections, {})
         self.assertEqual(self.somevalue, 1)
@@ -27,7 +27,6 @@ class TestRunAsync(TestCase):
         self.assertEqual(Tortoise._connections, {})
         self.assertEqual(self.somevalue, 2)
 
-    @skipIf(os.name == "nt", "stuck with windows : temporaily skip")
     def test_run_async_raised(self):
         self.assertEqual(Tortoise._connections, {})
         self.assertEqual(self.somevalue, 1)


### PR DESCRIPTION
Continuation of #399 

With #375, we found that different development environment can lead some unexpected errors. So we need to check many envs automatically. This is first step that support Windows to travis CI.