### PR TITLE
Add a default value for `Tortoise.get_connection` connection_name argument

### DIFF
--- a/examples/manual_sql.py
+++ b/examples/manual_sql.py
@@ -16,8 +16,8 @@ async def run():
     await Tortoise.init(db_url="sqlite://:memory:", modules={"models": ["__main__"]})
     await Tortoise.generate_schemas()
 
-    # Need to get a connection. Unless explicitly specified, the name should be 'default'
-    conn = Tortoise.get_connection("default")
+    # Retrieve database connection. Unless explicitly specified, 'default' connection will be used
+    conn = Tortoise.get_connection()
 
     # Now we can execute queries in the normal autocommit mode
     await conn.execute_query("INSERT INTO event (name) VALUES ('Foo')")

--- a/examples/schema_create.py
+++ b/examples/schema_create.py
@@ -49,19 +49,19 @@ class Team(Model):
 async def run():
     print("SQLite:\n")
     await Tortoise.init(db_url="sqlite://:memory:", modules={"models": ["__main__"]})
-    sql = get_schema_sql(Tortoise.get_connection("default"), safe=False)
+    sql = get_schema_sql(Tortoise.get_connection(), safe=False)
     print(sql)
 
     print("\n\nMySQL:\n")
     await Tortoise.init(db_url="mysql://root:@127.0.0.1:3306/", modules={"models": ["__main__"]})
-    sql = get_schema_sql(Tortoise.get_connection("default"), safe=False)
+    sql = get_schema_sql(Tortoise.get_connection(), safe=False)
     print(sql)
 
     print("\n\nPostgreSQL:\n")
     await Tortoise.init(
         db_url="postgres://postgres:@127.0.0.1:5432/", modules={"models": ["__main__"]}
     )
-    sql = get_schema_sql(Tortoise.get_connection("default"), safe=False)
+    sql = get_schema_sql(Tortoise.get_connection(), safe=False)
     print(sql)
 
 

--- a/tests/model_setup/test_init.py
+++ b/tests/model_setup/test_init.py
@@ -34,7 +34,7 @@ class TestInitErrors(test.SimpleTestCase):
             }
         )
         self.assertIn("models", Tortoise.apps)
-        self.assertIsNotNone(Tortoise.get_connection("default"))
+        self.assertIsNotNone(Tortoise.get_connection())
 
     async def test_empty_modules_init(self):
         with self.assertWarnsRegex(RuntimeWarning, 'Module "tests.model_setup" has no models'):
@@ -216,7 +216,7 @@ class TestInitErrors(test.SimpleTestCase):
             }
         )
         self.assertIn("models", Tortoise.apps)
-        self.assertIsNotNone(Tortoise.get_connection("default"))
+        self.assertIsNotNone(Tortoise.get_connection())
 
     async def test_db_url_init(self):
         await Tortoise.init(
@@ -228,14 +228,14 @@ class TestInitErrors(test.SimpleTestCase):
             }
         )
         self.assertIn("models", Tortoise.apps)
-        self.assertIsNotNone(Tortoise.get_connection("default"))
+        self.assertIsNotNone(Tortoise.get_connection())
 
     async def test_shorthand_init(self):
         await Tortoise.init(
             db_url=f"sqlite://{':memory:'}", modules={"models": ["tests.testmodels"]}
         )
         self.assertIn("models", Tortoise.apps)
-        self.assertIsNotNone(Tortoise.get_connection("default"))
+        self.assertIsNotNone(Tortoise.get_connection())
 
     async def test_init_wrong_connection_engine(self):
         with self.assertRaisesRegex(ImportError, "tortoise.backends.test"):
@@ -324,13 +324,13 @@ class TestInitErrors(test.SimpleTestCase):
     async def test_init_json_file(self):
         await Tortoise.init(config_file=os.path.dirname(__file__) + "/init.json")
         self.assertIn("models", Tortoise.apps)
