### PR TITLE
Timezone support added.

### DIFF
--- a/tests/fields/test_time.py
+++ b/tests/fields/test_time.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from time import sleep
 
 from iso8601 import ParseError
@@ -15,6 +15,21 @@ class TestDatetimeFields(test.TestCase):
             ConfigurationError, "You can choose only 'auto_now' or 'auto_now_add'"
         ):
             fields.DatetimeField(auto_now=True, auto_now_add=True)
+
+    async def test_timezone_aware(self):
+        _, now = datetime.now(), datetime.now()
+        utc_utc = await testmodels.DatetimeFields.create(datetime=_, datetime_tz_aware=now)
+        self.assertEqual(utc_utc.datetime_tz_aware.utcoffset().total_seconds(), 19800.0)
+
+    def test_timezone_aware_bad(self):
+        with self.assertRaisesRegex(
+            ConfigurationError, "Please specify a valid timezone to both 'tz' and 'db_tz'"
+        ):
+            fields.DatetimeField(tz=None, db_tz=timezone(timedelta(hours=5)))
+        with self.assertRaisesRegex(
+            ConfigurationError, "Please specify a valid timezone to both 'tz' and 'db_tz'"
+        ):
+            fields.DatetimeField(tz=timezone(timedelta(hours=5)), db_tz=None)
 
     async def test_empty(self):
         with self.assertRaises(IntegrityError):

--- a/tests/fields/test_time.py
+++ b/tests/fields/test_time.py
@@ -16,11 +16,6 @@ class TestDatetimeFields(test.TestCase):
         ):
             fields.DatetimeField(auto_now=True, auto_now_add=True)
 
