### PR TITLE
Json fields for correct pydantic schema creation

### DIFF
--- a/tortoise/contrib/pydantic/creator.py
+++ b/tortoise/contrib/pydantic/creator.py
@@ -349,6 +349,13 @@ def pydantic_model_creator(
                 pannotations[fname] = annotation
         # Json fields
         elif field_type is fields.JSONField:
+            if fdesc.get("nullable"):
+                fconfig["nullable"] = True
+            if fdesc.get("nullable") or field_default is not None:
+                pannotations[fname] = Optional[dict]
+            else:
+                pannotations[fname] = dict
+        elif field_type is fields.JSONField:
             pannotations[fname] = Any  # type: ignore
         # Any other tortoise fields
         else:


### PR DESCRIPTION
## Description
Added pydantic schema for Json field annotation

## Motivation and Context
JSON field not taken into pydantic scheme

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
