### PR TITLE
Parallel connections closing

### DIFF
--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -604,8 +604,10 @@ class Tortoise:
         else your event loop may never complete
         as it is waiting for the connections to die.
         """
+        tasks = []
         for connection in cls._connections.values():
-            await connection.close()
+            tasks.append(connection.close())
+        await asyncio.gather(*tasks)
         cls._connections = {}
         logger.info("Tortoise-ORM shutdown")
 


### PR DESCRIPTION
## Description
We don't need to await every connection to close in `for` loop, it may be called and awaited in parallel tasks.

## Motivation and Context
This will speed up closing

## How Has This Been Tested?
I didn't test that

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

