### PR TITLE
Make `DateField` accept valid date str and add `QuerySet.select_for_update()`.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,10 @@ Changelog
 
 0.16
 ====
+0.16.15
+-------
+- Make `DateField` accept valid date str.
+
 0.16.14
 -------
 - Make ``F`` expression work with ``QuerySet.filter()``.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Changelog
 0.16.15
 -------
 - Make `DateField` accept valid date str.
+- Add `QuerySet.select_for_update()`.
 
 0.16.14
 -------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pypika>=0.36.5
+pypika>=0.39.0
 iso8601>=0.1.12
 aiosqlite>=0.11.0
 typing-extensions>=3.7

--- a/tests/fields/test_time.py
+++ b/tests/fields/test_time.py
@@ -1,6 +1,8 @@
 from datetime import date, datetime, timedelta
 from time import sleep
 
+from iso8601 import ParseError
+
 from tests import testmodels
 from tortoise import fields
 from tortoise.contrib import test
@@ -92,7 +94,7 @@ class TestDatetimeFields(test.TestCase):
         obj0 = await testmodels.DateFields.create(date="2020-08-17")
         obj1 = await testmodels.DateFields.get(date="2020-08-17")
         self.assertEqual(obj0.date, obj1.date)
-        with self.assertRaises(ValueError):
+        with self.assertRaises((ParseError, ValueError),):
             await testmodels.DateFields.create(date="2020-08-xx")
         await testmodels.DateFields.filter(date="2020-08-17").update(date="2020-08-18")
         obj2 = await testmodels.DateFields.get(date="2020-08-18")

--- a/tests/fields/test_time.py
+++ b/tests/fields/test_time.py
@@ -88,6 +88,16 @@ class TestDatetimeFields(test.TestCase):
             await testmodels.DatetimeFields.filter(datetime_add=obj.datetime_add).count(), 1
         )
 
+    async def test_date_str(self):
+        obj0 = await testmodels.DateFields.create(date="2020-08-17")
+        obj1 = await testmodels.DateFields.get(date="2020-08-17")
+        self.assertEqual(obj0.date, obj1.date)
+        with self.assertRaises(ValueError):
+            await testmodels.DateFields.create(date="2020-08-xx")
+        await testmodels.DateFields.filter(date="2020-08-17").update(date="2020-08-18")
+        obj2 = await testmodels.DateFields.get(date="2020-08-18")
+        self.assertEqual(obj2.date, date(year=2020, month=8, day=18))
+
 
 class TestDateFields(test.TestCase):
     async def test_empty(self):

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -319,6 +319,7 @@ class TestQueryset(test.TestCase):
         sql = IntFields.all().sql()
         self.assertRegex(sql, r"^SELECT.+FROM.+")
 
