### PR TITLE
Check default for not None in pydantic model creation, propagate default to pydantic

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,11 @@ Changelog
 
 0.16
 ====
+0.16.15
+-------
+- check ``default`` for not ``None`` on pydantic model creation
+- propagate default to pydantic model
+
 0.16.14
 -------
 - Make ``F`` expression work with ``QuerySet.filter()``.

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -38,6 +38,7 @@ Contributors
 * Rodrigo Oliveira ``@allrod5``
 * ``@SnkSynthesis``
 * Alex Sinichkin ``@AlwxSin``
+* ``@Yolley``
 
 Special Thanks
 ==============

--- a/tortoise/contrib/pydantic/creator.py
+++ b/tortoise/contrib/pydantic/creator.py
@@ -324,7 +324,7 @@ def pydantic_model_creator(
             if model:
                 if fdesc.get("nullable"):
                     fconfig["nullable"] = True
-                if fdesc.get("nullable") or field_default:
+                if fdesc.get("nullable") or field_default is not None:
                     model = Optional[model]  # type: ignore
 
                 pannotations[fname] = model
@@ -369,6 +369,7 @@ def pydantic_model_creator(
             if field_default is not None:
                 if callable(field_default):
                     fconfig["default_factory"] = field_default
+                    properties[fname] = None
                 else:
                     properties[fname] = field_default
             pconfig.fields[fname] = fconfig

--- a/tortoise/contrib/pydantic/creator.py
+++ b/tortoise/contrib/pydantic/creator.py
@@ -324,7 +324,7 @@ def pydantic_model_creator(
             if model:
                 if fdesc.get("nullable"):
                     fconfig["nullable"] = True
-                if fdesc.get("nullable") or field_default is not None:
+                if fdesc.get("nullable") or field_default:
                     model = Optional[model]  # type: ignore
 
                 pannotations[fname] = model


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I propose two changes to `pydantic_model_creator`:
1. Check `default` of a field with `is not None`
2. Propagate default values to a pydantic model

## Motivation and Context
1. As of now if a model has a BooleanField with `default=False` or Integer field with `0` in default, `pydantic_model_creator` won't make these fields `Optional`, thus leading to wrong pydantic schema with these fields marked as required.
2. As of now default values are not propagated to a pydantic model, therefore when we generate a schema and add it to Swagger, fox example, it won't be clear to a user, what is the default value of an Optional field. Also I added callable default to `default_factory` just for consistency (to propagate all default fields), but I guess that it is more controversial, because pydantic will always try to generate field value with factory and if we create a model with `exclude_unset=True` param, we would call default function again, but now on Tortoise side, so it may be changed (may be we could add some boolean flag  to `pydantic_model_creator` arguments that either allow or not allow default values propagation)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
The existing tests actually don't have models with Boolean or Integer field with `0` in default value. I could add, but I guess it would to require to change all tests that use these models, so I am not sure if it needs to be done, because well my changes certainly don't break the existing logic.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
