### PR TITLE
Makes loop's _selector attribute optional

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,7 +8,7 @@ about: Create a report to help us improve
 A clear and concise description of what the bug is.
 
 **To Reproduce**
-Steps to reproduce the behavior, preferaby a small code snippet.
+Steps to reproduce the behavior, preferably a small code snippet.
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.

--- a/tortoise/contrib/test/__init__.py
+++ b/tortoise/contrib/test/__init__.py
@@ -112,7 +112,7 @@ def initializer(
 
     loop = loop or asyncio.get_event_loop()
     _LOOP = loop
-    _SELECTOR = loop._selector  # type: ignore
+    _SELECTOR = getattr(loop, "_selector", None)  # type: ignore
     loop.run_until_complete(_init_db(_CONFIG))
     _CONNECTIONS = Tortoise._connections.copy()
     _CONN_MAP = current_transaction_map.copy()
@@ -127,7 +127,8 @@ def finalizer() -> None:
     """
     _restore_default()
     loop = _LOOP
-    loop._selector = _SELECTOR  # type: ignore
+    if _SELECTOR:
+        loop._selector = _SELECTOR  # type: ignore
     loop.run_until_complete(Tortoise._drop_databases())
 
 


### PR DESCRIPTION
## Description

It looks like that we cannot take for granted that aloop will have a `_selector` attribute, so this PR is a hotfixz to `tortoise.contrib.test` to threat this attribte as optional.

## Motivation and Context

As described in #532, a loop without a `_selector` attribute break the test initializer function. This PR is a hotfix for situations like that.

## How Has This Been Tested?

I ran the context described in that issue with the code from this PR and it works. Also, I ran the test suite.

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation. **(no, it just changes the internals, not the API)**
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes. **(no, as there was no test for the `initializer` I thought it might be a design decision not to test testing tools)**
- [x] All new and existing tests passed.