+    @test.requireCapability(support_for_update=True)
     async def test_select_for_update(self):
         sql = IntFields.filter(pk=1).only("id").select_for_update().sql()
         self.assertEqual(

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -318,3 +318,10 @@ class TestQueryset(test.TestCase):
     async def test_get_raw_sql(self):
         sql = IntFields.all().sql()
         self.assertRegex(sql, r"^SELECT.+FROM.+")
+
+    async def test_select_for_update(self):
+        ret = await IntFields.first()
+        sql = IntFields.filter(pk=ret.pk).only("id").select_for_update().sql()
+        self.assertEqual(
+            sql, f'SELECT "id" "id" FROM "intfields" WHERE "id"={ret.pk} FOR UPDATE',
+        )

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -322,5 +322,5 @@ class TestQueryset(test.TestCase):
     async def test_select_for_update(self):
         sql = IntFields.filter(pk=1).only("id").select_for_update().sql()
         self.assertEqual(
-            sql, f'SELECT "id" "id" FROM "intfields" WHERE "id"=1 FOR UPDATE',
+            sql, 'SELECT "id" "id" FROM "intfields" WHERE "id"=1 FOR UPDATE',
         )

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -320,8 +320,7 @@ class TestQueryset(test.TestCase):
         self.assertRegex(sql, r"^SELECT.+FROM.+")
 
     async def test_select_for_update(self):
-        ret = await IntFields.first()
-        sql = IntFields.filter(pk=ret.pk).only("id").select_for_update().sql()
+        sql = IntFields.filter(pk=1).only("id").select_for_update().sql()
         self.assertEqual(
-            sql, f'SELECT "id" "id" FROM "intfields" WHERE "id"={ret.pk} FOR UPDATE',
+            sql, f'SELECT "id" "id" FROM "intfields" WHERE "id"=1 FOR UPDATE',
         )

--- a/tortoise/backends/base/client.py
+++ b/tortoise/backends/base/client.py
@@ -27,6 +27,7 @@ class Capabilities:
     :param inline_comment: Indicates that comments should be rendered in line with the
         DDL statement, and not as a separate statement.
     :param supports_transactions: Indicates that this DB supports transactions.
+    :param support_for_update: Indicates that this DB supports SELECT ... FOR UPDATE SQL statement.
     """
 
     def __init__(
@@ -39,6 +40,7 @@ class Capabilities:
         requires_limit: bool = False,
         inline_comment: bool = False,
         supports_transactions: bool = True,
+        support_for_update: bool = True,
     ) -> None:
         super().__setattr__("_mutable", True)
 
@@ -47,7 +49,7 @@ class Capabilities:
         self.requires_limit = requires_limit
         self.inline_comment = inline_comment
         self.supports_transactions = supports_transactions
-
+        self.support_for_update = support_for_update
         super().__setattr__("_mutable", False)
 
     def __setattr__(self, attr: str, value: Any) -> None:

--- a/tortoise/backends/sqlite/client.py
+++ b/tortoise/backends/sqlite/client.py
@@ -38,7 +38,9 @@ def translate_exceptions(func: F) -> F:
 class SqliteClient(BaseDBAsyncClient):
     executor_class = SqliteExecutor
     schema_generator = SqliteSchemaGenerator
-    capabilities = Capabilities("sqlite", daemon=False, requires_limit=True, inline_comment=True)
+    capabilities = Capabilities(
+        "sqlite", daemon=False, requires_limit=True, inline_comment=True, support_for_update=False
+    )
 
     def __init__(self, file_path: str, **kwargs: Any) -> None:
         super().__init__(**kwargs)

--- a/tortoise/fields/data.py
+++ b/tortoise/fields/data.py
@@ -335,6 +335,13 @@ class DateField(Field, datetime.date):
             return value
         return parse_datetime(value).date()
 
+    def to_db_value(
+        self, value: Optional[Union[datetime.date, str]], instance: "Union[Type[Model], Model]"
+    ) -> Optional[datetime.date]:
+        if value is None or isinstance(value, datetime.date):
+            return value
+        return parse_datetime(value).date()
+
 
 class TimeDeltaField(Field, datetime.timedelta):
     """

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -249,6 +249,7 @@ class QuerySet(AwaitableQuery[MODEL]):
         "_having",
         "_custom_filters",
         "_group_bys",
+        "_select_for_update",
     )
 
     def __init__(self, model: Type[MODEL]) -> None:
@@ -268,6 +269,7 @@ class QuerySet(AwaitableQuery[MODEL]):
         self._custom_filters: Dict[str, dict] = {}
         self._fields_for_select: Tuple[str, ...] = ()
         self._group_bys: Tuple[str, ...] = ()
+        self._select_for_update: bool = False
 
     def _clone(self) -> "QuerySet[MODEL]":
         queryset = QuerySet.__new__(QuerySet)
@@ -292,6 +294,7 @@ class QuerySet(AwaitableQuery[MODEL]):
         queryset._having = copy(self._having)
         queryset._custom_filters = copy(self._custom_filters)
         queryset._group_bys = copy(self._group_bys)
+        queryset._select_for_update = self._select_for_update
         return queryset
 
     def _filter_or_exclude(self, *args: Q, negate: bool, **kwargs: Any) -> "QuerySet[MODEL]":
@@ -393,6 +396,17 @@ class QuerySet(AwaitableQuery[MODEL]):
         """
         queryset = self._clone()
         queryset._distinct = True
+        return queryset
+
+    def select_for_update(self) -> "QuerySet[MODEL]":
+        """
+        Make QuerySet select for update.
+
+        Returns a queryset that will lock rows until the end of the transaction,
+        generating a SELECT ... FOR UPDATE SQL statement on supported databases.
+        """
+        queryset = self._clone()
+        queryset._select_for_update = True
         return queryset
 
     def annotate(self, **kwargs: Function) -> "QuerySet[MODEL]":
@@ -697,6 +711,8 @@ class QuerySet(AwaitableQuery[MODEL]):
             self.query._offset = self._offset
         if self._distinct:
             self.query._distinct = True
+        if self._select_for_update:
+            self.query._for_update = True
 
     def __await__(self) -> Generator[Any, None, List[MODEL]]:
         if self._db is None:

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -405,9 +405,11 @@ class QuerySet(AwaitableQuery[MODEL]):
         Returns a queryset that will lock rows until the end of the transaction,
         generating a SELECT ... FOR UPDATE SQL statement on supported databases.
         """
-        queryset = self._clone()
-        queryset._select_for_update = True
-        return queryset
+        if self.capabilities.support_for_update:
+            queryset = self._clone()
+            queryset._select_for_update = True
+            return queryset
+        return self
 
     def annotate(self, **kwargs: Function) -> "QuerySet[MODEL]":
         """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Make `DateField` accept valid date str.
- Add `QuerySet.select_for_update()`.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
And the `QuerySet.select_for_update()` need `pypika` latest master branch because it's not publish `select_for_update` support to pypi now.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

