### PR TITLE
Add `db_constraint` for `RelationalField` family

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Changelog
 - propagate default to pydantic model
 - Add `QuerySet.select_related()`.
 - Add custom attribute name for Prefetch instruction.
+- Add `db_constraint` for `RelationalField` family.
 
 0.16.14
 -------

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -87,7 +87,7 @@ pygments==2.5.1           # via -r ../docs/requirements.in, -r requirements.in, 
 pylint==2.5.3             # via -r requirements.in
 pymysql==0.9.2            # via aiomysql
 pyparsing==2.4.7          # via packaging
-pypika==0.38.0            # via -r ../docs/../requirements.txt, tortoise-orm
+pypika==0.39.1            # via -r ../docs/../requirements.txt, tortoise-orm
 pytest-cov==2.10.0        # via -r requirements.in
 pytest-forked==1.3.0      # via pytest-xdist
 pytest-xdist==1.34.0      # via -r requirements.in

--- a/tests/schema/models_no_db_constraint.py
+++ b/tests/schema/models_no_db_constraint.py
@@ -1,0 +1,56 @@
+"""
+This example demonstrates SQL Schema generation for each DB type supported without db fk constraint.
+"""
+
+from tortoise import fields
+from tortoise.models import Model
+
+
+class Tournament(Model):
+    tid = fields.SmallIntField(pk=True)
+    name = fields.CharField(max_length=100, description="Tournament name", index=True)
+    created = fields.DatetimeField(auto_now_add=True, description="Created */'`/* datetime")
+
+    class Meta:
+        table_description = "What Tournaments */'`/* we have"
+
+
+class Event(Model):
+    id = fields.BigIntField(pk=True, description="Event ID")
+    name = fields.TextField()
+    tournament = fields.ForeignKeyField(
+        "models.Tournament",
+        db_constraint=False,
+        related_name="events",
+        description="FK to tournament",
+    )
+    participants = fields.ManyToManyField(
+        "models.Team",
+        db_constraint=False,
+        related_name="events",
+        through="teamevents",
+        description="How participants relate",
+    )
+    modified = fields.DatetimeField(auto_now=True)
+    prize = fields.DecimalField(max_digits=10, decimal_places=2, null=True)
+    token = fields.CharField(max_length=100, description="Unique token", unique=True)
+    key = fields.CharField(max_length=100)
+
+    class Meta:
+        table_description = "This table contains a list of all the events"
+        unique_together = [("name", "prize"), ["tournament", "key"]]
+
+
+class Team(Model):
+    name = fields.CharField(max_length=50, pk=True, description="The TEAM name (and PK)")
+    key = fields.IntField()
+    manager = fields.ForeignKeyField(
+        "models.Team", db_constraint=False, related_name="team_members", null=True
+    )
+    talks_to = fields.ManyToManyField(
+        "models.Team", db_constraint=False, related_name="gets_talked_to"
+    )
+
+    class Meta:
+        table_description = "The TEAMS!"
+        indexes = [("manager", "key"), ["manager_id", "name"]]

--- a/tests/schema/test_generate_schema.py
+++ b/tests/schema/test_generate_schema.py
@@ -135,6 +135,46 @@ class TestGenerateSchema(test.SimpleTestCase):
         self.assertRegex(sql, r".*\\n.*")
         self.assertIn("\\/", sql)
 
