### PR TITLE
Fix select_related crash when join the same table twice

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Changelog
 -------
 - Add `on_delete` in `ManyToManyField`. (#508)
 - Support `F` expression in `annotate`. (#475)
+- Fix `QuerySet.select_related` in case of join same table twice. (#525)
 
 0.16.16
 -------

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -42,6 +42,7 @@ Contributors
 * Weiliang Li ``@kigawas``
 * Bogdan Evstratenko ``@evstratbg``
 * Mike Ryan ``@devsetgo``
+* Eugene Dubovskoy ``@drjackild``
 
 Special Thanks
 ==============

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -1,4 +1,4 @@
-from tests.testmodels import Event, IntFields, MinRelation, Reporter, Tournament
+from tests.testmodels import Event, IntFields, MinRelation, Node, Reporter, Tournament, Tree
 from tortoise import Tortoise
 from tortoise.contrib import test
 from tortoise.exceptions import (
@@ -350,3 +350,13 @@ class TestQueryset(test.TestCase):
         event = await Event.all().select_related("tournament", "reporter").get(pk=event.pk)
         self.assertEqual(event.tournament.pk, tournament.pk)
         self.assertEqual(event.reporter.pk, reporter.pk)
+
+    async def test_select_related_with_two_same_models(self):
+        parent_node = await Node.create(name="1")
+        child_node = await Node.create(name="2")
+        tree = await Tree.create(parent=parent_node, child=child_node)
+        tree = await Tree.all().select_related("parent", "child").get(pk=tree.pk)
+        self.assertEqual(tree.parent.pk, parent_node.pk)
+        self.assertEqual(tree.parent.name, parent_node.name)
+        self.assertEqual(tree.child.pk, child_node.pk)
+        self.assertEqual(tree.child.name, child_node.name)

--- a/tests/testmodels.py
+++ b/tests/testmodels.py
@@ -92,6 +92,15 @@ class Event(Model):
         return self.name
 
 
+class Node(Model):
+    name = fields.CharField(max_length=10)
+
+
+class Tree(Model):
+    parent = fields.ForeignKeyField("models.Node", related_name="parent_trees")
+    child = fields.ForeignKeyField("models.Node", related_name="children_trees")
+
+
 class Address(Model):
     city = fields.CharField(max_length=64)
     street = fields.CharField(max_length=128)

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -732,7 +732,7 @@ class QuerySet(AwaitableQuery[MODEL]):
         )
         for related_field in related_fields:
             self.query = self.query.select(
-                table[related_field].as_(f"{table._table_name}.{related_field}")
+                table[related_field].as_(f"{table.get_table_name()}.{related_field}")
             )
         if forwarded_fields:
             forwarded_fields_split = forwarded_fields.split("__")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR fixes an error when you try to join the same table twice in `select_related`
(issue: https://github.com/tortoise/tortoise-orm/issues/525)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

