### PR TITLE
Fix sqlite client calling .start method

### DIFF
--- a/tortoise/backends/sqlite/client.py
+++ b/tortoise/backends/sqlite/client.py
@@ -57,8 +57,7 @@ class SqliteClient(BaseDBAsyncClient):
     async def create_connection(self, with_db: bool) -> None:
         if not self._connection:  # pragma: no branch
             self._connection = aiosqlite.connect(self.filename, isolation_level=None)
-            self._connection.start()
-            await self._connection._connect()
+            await self._connection
             self._connection._conn.row_factory = sqlite3.Row
             for pragma, val in self.pragmas.items():
                 cursor = await self._connection.execute(f"PRAGMA {pragma}={val}")


### PR DESCRIPTION
Remove call to `Thread.start()` that may be removed if https://github.com/omnilib/aiosqlite/pull/82 is accepted.
Replaced with awaiting the connection, that does the same: https://github.com/omnilib/aiosqlite/blob/main/aiosqlite/core.py#L124

## Motivation and Context
`aiosqlite` hangs the app if the connection is not correctly closed before the end. It makes unpleasant working with `aiosqlite` and this module in interactive python.

## How Has This Been Tested?
Checked the linters, but wasn't able to run pytest. Hope there's a CI here that will run them instead of me :)
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