+    async def test_schema_no_db_constraint(self):
+        self.maxDiff = None
+        await self.init_for("tests.schema.models_no_db_constraint")
+        sql = get_schema_sql(Tortoise.get_connection("default"), safe=False)
+        self.assertEqual(
+            sql.strip(),
+            r"""CREATE TABLE "team" (
+    "name" VARCHAR(50) NOT NULL  PRIMARY KEY /* The TEAM name (and PK) */,
+    "key" INT NOT NULL,
+    "manager_id" VARCHAR(50)
+) /* The TEAMS! */;
+CREATE INDEX "idx_team_manager_676134" ON "team" ("manager_id", "key");
+CREATE INDEX "idx_team_manager_ef8f69" ON "team" ("manager_id", "name");
+CREATE TABLE "tournament" (
+    "tid" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    "name" VARCHAR(100) NOT NULL  /* Tournament name */,
+    "created" TIMESTAMP NOT NULL  DEFAULT CURRENT_TIMESTAMP /* Created *\/'`\/* datetime */
+) /* What Tournaments *\/'`\/* we have */;
+CREATE INDEX "idx_tournament_name_6fe200" ON "tournament" ("name");
+CREATE TABLE "event" (
+    "id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL /* Event ID */,
+    "name" TEXT NOT NULL,
+    "modified" TIMESTAMP NOT NULL  DEFAULT CURRENT_TIMESTAMP,
+    "prize" VARCHAR(40),
+    "token" VARCHAR(100) NOT NULL UNIQUE /* Unique token */,
+    "key" VARCHAR(100) NOT NULL,
+    "tournament_id" SMALLINT NOT NULL,
+    CONSTRAINT "uid_event_name_c6f89f" UNIQUE ("name", "prize"),
+    CONSTRAINT "uid_event_tournam_a5b730" UNIQUE ("tournament_id", "key")
+) /* This table contains a list of all the events */;
+CREATE TABLE "team_team" (
+    "team_rel_id" VARCHAR(50) NOT NULL,
+    "team_id" VARCHAR(50) NOT NULL
+);
+CREATE TABLE "teamevents" (
+    "event_id" BIGINT NOT NULL,
+    "team_id" VARCHAR(50) NOT NULL
+) /* How participants relate */;""",
+        )
+
     async def test_schema(self):
         self.maxDiff = None
         await self.init_for("tests.schema.models_schema_create")
@@ -372,6 +412,46 @@ class TestGenerateSchemaMySQL(TestGenerateSchema):
         self.assertIn("COMMENT 'This column acts as it\\'s own comment'", sql)
         self.assertRegex(sql, r".*\\n.*")
         self.assertRegex(sql, r".*it\\'s.*")
+
+    async def test_schema_no_db_constraint(self):
+        self.maxDiff = None
+        await self.init_for("tests.schema.models_no_db_constraint")
+        sql = get_schema_sql(Tortoise.get_connection("default"), safe=False)
+        self.assertEqual(
+            sql.strip(),
+            r"""CREATE TABLE `team` (
+    `name` VARCHAR(50) NOT NULL  PRIMARY KEY COMMENT 'The TEAM name (and PK)',
+    `key` INT NOT NULL,
+    `manager_id` VARCHAR(50),
+    KEY `idx_team_manager_676134` (`manager_id`, `key`),
+    KEY `idx_team_manager_ef8f69` (`manager_id`, `name`)
+) CHARACTER SET utf8mb4 COMMENT='The TEAMS!';
+CREATE TABLE `tournament` (
+    `tid` SMALLINT NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    `name` VARCHAR(100) NOT NULL  COMMENT 'Tournament name',
+    `created` DATETIME(6) NOT NULL  COMMENT 'Created */\'`/* datetime' DEFAULT CURRENT_TIMESTAMP(6),
+    KEY `idx_tournament_name_6fe200` (`name`)
+) CHARACTER SET utf8mb4 COMMENT='What Tournaments */\'`/* we have';
+CREATE TABLE `event` (
+    `id` BIGINT NOT NULL PRIMARY KEY AUTO_INCREMENT COMMENT 'Event ID',
+    `name` LONGTEXT NOT NULL,
+    `modified` DATETIME(6) NOT NULL  DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    `prize` DECIMAL(10,2),
+    `token` VARCHAR(100) NOT NULL UNIQUE COMMENT 'Unique token',
+    `key` VARCHAR(100) NOT NULL,
+    `tournament_id` SMALLINT NOT NULL,
+    UNIQUE KEY `uid_event_name_c6f89f` (`name`, `prize`),
+    UNIQUE KEY `uid_event_tournam_a5b730` (`tournament_id`, `key`)
+) CHARACTER SET utf8mb4 COMMENT='This table contains a list of all the events';
+CREATE TABLE `team_team` (
+    `team_rel_id` VARCHAR(50) NOT NULL,
+    `team_id` VARCHAR(50) NOT NULL
+) CHARACTER SET utf8mb4;
+CREATE TABLE `teamevents` (
+    `event_id` BIGINT NOT NULL,
+    `team_id` VARCHAR(50) NOT NULL
+) CHARACTER SET utf8mb4 COMMENT='How participants relate';""",
+        )
 
     async def test_schema(self):
         self.maxDiff = None
