### PR TITLE
Do not propagate default_factory to pydantic

### DIFF
--- a/tortoise/contrib/pydantic/creator.py
+++ b/tortoise/contrib/pydantic/creator.py
@@ -382,9 +382,8 @@ def pydantic_model_creator(
             description = comment or _br_it(fdesc.get("docstring") or fdesc["description"] or "")
             fconfig["description"] = description
             fconfig["title"] = fname.replace("_", " ").title()
-            if field_default is not None:
-                if not callable(field_default):
-                    properties[fname] = field_default
+            if field_default is not None and not callable(field_default):
+                properties[fname] = field_default
             pconfig.fields[fname] = fconfig
 
     # Here we endure that the name is unique, but complete objects are still labeled verbatim

--- a/tortoise/contrib/pydantic/creator.py
+++ b/tortoise/contrib/pydantic/creator.py
@@ -385,7 +385,6 @@ def pydantic_model_creator(
             if field_default is not None:
                 if callable(field_default):
                     fconfig["default_factory"] = field_default
-                    properties[fname] = None
                 else:
                     properties[fname] = field_default
             pconfig.fields[fname] = fconfig

--- a/tortoise/contrib/pydantic/creator.py
+++ b/tortoise/contrib/pydantic/creator.py
@@ -384,7 +384,7 @@ def pydantic_model_creator(
             fconfig["title"] = fname.replace("_", " ").title()
             if field_default is not None:
                 if callable(field_default):
-                    fconfig["default_factory"] = field_default
+                    properties[fname] = None
                 else:
                     properties[fname] = field_default
             pconfig.fields[fname] = fconfig

--- a/tortoise/contrib/pydantic/creator.py
+++ b/tortoise/contrib/pydantic/creator.py
@@ -383,9 +383,7 @@ def pydantic_model_creator(
             fconfig["description"] = description
             fconfig["title"] = fname.replace("_", " ").title()
             if field_default is not None:
-                if callable(field_default):
-                    properties[fname] = None
-                else:
+                if not callable(field_default):
                     properties[fname] = field_default
             pconfig.fields[fname] = fconfig
 


### PR DESCRIPTION
## Description
Pydantic never really allowed usage of `default` and `default_factory` at the same time, but in the latest release they added this validation https://github.com/samuelcolvin/pydantic/commit/b742c6f527f32fd0c6eb96f0a35f9e632a3af6bd#diff-bfaaac2ae0a71d9686a272982d29d0bed82bfaacf8b5b30e2b88ed2543e74a3bR124, that causes ValueError when we try to create a pydantic model for Tortoise Model with fields with callable default values. 

## Motivation and Context
This is a fix for my previous pull request https://github.com/tortoise/tortoise-orm/pull/480, I am not sure why with `default_factory` I've also added a `default`
```python
                if callable(field_default):
                    fconfig["default_factory"] = field_default
                    properties[fname] = None
```
May be because I was thinking of removing `default_factory`, because there was a chance of calling this factory function twice (once by pydantic, then by tortoise). So, I guess it would be better to remove `default_factory`, then there is also no need to keep `default` with `None` value. Also these fields will still be optional in json schema, so that end user that views this schema could understand that these fields are not required.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've run only simple test with `make test` on python3.7 (these changes do not depend on python version), test ran successfully:
```
950 passed, 15 skipped, 4 xfailed in 31.63s
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.