### PR TITLE
Fix ExistsQuery typing

### DIFF
--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -858,7 +858,7 @@ class ExistsQuery(AwaitableQuery):
         self.query._limit = 1
         self.query._select_other(ValueWrapper(1))
 
-    def __await__(self) -> Generator[Any, None, int]:
+    def __await__(self) -> Generator[Any, None, bool]:
         if self._db is None:
             self._db = self.model._meta.db  # type: ignore
         self._make_query()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`ExistsQuery` should return `bool` instead of `int`. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

