### PR TITLE
bugfix: name not affect pydantic_queryset_creator

### DIFF
--- a/tortoise/contrib/pydantic/creator.py
+++ b/tortoise/contrib/pydantic/creator.py
@@ -455,6 +455,7 @@ def pydantic_queryset_creator(
         computed=computed,
         allow_cycles=allow_cycles,
         sort_alphabetically=sort_alphabetically,
+        name=name,
     )
     lname = name or f"{submodel.__name__}_list"
 


### PR DESCRIPTION
```
UserSerializer = pydantic_model_creator(User, exclude=('id',), name="short_user")
UsersListSerializer = pydantic_queryset_creator(User, name="short_user")

FullUserSerializer = pydantic_model_creator(User, name="all_user_fields")
# here is bug, pydantic_queryset_creator will use default PydanticModel, not all_user_fields
FullUsersListSerializer = pydantic_queryset_creator(User, name="all_user_fields")
```