@@ -615,6 +695,56 @@ class TestGenerateSchemaPostgresSQL(TestGenerateSchema):
         )
         self.assertIn(
             'COMMENT ON COLUMN "comments"."multiline_comment" IS \'Some \\n comment\'', sql
+        )
+
+    async def test_schema_no_db_constraint(self):
+        self.maxDiff = None
+        await self.init_for("tests.schema.models_no_db_constraint")
+        sql = get_schema_sql(Tortoise.get_connection("default"), safe=False)
+        self.assertEqual(
+            sql.strip(),
+            r"""CREATE TABLE "team" (
+    "name" VARCHAR(50) NOT NULL  PRIMARY KEY,
+    "key" INT NOT NULL,
+    "manager_id" VARCHAR(50)
+);
+CREATE INDEX "idx_team_manager_676134" ON "team" ("manager_id", "key");
+CREATE INDEX "idx_team_manager_ef8f69" ON "team" ("manager_id", "name");
+COMMENT ON COLUMN "team"."name" IS 'The TEAM name (and PK)';
+COMMENT ON TABLE "team" IS 'The TEAMS!';
+CREATE TABLE "tournament" (
+    "tid" SMALLSERIAL NOT NULL PRIMARY KEY,
+    "name" VARCHAR(100) NOT NULL,
+    "created" TIMESTAMP NOT NULL  DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX "idx_tournament_name_6fe200" ON "tournament" ("name");
+COMMENT ON COLUMN "tournament"."name" IS 'Tournament name';
+COMMENT ON COLUMN "tournament"."created" IS 'Created */''`/* datetime';
+COMMENT ON TABLE "tournament" IS 'What Tournaments */''`/* we have';
+CREATE TABLE "event" (
+    "id" BIGSERIAL NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "modified" TIMESTAMP NOT NULL  DEFAULT CURRENT_TIMESTAMP,
+    "prize" DECIMAL(10,2),
+    "token" VARCHAR(100) NOT NULL UNIQUE,
+    "key" VARCHAR(100) NOT NULL,
+    "tournament_id" SMALLINT NOT NULL,
+    CONSTRAINT "uid_event_name_c6f89f" UNIQUE ("name", "prize"),
+    CONSTRAINT "uid_event_tournam_a5b730" UNIQUE ("tournament_id", "key")
+);
+COMMENT ON COLUMN "event"."id" IS 'Event ID';
+COMMENT ON COLUMN "event"."token" IS 'Unique token';
+COMMENT ON COLUMN "event"."tournament_id" IS 'FK to tournament';
+COMMENT ON TABLE "event" IS 'This table contains a list of all the events';
+CREATE TABLE "team_team" (
+    "team_rel_id" VARCHAR(50) NOT NULL,
+    "team_id" VARCHAR(50) NOT NULL
+);
+CREATE TABLE "teamevents" (
+    "event_id" BIGINT NOT NULL,
+    "team_id" VARCHAR(50) NOT NULL
+);
+COMMENT ON TABLE "teamevents" IS 'How participants relate';""",
         )
 
     async def test_schema(self):

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -1,4 +1,14 @@
-from tests.testmodels import Address, DoubleFK, Employee, Event, Reporter, Team, Tournament
+from tests.testmodels import (
+    Address,
+    Author,
+    BookNoConstraint,
+    DoubleFK,
+    Employee,
+    Event,
+    Reporter,
+    Team,
+    Tournament,
+)
 from tortoise.contrib import test
 from tortoise.exceptions import FieldError, NoValuesFetched
 from tortoise.functions import Count
@@ -270,6 +280,12 @@ class TestRelations(test.TestCase):
 
         self.assertFalse(event1.reporter)
         self.assertTrue(event2.reporter)
+
+    async def test_db_constraint(self):
+        author = await Author.create(name="Some One")
+        book = await BookNoConstraint.create(name="First!", author=author, rating=4)
+        book = await BookNoConstraint.all().select_related("author").get(pk=book.pk)
+        self.assertEqual(author.pk, book.author.pk)
 
 
 class TestDoubleFK(test.TestCase):

