### PR TITLE
fix save with F expression and field with source_field

### DIFF
--- a/tests/test_source_field.py
+++ b/tests/test_source_field.py
@@ -4,7 +4,7 @@ This module does a series of use tests on a non-source_field model,
 
 This is to test that behaviour doesn't change when one defined source_field parameters.
 """
-from tests.testmodels import SourceFields, StraightFields
+from tests.testmodels import NumberSourceField, SourceFields, StraightFields
 from tortoise.contrib import test
 from tortoise.expressions import F
 from tortoise.functions import Coalesce, Count, Length, Lower, Trim, Upper
@@ -259,3 +259,18 @@ class StraightFieldTests(test.TestCase):
 class SourceFieldTests(StraightFieldTests):
     def setUp(self) -> None:
         self.model = SourceFields  # type: ignore
+
+
+class NumberSourceFieldTests(test.TestCase):
+    def setUp(self) -> None:
+        self.model = NumberSourceField
+
+    async def test_f_expression_save(self):
+        obj1 = await self.model.create()
+        obj1.number = F("number") + 1
+        await obj1.save()
+
+    async def test_f_expression_save_update_fields(self):
+        obj1 = await self.model.create()
+        obj1.number = F("number") + 1
+        await obj1.save(update_fields=["number"])

--- a/tests/testmodels.py
+++ b/tests/testmodels.py
@@ -725,3 +725,7 @@ class ValidatorModel(Model):
     comma_separated_integer_list = fields.CharField(
         max_length=100, null=True, validators=[CommaSeparatedIntegerListValidator()]
     )
+
+
+class NumberSourceField(Model):
+    number = fields.IntField(source_field="counter", default=0)

--- a/tortoise/backends/base/executor.py
+++ b/tortoise/backends/base/executor.py
@@ -272,7 +272,9 @@ class BaseExecutor:
                     query = query.set(db_column, self.parameter(count))
                     count += 1
                 else:
-                    value = F.resolver_arithmetic_expression(self.model, arithmetic_or_function.get(field))[0]
+                    value = F.resolver_arithmetic_expression(
+                        self.model, arithmetic_or_function.get(field)
+                    )[0]
                     query = query.set(db_column, value)
 
         query = query.where(table[self.model._meta.db_pk_column] == self.parameter(count))

--- a/tortoise/backends/base/executor.py
+++ b/tortoise/backends/base/executor.py
@@ -23,6 +23,7 @@ from pypika import JoinType, Parameter, Query, Table
 from pypika.terms import ArithmeticExpression, Function
 
 from tortoise.exceptions import OperationalError
+from tortoise.expressions import F
 from tortoise.fields.base import Field
 from tortoise.fields.relational import (
     BackwardFKRelation,
@@ -267,11 +268,12 @@ class BaseExecutor:
             db_column = self.model._meta.fields_db_projection[field]
             field_object = self.model._meta.fields_map[field]
             if not field_object.pk:
-                if db_column not in arithmetic_or_function.keys():
+                if field not in arithmetic_or_function.keys():
                     query = query.set(db_column, self.parameter(count))
                     count += 1
                 else:
-                    query = query.set(db_column, arithmetic_or_function.get(db_column))
+                    value = F.resolver_arithmetic_expression(self.model, arithmetic_or_function.get(field))[0]
+                    query = query.set(db_column, value)
 
         query = query.where(table[self.model._meta.db_pk_column] == self.parameter(count))
 


### PR DESCRIPTION
Hi
I'm not 100% sure, but there seems to be a bug in the case of using F expression for a field with source_field. 
If I update the record via update call - no problem.
But if I update via save call - TypeError: not enough arguments for format string.