-        self.assertIsNotNone(Tortoise.get_connection("default"))
+        self.assertIsNotNone(Tortoise.get_connection())
 
     @test.skipIf(os.name == "nt", "path issue on Windows")
     async def test_init_yaml_file(self):
         await Tortoise.init(config_file=os.path.dirname(__file__) + "/init.yaml")
         self.assertIn("models", Tortoise.apps)
-        self.assertIsNotNone(Tortoise.get_connection("default"))
+        self.assertIsNotNone(Tortoise.get_connection())
 
     async def test_generate_schema_without_init(self):
         with self.assertRaisesRegex(

--- a/tests/model_setup/test_init.py
+++ b/tests/model_setup/test_init.py
@@ -237,6 +237,22 @@ class TestInitErrors(test.SimpleTestCase):
         self.assertIn("models", Tortoise.apps)
         self.assertIsNotNone(Tortoise.get_connection())
 
+    async def test_default_connection(self):
+        await Tortoise.init(
+            db_url=f"sqlite://{':memory:'}", modules={"models": ["tests.testmodels"]}
+        )
+        self.assertIn("models", Tortoise.apps)
+        self.assertIsNotNone(Tortoise.get_connection("default"))
+
+    async def test_non_existing_connection(self):
+        await Tortoise.init(
+            db_url=f"sqlite://{':memory:'}", modules={"models": ["tests.testmodels"]}
+        )
+        self.assertIn("models", Tortoise.apps)
+
+        with self.assertRaises(KeyError):
+            Tortoise.get_connection("a_non_existing_connection")
+
     async def test_init_wrong_connection_engine(self):
         with self.assertRaisesRegex(ImportError, "tortoise.backends.test"):
             await Tortoise.init(

--- a/tests/schema/test_generate_schema.py
+++ b/tests/schema/test_generate_schema.py
@@ -138,7 +138,7 @@ class TestGenerateSchema(test.SimpleTestCase):
     async def test_schema_no_db_constraint(self):
         self.maxDiff = None
         await self.init_for("tests.schema.models_no_db_constraint")
-        sql = get_schema_sql(Tortoise.get_connection("default"), safe=False)
+        sql = get_schema_sql(Tortoise.get_connection(), safe=False)
         self.assertEqual(
             sql.strip(),
             r"""CREATE TABLE "team" (
@@ -178,7 +178,7 @@ CREATE TABLE "teamevents" (
     async def test_schema(self):
         self.maxDiff = None
         await self.init_for("tests.schema.models_schema_create")
-        sql = get_schema_sql(Tortoise.get_connection("default"), safe=False)
+        sql = get_schema_sql(Tortoise.get_connection(), safe=False)
         self.assertEqual(
             sql.strip(),
             """
@@ -265,7 +265,7 @@ CREATE TABLE "teamevents" (
     async def test_schema_safe(self):
         self.maxDiff = None
         await self.init_for("tests.schema.models_schema_create")
-        sql = get_schema_sql(Tortoise.get_connection("default"), safe=True)
+        sql = get_schema_sql(Tortoise.get_connection(), safe=True)
         self.assertEqual(
             sql.strip(),
             """
@@ -416,7 +416,7 @@ class TestGenerateSchemaMySQL(TestGenerateSchema):
     async def test_schema_no_db_constraint(self):
         self.maxDiff = None
         await self.init_for("tests.schema.models_no_db_constraint")
-        sql = get_schema_sql(Tortoise.get_connection("default"), safe=False)
+        sql = get_schema_sql(Tortoise.get_connection(), safe=False)
         self.assertEqual(
             sql.strip(),
             r"""CREATE TABLE `team` (
@@ -456,7 +456,7 @@ CREATE TABLE `teamevents` (
     async def test_schema(self):
         self.maxDiff = None
         await self.init_for("tests.schema.models_schema_create")
-        sql = get_schema_sql(Tortoise.get_connection("default"), safe=False)
+        sql = get_schema_sql(Tortoise.get_connection(), safe=False)
         self.assertEqual(
             sql.strip(),
             """
@@ -555,7 +555,7 @@ CREATE TABLE `teamevents` (
     async def test_schema_safe(self):
         self.maxDiff = None
         await self.init_for("tests.schema.models_schema_create")
-        sql = get_schema_sql(Tortoise.get_connection("default"), safe=True)
+        sql = get_schema_sql(Tortoise.get_connection(), safe=True)
 
         self.assertEqual(
             sql.strip(),
@@ -700,7 +700,7 @@ class TestGenerateSchemaPostgresSQL(TestGenerateSchema):
     async def test_schema_no_db_constraint(self):
         self.maxDiff = None
         await self.init_for("tests.schema.models_no_db_constraint")
-        sql = get_schema_sql(Tortoise.get_connection("default"), safe=False)
+        sql = get_schema_sql(Tortoise.get_connection(), safe=False)
         self.assertEqual(
             sql.strip(),
             r"""CREATE TABLE "team" (
@@ -750,7 +750,7 @@ COMMENT ON TABLE "teamevents" IS 'How participants relate';""",
     async def test_schema(self):
         self.maxDiff = None
         await self.init_for("tests.schema.models_schema_create")
-        sql = get_schema_sql(Tortoise.get_connection("default"), safe=False)
+        sql = get_schema_sql(Tortoise.get_connection(), safe=False)
         self.assertEqual(
             sql.strip(),
             """
@@ -852,7 +852,7 @@ COMMENT ON TABLE "teamevents" IS 'How participants relate';
     async def test_schema_safe(self):
         self.maxDiff = None
         await self.init_for("tests.schema.models_schema_create")
-        sql = get_schema_sql(Tortoise.get_connection("default"), safe=True)
+        sql = get_schema_sql(Tortoise.get_connection(), safe=True)
         self.assertEqual(
             sql.strip(),
             """

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -36,10 +36,12 @@ class Tortoise:
     _inited: bool = False
 
     @classmethod
-    def get_connection(cls, connection_name: str) -> BaseDBAsyncClient:
+    def get_connection(cls, connection_name: str = "default") -> BaseDBAsyncClient:
         """
         Returns the connection by name.
 
+        :param connection_name: Name of the connection to retrieve.
+        :return: An instance of a database connection.
         :raises KeyError: If connection name does not exist.
         """
         return cls._connections[connection_name]

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -113,7 +113,7 @@ class Tortoise:
         def get_related_model(related_app_name: str, related_model_name: str) -> Type[Model]:
             """
             Test, if app and model really exist. Throws a ConfigurationError with a hopefully
-            helpful message. If successfull, returns the requested model.
+            helpful message. If successful, returns the requested model.
 
             :raises ConfigurationError: If no such app exists.
             """
@@ -130,7 +130,7 @@ class Tortoise:
         def split_reference(reference: str) -> Tuple[str, str]:
             """
             Test, if reference follow the official naming conventions. Throws a
-            ConfigurationError with a hopefully helpful message. If successfull,
+            ConfigurationError with a hopefully helpful message. If successful,
             returns the app and the model name.
 
             :raises ConfigurationError: If no model reference is invalid.


### PR DESCRIPTION
## Description
This PR intends to set `default` as a default value for `connection_name` argument in Tortoise `get_connection` method.

## Motivation and Context
Passing `db_url` to Tortoise `init` method  currently automatically instantiates the connection as `default`, and most projects may only ever define a `default` connection when using a dict-based configuration through `config` or `config_file` arguments.

The proposed change would remove the need to explictly pass `default` to the method, which would be useful for projects that only use a single default connection.

## How Has This Been Tested?
I've updated the tests so that they don't specify the parameter anymore, but I've added a specific test to showcase that explicitly passing `default` value still works as expected. I also took the occasion to add a test showcasing a `KeyError` when a connection doesn't exist.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.