### PR TITLE
Fix typo in docs

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -34,6 +34,7 @@ Contributors
 * Mykola Solodukha ``@TrDex``
 * Seo Jiyeon ``jiyeonseo``
 * Blake Watters ``blakewatters``
+* ``@SnkSynthesis``
 
 Special Thanks
 ==============

--- a/examples/pydantic/tutorial_2.py
+++ b/examples/pydantic/tutorial_2.py
@@ -26,7 +26,7 @@ class Tournament(Model):
         ordering = ["name"]
 
 
-# Create for population of models from a queryset.
+# Create for a population of models from a queryset.
 Tournament_Pydantic_List = pydantic_queryset_creator(Tournament)
 # Print JSON-schema
 print(Tournament_Pydantic_List.schema_json(indent=4))

--- a/examples/pydantic/tutorial_2.py
+++ b/examples/pydantic/tutorial_2.py
@@ -26,7 +26,7 @@ class Tournament(Model):
         ordering = ["name"]
 
 
-# Create a lost of models for population from a queryset.
+# Create for population of models from a queryset.
 Tournament_Pydantic_List = pydantic_queryset_creator(Tournament)
 # Print JSON-schema
 print(Tournament_Pydantic_List.schema_json(indent=4))

--- a/examples/pydantic/tutorial_2.py
+++ b/examples/pydantic/tutorial_2.py
@@ -26,7 +26,7 @@ class Tournament(Model):
         ordering = ["name"]
 
 
-# Create for a population of models from a queryset.
+# Create a list of models for population from a queryset.
 Tournament_Pydantic_List = pydantic_queryset_creator(Tournament)
 # Print JSON-schema
 print(Tournament_Pydantic_List.schema_json(indent=4))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes typo which appears in docs. Typo occurs in [examples/pydantic/tutorial_2.py](https://github.com/tortoise/tortoise-orm/blob/develop/examples/pydantic/tutorial_2.py)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

