### PR TITLE
Replace set `TZ` environment variable to `TIMEZONE`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,11 @@ Changelog
 
 0.16
 ====
+
+0.16.19
+-------
+- Replace set `TZ` environment variable to `TIMEZONE` to avoid affecting global timezone.
+
 0.16.18
 -------
 - Support custom function in update. (#537)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tortoise-orm"
-version = "0.16.18"
+version = "0.16.19"
 description = "Easy async ORM for python, built with relations in mind"
 authors = ["Andrey Bondar <andrey@bondar.ru>", "Nickolas Grigoriadis <nagrigoriadis@gmail.com>", "long2ice <long2ice@gmail.com>"]
 license = "Apache-2.0"

--- a/tests/fields/test_time.py
+++ b/tests/fields/test_time.py
@@ -115,9 +115,9 @@ class TestDatetimeFields(test.TestCase):
         self.assertEqual(obj_get.datetime, now)
 
     async def test_set_timezone(self):
-        old_tz = os.environ["TZ"]
+        old_tz = os.environ["TIMEZONE"]
         tz = "Asia/Shanghai"
-        os.environ["TZ"] = tz
+        os.environ["TIMEZONE"] = tz
         now = datetime.now(pytz.timezone(tz))
         obj = await testmodels.DatetimeFields.create(datetime=now)
         self.assertEqual(obj.datetime.tzinfo.zone, tz)
@@ -126,13 +126,13 @@ class TestDatetimeFields(test.TestCase):
         self.assertEqual(obj_get.datetime.tzinfo.zone, tz)
         self.assertEqual(obj_get.datetime, now)
 
-        os.environ["TZ"] = old_tz
+        os.environ["TIMEZONE"] = old_tz
 
     async def test_timezone(self):
-        old_tz = os.environ["TZ"]
+        old_tz = os.environ["TIMEZONE"]
         old_use_tz = os.environ["USE_TZ"]
         tz = "Asia/Shanghai"
-        os.environ["TZ"] = tz
+        os.environ["TIMEZONE"] = tz
         os.environ["USE_TZ"] = "True"
 
         now = datetime.now(pytz.timezone(tz))
@@ -142,7 +142,7 @@ class TestDatetimeFields(test.TestCase):
         self.assertEqual(obj.datetime.tzinfo.zone, tz)
         self.assertEqual(obj_get.datetime, now)
 
-        os.environ["TZ"] = old_tz
+        os.environ["TIMEZONE"] = old_tz
         os.environ["USE_TZ"] = old_use_tz
 
 

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -626,7 +626,7 @@ class Tortoise:
     @classmethod
     def _init_timezone(cls, use_tz: bool, timezone: str) -> None:
         os.environ["USE_TZ"] = str(use_tz)
-        os.environ["TZ"] = timezone
+        os.environ["TIMEZONE"] = timezone
 
 
 def run_async(coro: Coroutine) -> None:
@@ -655,4 +655,4 @@ def run_async(coro: Coroutine) -> None:
         loop.run_until_complete(Tortoise.close_connections())
 
 
-__version__ = "0.16.18"
+__version__ = "0.16.19"

--- a/tortoise/timezone.py
+++ b/tortoise/timezone.py
@@ -16,7 +16,7 @@ def get_timezone() -> str:
     """
     Get timezone from env set in Tortoise config.
     """
-    return os.environ.get("TZ") or "UTC"
+    return os.environ.get("TIMEZONE") or "UTC"
 
 
 def now() -> datetime:


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Replace set `TZ` environment variable to `TIMEZONE` to avoid affecting global timezone.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