-    async def test_timezone_aware(self):
-        _, now = datetime.now(), datetime.now()
-        utc_utc = await testmodels.DatetimeFields.create(datetime=_, datetime_tz_aware=now)
-        self.assertEqual(utc_utc.datetime_tz_aware.utcoffset().total_seconds(), 19800.0)
-
     def test_timezone_aware_bad(self):
         with self.assertRaisesRegex(
             ConfigurationError, "Please specify a valid timezone to both 'tz' and 'db_tz'"
@@ -36,23 +31,31 @@ class TestDatetimeFields(test.TestCase):
             await testmodels.DatetimeFields.create()
 
     async def test_create(self):
-        now = datetime.utcnow()
-        obj0 = await testmodels.DatetimeFields.create(datetime=now)
+        utc_now = datetime.utcnow()
+        tz = timezone(timedelta(hours=3))
+        now = datetime.now(tz)
+        auto_now = datetime.now()
+        obj0 = await testmodels.DatetimeFields.create(datetime=utc_now, datetime_tz_aware=now)
         obj = await testmodels.DatetimeFields.get(id=obj0.id)
-        self.assertEqual(obj.datetime, now)
+        self.assertEqual(obj.datetime, utc_now)
         self.assertEqual(obj.datetime_null, None)
-        self.assertLess(obj.datetime_auto - now, timedelta(microseconds=20000))
-        self.assertLess(obj.datetime_add - now, timedelta(microseconds=20000))
+        self.assertLess(obj.datetime_auto - auto_now, timedelta(microseconds=20000))
+        self.assertLess(obj.datetime_add - auto_now, timedelta(microseconds=20000))
+        self.assertEqual(obj.datetime_tz_aware.utcoffset().total_seconds(), 27000.0)
+        self.assertLess(
+            obj.datetime_tz_aware - now.astimezone(timezone(timedelta(hours=7, minutes=30))),
+            timedelta(microseconds=20000),
+        )
         datetime_auto = obj.datetime_auto
         sleep(0.012)
         await obj.save()
         obj2 = await testmodels.DatetimeFields.get(id=obj.id)
-        self.assertEqual(obj2.datetime, now)
+        self.assertEqual(obj2.datetime, utc_now)
         self.assertEqual(obj2.datetime_null, None)
         self.assertEqual(obj2.datetime_auto, obj.datetime_auto)
         self.assertNotEqual(obj2.datetime_auto, datetime_auto)
-        self.assertGreater(obj2.datetime_auto - now, timedelta(microseconds=10000))
-        self.assertLess(obj2.datetime_auto - now, timedelta(seconds=1))
+        self.assertGreater(obj2.datetime_auto - auto_now, timedelta(microseconds=10000))
+        self.assertLess(obj2.datetime_auto - auto_now, timedelta(seconds=1))
         self.assertEqual(obj2.datetime_add, obj.datetime_add)
 
     async def test_update(self):

--- a/tests/testmodels.py
+++ b/tests/testmodels.py
@@ -3,9 +3,9 @@ This is the testing Models
 """
 import binascii
 import datetime
-from datetime import timedelta, timezone
 import os
 import uuid
+from datetime import timedelta, timezone
 from decimal import Decimal
 from enum import Enum, IntEnum
 
@@ -226,8 +226,9 @@ class DatetimeFields(Model):
     datetime_null = fields.DatetimeField(null=True)
     datetime_auto = fields.DatetimeField(auto_now=True)
     datetime_add = fields.DatetimeField(auto_now_add=True)
-    datetime_tz_aware = fields.DatetimeField(null=True, tz=timezone(timedelta(hours=5)),
-                                             db_tz=timezone(timedelta(hours=0)))
+    datetime_tz_aware = fields.DatetimeField(
+        null=True, tz=timezone(timedelta(hours=7, minutes=30)), db_tz=timezone(timedelta(hours=0))
+    )
 
 
 class TimeDeltaFields(Model):

--- a/tests/testmodels.py
+++ b/tests/testmodels.py
@@ -3,6 +3,7 @@ This is the testing Models
 """
 import binascii
 import datetime
+from datetime import timedelta, timezone
 import os
 import uuid
 from decimal import Decimal
@@ -225,6 +226,8 @@ class DatetimeFields(Model):
     datetime_null = fields.DatetimeField(null=True)
     datetime_auto = fields.DatetimeField(auto_now=True)
     datetime_add = fields.DatetimeField(auto_now_add=True)
+    datetime_tz_aware = fields.DatetimeField(null=True, tz=timezone(timedelta(hours=5)),
+                                             db_tz=timezone(timedelta(hours=0)))
 
 
 class TimeDeltaFields(Model):

--- a/tortoise/backends/sqlite/executor.py
+++ b/tortoise/backends/sqlite/executor.py
@@ -42,10 +42,14 @@ def to_db_datetime(
         self.auto_now
         or (self.auto_now_add and getattr(instance, self.model_field_name, None) is None)
     ):
-        value = datetime.datetime.utcnow()
+        value = datetime.datetime.now()
         setattr(instance, self.model_field_name, value)
-        return value.isoformat(" ")
     if isinstance(value, datetime.datetime):
+        if self.tz is not None and value is not None:
+            if hasattr(value, "tzinfo") and value.tzinfo is not None:
+                value = value.astimezone(self.db_tz)
+            else:
+                value = value.replace(tzinfo=self.tz).astimezone(self.db_tz)
         return value.isoformat(" ")
     return None
 


### PR DESCRIPTION
Now a DatetimeField can be created with timezone support.

Eg:

 
    datetime_tz = fields.DatetimeField(tz=timezone(timedelta(hours=7, minutes=30)), db_tz=timezone(timedelta(hours=0)))


## Description
After setting both ``tz`` and ``db_tz`` you can pass datetime aware objects in any timezone and
    it will get automatically converted to ``db_tz`` and stored in database and attribute will be
    accessible with timezone ``tz``. If you pass native datetime objects, the timezone of datetime
    is assumed to be in ``db_tz``.

## How Has This Been Tested?
Tested with mysql, sqlite. Please test in postgresql