### PR TITLE
Respect PydanticMeta::backward_relations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Changelog
 -------
 - Replace set `TZ` environment variable to `TIMEZONE` to avoid affecting global timezone.
 - Allow passing module objects to `models_paths` param of `Tortoise.init_models()`. (#561)
+- Implement `PydanticMeta.backward_relations`. (#536)
+- Allow overriding `PydanticMeta` in `PydanticModelCreator`. (#536)
 
 0.16.18
 -------

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -44,6 +44,7 @@ Contributors
 * Mike Ryan ``@devsetgo``
 * Eugene Dubovskoy ``@drjackild``
 * Lương Quang Mạnh ``@lqmanh``
+* Mykyta Holubakha ``@Hummer12007``
 
 Special Thanks
 ==============

--- a/tortoise/contrib/pydantic/creator.py
+++ b/tortoise/contrib/pydantic/creator.py
@@ -186,9 +186,7 @@ def pydantic_model_creator(
 
     def get_param(attr: str) -> Any:
         if meta_override:
-            return getattr(
-                meta_override, attr, getattr(meta, attr, getattr(PydanticMeta, attr))
-            )
+            return getattr(meta_override, attr, getattr(meta, attr, getattr(PydanticMeta, attr)))
         return getattr(meta, attr, getattr(PydanticMeta, attr))
 
     default_include: Tuple[str, ...] = tuple(get_param("include"))
@@ -204,9 +202,7 @@ def pydantic_model_creator(
         if sort_alphabetically is None
         else sort_alphabetically
     )
-    _allow_cycles: bool = bool(
-        get_param("allow_cycles") if allow_cycles is None else allow_cycles
-    )
+    _allow_cycles: bool = bool(get_param("allow_cycles") if allow_cycles is None else allow_cycles)
 
     # Update parameters with defaults
     include = tuple(include) + default_include

--- a/tortoise/contrib/pydantic/creator.py
+++ b/tortoise/contrib/pydantic/creator.py
@@ -184,6 +184,10 @@ def pydantic_model_creator(
     default_include: Tuple[str, ...] = tuple(getattr(meta, "include", PydanticMeta.include))
     default_exclude: Tuple[str, ...] = tuple(getattr(meta, "exclude", PydanticMeta.exclude))
     default_computed: Tuple[str, ...] = tuple(getattr(meta, "computed", PydanticMeta.computed))
+    backward_relations: bool = bool(
+        getattr(meta, "backward_relations", PydanticMeta.backward_relations)
+    )
+
     max_recursion: int = int(getattr(meta, "max_recursion", PydanticMeta.max_recursion))
     exclude_raw_fields: bool = bool(
         getattr(meta, "exclude_raw_fields", PydanticMeta.exclude_raw_fields)
@@ -248,10 +252,15 @@ def pydantic_model_creator(
         field_map_update(("pk_field",), is_relation=False)
     field_map_update(("data_fields",), is_relation=False)
     if not exclude_readonly:
-        field_map_update(
-            ("fk_fields", "o2o_fields", "m2m_fields", "backward_fk_fields", "backward_o2o_fields")
+        included_fields: tuple = (
+            "fk_fields",
+            "o2o_fields",
+            "m2m_fields",
         )
+        if backward_relations:
+            included_fields = (*included_fields, "backward_fk_fields", "backward_o2o_fields")
 
+        field_map_update(included_fields)
         # Add possible computed fields
         field_map.update(
             {


### PR DESCRIPTION
## Description
Implemented `backward_relations` for PydanticMeta: if it is set to `False`, fields of backward relationships will not be added to the Pydantic model.

## Motivation and Context
Specifying `backward_relations` has no effect with current versions of tortoise, even though it is mentioned in the docs.

## How Has This Been Tested?
Ran make test in the testing environment, will later add tests covering this feature.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] ~My change requires a change to the documentation.~
- [ ] ~I have updated the documentation accordingly.~
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

