### PR TITLE
Add date part extract filtering

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,10 @@ Changelog
 
 0.16
 ====
+0.16.22
+-------
+- Add date part extract filtering.
+
 0.16.21
 -------
 - Fixed validating JSON before decoding. (#623)

--- a/docs/query.rst
+++ b/docs/query.rst
@@ -266,6 +266,22 @@ When using ``.filter()`` method you can use number of modifiers to field names t
 - ``iendswith`` - case insensitive ``endswith``
 - ``iexact`` - case insensitive equals
 
+Specially, you can filter date part with one of following:
+
+.. code-block:: python3
+
+    class DatePart(Enum):
+        year = "YEAR"
+        quarter = "QUARTER"
+        month = "MONTH"
+        week = "WEEK"
+        day = "DAY"
+        hour = "HOUR"
+        minute = "MINUTE"
+        second = "SECOND"
+        microsecond = "MICROSECOND"
+
+    teams = await Team.filter(created_at__year=2020)
 
 Complex prefetch
 ================

--- a/docs/query.rst
+++ b/docs/query.rst
@@ -266,7 +266,7 @@ When using ``.filter()`` method you can use number of modifiers to field names t
 - ``iendswith`` - case insensitive ``endswith``
 - ``iexact`` - case insensitive equals
 
-Specially, you can filter date part with one of following:
+Specially, you can filter date part with one of following, note that current only support PostgreSQL and MySQL, but not sqlite:
 
 .. code-block:: python3
 
@@ -282,6 +282,8 @@ Specially, you can filter date part with one of following:
         microsecond = "MICROSECOND"
 
     teams = await Team.filter(created_at__year=2020)
+    teams = await Team.filter(created_at__month=12)
+    teams = await Team.filter(created_at__day=5)
 
 Complex prefetch
 ================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tortoise-orm"
-version = "0.16.21"
+version = "0.16.22"
 description = "Easy async ORM for python, built with relations in mind"
 authors = ["Andrey Bondar <andrey@bondar.ru>", "Nickolas Grigoriadis <nagrigoriadis@gmail.com>", "long2ice <long2ice@gmail.com>"]
 license = "Apache-2.0"

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -157,6 +157,8 @@ class TestFiltering(test.TestCase):
         self.assertEqual(len(tournaments), 2)
         self.assertSetEqual({t.name for t in tournaments}, {"0", "1"})
 
+    @test.requireCapability(dialect="mysql")
+    @test.requireCapability(dialect="postgres")
     async def test_filter_exact(self):
         await DatetimeFields.create(
             datetime=datetime.datetime(

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -1,4 +1,6 @@
-from tests.testmodels import Event, IntFields, Reporter, Team, Tournament
+import datetime
+
+from tests.testmodels import DatetimeFields, Event, IntFields, Reporter, Team, Tournament
 from tortoise.contrib import test
 from tortoise.expressions import F
 from tortoise.functions import Coalesce, Count, Length, Lower, Max, Trim, Upper
@@ -154,6 +156,22 @@ class TestFiltering(test.TestCase):
         tournaments = await Tournament.filter(Q(name="1") | ~Q(name="2"))
         self.assertEqual(len(tournaments), 2)
         self.assertSetEqual({t.name for t in tournaments}, {"0", "1"})
+
+    async def test_filter_exact(self):
+        await DatetimeFields.create(
+            datetime=datetime.datetime(
+                year=2020, month=5, day=20, hour=0, minute=0, second=0, microsecond=0
+            )
+        )
+        self.assertEqual(await DatetimeFields.filter(datetime__year=2020).count(), 1)
+        self.assertEqual(await DatetimeFields.filter(datetime__quarter=2).count(), 1)
+        self.assertEqual(await DatetimeFields.filter(datetime__month=5).count(), 1)
+        self.assertEqual(await DatetimeFields.filter(datetime__week=20).count(), 1)
+        self.assertEqual(await DatetimeFields.filter(datetime__day=20).count(), 1)
+        self.assertEqual(await DatetimeFields.filter(datetime__hour=0).count(), 1)
+        self.assertEqual(await DatetimeFields.filter(datetime__minute=0).count(), 1)
+        self.assertEqual(await DatetimeFields.filter(datetime__second=0).count(), 1)
+        self.assertEqual(await DatetimeFields.filter(datetime__microsecond=0).count(), 1)
 
     async def test_filter_by_aggregation_field(self):
         tournament = await Tournament.create(name="0")

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -683,4 +683,4 @@ def run_async(coro: Coroutine) -> None:
         loop.run_until_complete(Tortoise.close_connections())
 
 
-__version__ = "0.16.21"
+__version__ = "0.16.22"

--- a/tortoise/filters.py
+++ b/tortoise/filters.py
@@ -3,8 +3,8 @@ from functools import partial
 from typing import TYPE_CHECKING, Any, Dict, Iterable, Optional, Tuple
 
 from pypika import Table
-from pypika.enums import SqlTypes
-from pypika.functions import Cast, Upper
+from pypika.enums import DatePart, SqlTypes
+from pypika.functions import Cast, Extract, Upper
 from pypika.terms import (
     BasicCriterion,
     Criterion,
@@ -21,6 +21,7 @@ from tortoise.fields.relational import BackwardFKRelation, ManyToManyFieldInstan
 
 if TYPE_CHECKING:  # pragma: nocoverage
     from tortoise.models import Model
+
 
 ##############################################################################
 # Here we monkey-patch PyPika Valuewrapper to behave differently for MySQL
@@ -53,6 +54,8 @@ def get_value_sql(self, **kwargs):  # pragma: nocoverage
 
 
 ValueWrapper.get_value_sql = get_value_sql
+
+
 ##############################################################################
 
 
@@ -178,6 +181,42 @@ def insensitive_ends_with(field: Term, value: str) -> Criterion:
     return Like(
         Upper(Cast(field, SqlTypes.VARCHAR)), field.wrap_constant(Upper(f"%{escape_like(value)}"))
     )
+
+
+def extract_year_equal(field: Term, value: int) -> Criterion:
+    return Extract(DatePart.year, field).eq(value)
+
+
+def extract_quarter_equal(field: Term, value: int) -> Criterion:
+    return Extract(DatePart.quarter, field).eq(value)
+
+
+def extract_month_equal(field: Term, value: int) -> Criterion:
+    return Extract(DatePart.month, field).eq(value)
+
+
+def extract_week_equal(field: Term, value: int) -> Criterion:
+    return Extract(DatePart.week, field).eq(value)
+
+
+def extract_day_equal(field: Term, value: int) -> Criterion:
+    return Extract(DatePart.day, field).eq(value)
+
+
+def extract_hour_equal(field: Term, value: int) -> Criterion:
+    return Extract(DatePart.hour, field).eq(value)
+
+
+def extract_minute_equal(field: Term, value: int) -> Criterion:
+    return Extract(DatePart.minute, field).eq(value)
+
+
+def extract_second_equal(field: Term, value: int) -> Criterion:
+    return Extract(DatePart.second, field).eq(value)
+
+
+def extract_microsecond_equal(field: Term, value: int) -> Criterion:
+    return Extract(DatePart.microsecond, field).eq(value)
 
 
 ##############################################################################
@@ -365,5 +404,50 @@ def get_filters_for_field(
             "source_field": source_field,
             "operator": insensitive_ends_with,
             "value_encoder": string_encoder,
+        },
+        f"{field_name}__year": {
+            "field": actual_field_name,
+            "source_field": source_field,
+            "operator": extract_year_equal,
+        },
+        f"{field_name}__quarter": {
+            "field": actual_field_name,
+            "source_field": source_field,
+            "operator": extract_quarter_equal,
+        },
+        f"{field_name}__month": {
+            "field": actual_field_name,
+            "source_field": source_field,
+            "operator": extract_month_equal,
+        },
+        f"{field_name}__week": {
+            "field": actual_field_name,
+            "source_field": source_field,
+            "operator": extract_week_equal,
+        },
+        f"{field_name}__day": {
+            "field": actual_field_name,
+            "source_field": source_field,
+            "operator": extract_day_equal,
+        },
+        f"{field_name}__hour": {
+            "field": actual_field_name,
+            "source_field": source_field,
+            "operator": extract_hour_equal,
+        },
+        f"{field_name}__minute": {
+            "field": actual_field_name,
+            "source_field": source_field,
+            "operator": extract_minute_equal,
+        },
+        f"{field_name}__second": {
+            "field": actual_field_name,
+            "source_field": source_field,
+            "operator": extract_second_equal,
+        },
+        f"{field_name}__microsecond": {
+            "field": actual_field_name,
+            "source_field": source_field,
+            "operator": extract_microsecond_equal,
         },
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add date part extract filtering.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Now can filter datetime or date field with `users = await User.filter(created_at__year=2021)`
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
add tests.
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

