### PR TITLE
replace List with Iterable for some typings

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -37,6 +37,7 @@ Contributors
 * Alexey Tylindus ``@mirrorrim``
 * Rodrigo Oliveira ``@allrod5``
 * ``@SnkSynthesis``
+* Alex Sinichkin ``@AlwxSin``
 
 Special Thanks
 ==============

--- a/tortoise/backends/asyncpg/executor.py
+++ b/tortoise/backends/asyncpg/executor.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import List, Optional
+from typing import Optional, Sequence
 
 import asyncpg
 from pypika import Parameter
@@ -15,7 +15,7 @@ class AsyncpgExecutor(BaseExecutor):
     def parameter(self, pos: int) -> Parameter:
         return Parameter("$%d" % (pos + 1,))
 
-    def _prepare_insert_statement(self, columns: List[str], has_generated: bool = True) -> str:
+    def _prepare_insert_statement(self, columns: Sequence[str], has_generated: bool = True) -> str:
         query = (
             self.db.query_class.into(self.model._meta.basetable)
             .columns(*columns)

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -9,6 +9,7 @@ from typing import (
     Callable,
     Dict,
     Generator,
+    Iterable,
     List,
     Optional,
     Set,
@@ -815,7 +816,7 @@ class Model(metaclass=ModelMeta):
     async def _pre_save(
         self,
         using_db: Optional[BaseDBAsyncClient] = None,
-        update_fields: Optional[List[str]] = None,
+        update_fields: Optional[Iterable[str]] = None,
     ) -> None:
         listeners = []
         cls_listeners = self._listeners.get(Signals.pre_save, {}).get(self.__class__, [])
@@ -827,7 +828,7 @@ class Model(metaclass=ModelMeta):
         self,
         using_db: Optional[BaseDBAsyncClient] = None,
         created: bool = False,
-        update_fields: Optional[List[str]] = None,
+        update_fields: Optional[Iterable[str]] = None,
     ) -> None:
         listeners = []
         cls_listeners = self._listeners.get(Signals.post_save, {}).get(self.__class__, [])
@@ -838,7 +839,7 @@ class Model(metaclass=ModelMeta):
     async def save(
         self,
         using_db: Optional[BaseDBAsyncClient] = None,
-        update_fields: Optional[List[str]] = None,
+        update_fields: Optional[Iterable[str]] = None,
         force_create: bool = False,
         force_update: bool = False,
     ) -> None:
@@ -984,7 +985,7 @@ class Model(metaclass=ModelMeta):
 
     @classmethod
     async def bulk_create(
-        cls: Type[MODEL], objects: List[MODEL], using_db: Optional[BaseDBAsyncClient] = None,
+        cls: Type[MODEL], objects: Iterable[MODEL], using_db: Optional[BaseDBAsyncClient] = None,
     ) -> None:
         """
         Bulk insert operation:
@@ -1010,7 +1011,7 @@ class Model(metaclass=ModelMeta):
         :param using_db: Specific DB connection to use instead of default bound
         """
         db = using_db or cls._meta.db
-        await db.executor_class(model=cls, db=db).execute_bulk_insert(objects)  # type: ignore
+        await db.executor_class(model=cls, db=db).execute_bulk_insert(objects)
 
     @classmethod
     def first(cls: Type[MODEL]) -> QuerySetSingle[Optional[MODEL]]:
@@ -1102,7 +1103,10 @@ class Model(metaclass=ModelMeta):
 
     @classmethod
     async def fetch_for_list(
-        cls, instance_list: "List[Model]", *args: Any, using_db: Optional[BaseDBAsyncClient] = None,
+        cls,
+        instance_list: "Iterable[Model]",
+        *args: Any,
+        using_db: Optional[BaseDBAsyncClient] = None,
     ) -> None:
         """
         Fetches related models for provided list of Model objects.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Change some `List` typing with `Iterable` or `Sequence`

## Motivation and Context
I have a tuple or set with raw model objects and can't just pass them to bulk_create, because mypy will throw an error.
`.bulk_create` explicitly receive only a list of models even though it only iterates over them.
```python
set_of_raw_models = {MyModel(...) for smth in other_smth}
MyModel.bulk_create(set_of_raw_models)  #  <--- mypy error
```

Somewhere I read "A rule of thumb. Arguments should be as general as possible, return values should be as specific as possible".


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

