### PR TITLE
add OSError to _get_comments

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -39,6 +39,7 @@ Contributors
 * ``@SnkSynthesis``
 * Alex Sinichkin ``@AlwxSin``
 * ``@Yolley``
+* Bogdan Evstratenko ``@evstratbg``
 
 Special Thanks
 ==============

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -138,7 +138,7 @@ def _get_comments(cls: "Type[Model]") -> Dict[str, str]:
     """
     try:
         source = inspect.getsource(cls)
-    except (TypeError, OsError):  # pragma: nocoverage
+    except (TypeError, OSError):  # pragma: nocoverage
         return {}
     comments = {}
 

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -138,7 +138,7 @@ def _get_comments(cls: "Type[Model]") -> Dict[str, str]:
     """
     try:
         source = inspect.getsource(cls)
-    except TypeError:  # pragma: nocoverage
+    except (TypeError, OsError):  # pragma: nocoverage
         return {}
     comments = {}
 


### PR DESCRIPTION
Hi! Thanks for the great soft

I've faced the problem, using tortoise-orm and pyarmor (https://github.com/dashingsoft/pyarmor)

As a run obfuscation like so:
pyarmor obfuscate -r run.py

the app doesnt start, throwing following traceback:

```
Traceback (most recent call last):
  File "<dist/run.py>", line 3, in <module>
  File "<frozen run>", line 15, in <module>
  File "</app/dist/app/app.py>", line 1, in <module>
  File "<frozen app.app>", line 5, in <module>
  File "</app/dist/app/routes/__init__.py>", line 1, in <module>
  File "<frozen app.routes>", line 7, in <module>
  File "</app/dist/app/routes/v1/app.py>", line 1, in <module>
  File "<frozen app.routes.v1.app>", line 6, in <module>
  File "</app/dist/app/routes/v1/handlers/file.py>", line 1, in <module>
  File "<frozen app.routes.v1.handlers.file>", line 15, in <module>
  File "</app/dist/app/database/models.py>", line 3, in <module>
  File "<frozen app.database.models>", line 45, in <module>
  File "/app/.venv/lib/python3.8/site-packages/tortoise/models.py", line 596, in __new__
    for fname, comment in _get_comments(new_class).items():
  File "/app/.venv/lib/python3.8/site-packages/tortoise/models.py", line 140, in _get_comments
    source = inspect.getsource(cls)
  File "/usr/local/lib/python3.8/inspect.py", line 985, in getsource
    lines, lnum = getsourcelines(object)
  File "/usr/local/lib/python3.8/inspect.py", line 967, in getsourcelines
    lines, lnum = findsource(object)
  File "/usr/local/lib/python3.8/inspect.py", line 824, in findsource
    raise OSError('could not find class definition')
OSError: could not find class definition
```
As far, as I understood, the problem is in `source = inspect.getsource(cls)`, because interpreter can't get the text of the source code for an object.

So, I've added OSError to except block to avoid this 