### PR TITLE
Make Tortoise's __init__ docs more clear

### DIFF
--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -495,10 +495,10 @@ class Tortoise:
                                 }
                             },
                             # Using a DB_URL string
-                            'default': 'postgres://postgres:qwerty123@localhost:5432/events'
+                            'default': 'postgres://postgres:qwerty123@localhost:5432/test'
                         },
                         'apps': {
-                            'models': {
+                            'my_app': {
                                 'models': ['__main__'],
                                 # If no default_connection specified, defaults to 'default'
                                 'default_connection': 'default',


### PR DESCRIPTION
Renames example database name and key name in example config dict. Starts from [here](https://github.com/jakub-balinski/tortoise-orm/blob/develop/tortoise/__init__.py#L498).

## Description
I find it confusing to set a key name to "models" in the example config dictionary, when an entry name in it is required to be the same, so I renamed it to "my_app". Also I changed database name in example DB_URL string to "test" instead of "events", which I find more consistent with the example above it (dict format).

## Motivation and Context
Make docs more clear to new users.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