--- a/tests/testmodels.py
+++ b/tests/testmodels.py
@@ -27,6 +27,12 @@ class Book(Model):
     rating = fields.FloatField()
 
 
+class BookNoConstraint(Model):
+    name = fields.CharField(max_length=255)
+    author = fields.ForeignKeyField("models.Author", db_constraint=False)
+    rating = fields.FloatField()
+
+
 class Tournament(Model):
     id = fields.SmallIntField(pk=True)
     name = fields.CharField(max_length=255)

--- a/tortoise/fields/relational.py
+++ b/tortoise/fields/relational.py
@@ -291,12 +291,17 @@ class RelationalField(Field):
     has_db_field = False
 
     def __init__(
-        self, related_model: "Type[Model]", to_field: Optional[str] = None, **kwargs: Any
+        self,
+        related_model: "Type[Model]",
+        to_field: Optional[str] = None,
+        db_constraint: bool = True,
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.related_model: "Type[Model]" = related_model
         self.to_field: str = to_field  # type: ignore
         self.to_field_instance: Field = None  # type: ignore
+        self.db_constraint = db_constraint
 
     def describe(self, serializable: bool) -> dict:
         desc = super().describe(serializable)
@@ -392,6 +397,7 @@ def OneToOneField(
     model_name: str,
     related_name: Union[Optional[str], Literal[False]] = None,
     on_delete: str = CASCADE,
+    db_constraint: bool = True,
     **kwargs: Any,
 ) -> OneToOneRelation:
     """
@@ -426,15 +432,21 @@ def OneToOneField(
     ``to_field``:
         The attribute name on the related model to establish foreign key relationship.
         If not set, pk is used
+    ``db_constraint``:
+        Controls whether or not a constraint should be created in the database for this foreign key.
+        The default is True, and that’s almost certainly what you want; setting this to False can be very bad for data integrity.
     """
 
-    return OneToOneFieldInstance(model_name, related_name, on_delete, **kwargs)
+    return OneToOneFieldInstance(
+        model_name, related_name, on_delete, db_constraint=db_constraint, **kwargs
+    )
 
 
 def ForeignKeyField(
     model_name: str,
     related_name: Union[Optional[str], Literal[False]] = None,
     on_delete: str = CASCADE,
+    db_constraint: bool = True,
     **kwargs: Any,
 ) -> ForeignKeyRelation:
     """
@@ -469,9 +481,14 @@ def ForeignKeyField(
     ``to_field``:
         The attribute name on the related model to establish foreign key relationship.
         If not set, pk is used
+    ``db_constraint``:
+        Controls whether or not a constraint should be created in the database for this foreign key.
+        The default is True, and that’s almost certainly what you want; setting this to False can be very bad for data integrity.
     """
 
-    return ForeignKeyFieldInstance(model_name, related_name, on_delete, **kwargs)
+    return ForeignKeyFieldInstance(
+        model_name, related_name, on_delete, db_constraint=db_constraint, **kwargs
+    )
 
 
 def ManyToManyField(
@@ -480,6 +497,7 @@ def ManyToManyField(
     forward_key: Optional[str] = None,
     backward_key: str = "",
     related_name: str = "",
+    db_constraint: bool = True,
     **kwargs: Any,
 ) -> "ManyToManyRelation":
     """
@@ -507,8 +525,17 @@ def ManyToManyField(
         The default is normally safe.
     ``related_name``:
         The attribute name on the related model to reverse resolve the many to many.
+    ``db_constraint``:
+        Controls whether or not a constraint should be created in the database for this foreign key.
+        The default is True, and that’s almost certainly what you want; setting this to False can be very bad for data integrity.
     """
 
     return ManyToManyFieldInstance(  # type: ignore
-        model_name, through, forward_key, backward_key, related_name, **kwargs
+        model_name,
+        through,
+        forward_key,
+        backward_key,
+        related_name,
+        db_constraint=db_constraint,
+        **kwargs,
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add `db_constraint` for `RelationalField` family
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
resolve https://github.com/tortoise/tortoise-orm/issues/499
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Add test cases.
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

