### PR TITLE
RESTful examples for sanic

### DIFF
--- a/examples/group_by.py
+++ b/examples/group_by.py
@@ -36,6 +36,10 @@ async def run():
     print(ret)
     # >>> [{'author_id': 1, 'count': 10}]
 
+    ret = (await Book.annotate(sum=Sum("rating")).values_list("sum", flat=True))[0]
+    print(ret)
+    # >>> 55.0
+
     ret = await Book.annotate(sum=Sum("rating")).group_by("author_id").values("author_id", "sum")
     print(ret)
     # >>> [{'author_id': 1, 'sum': 45.0}, {'author_id': 2, 'sum': 10.0}]

--- a/examples/sanic/main.py
+++ b/examples/sanic/main.py
@@ -17,7 +17,7 @@ async def list_all(request):
     return response.json({"users": [user.to_json() for user in users]})
 
 
-@app.route("/user", methods=['POST'])
+@app.route("/user", methods=["POST"])
 async def add_user(request):
     user = await User.create(name="New User")
     return response.json(user.to_json())

--- a/examples/sanic/main.py
+++ b/examples/sanic/main.py
@@ -1,7 +1,7 @@
 # pylint: disable=E0401,E0611
 import logging
 
-from models import Users
+from models import User
 from sanic import Sanic, response
 
 from tortoise.contrib.sanic import register_tortoise
@@ -13,14 +13,14 @@ app = Sanic(__name__)
 
 @app.route("/")
 async def list_all(request):
-    users = await Users.all()
-    return response.json({"users": [str(user) for user in users]})
+    users = await User.all()
+    return response.json({"users": [user.to_json() for user in users]})
 
 
-@app.route("/user")
+@app.route("/user", methods=['POST'])
 async def add_user(request):
-    user = await Users.create(name="New User")
-    return response.json({"user": str(user)})
+    user = await User.create(name="New User")
+    return response.json(user.to_json())
 
 
 register_tortoise(

--- a/examples/sanic/models.py
+++ b/examples/sanic/models.py
@@ -1,9 +1,14 @@
+from typing import Dict, Union
+
 from tortoise import Model, fields
 
 
-class Users(Model):
+class User(Model):
     id = fields.IntField(pk=True)
     name = fields.CharField(50)
+
+    def to_json(self) -> Dict[str, Union[int, str]]:
+        return {f: getattr(self, f) for f in self._meta.fields}
 
     def __str__(self):
         return f"User {self.id}: {self.name}"


### PR DESCRIPTION
Update Examples
----
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We use `Sanic`+`tortoise-orm`+`postgresql` at production environment for more than one year.
The orm help us so much~

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
1. For `django`, when I want to count the sum of a field, it should be `Model.objects.aggregate(sum=Sum('{field_name}'))`
    It cost me about half hour to find the way in here:  `await Model.annotate(sum=Sum('{field_name}'))`
    So I add an example to `examples/group_by.py`
2. `response.json` of Sanic is for RESTful API most of the time, so I add `to_json` method for User model.


