### PR TITLE
Do not pass `Null` value to `generated=True` fields

### DIFF
--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -663,7 +663,7 @@ class Model(metaclass=ModelMeta):
                 passed_fields.add(meta.fields_map[key].source_field)
             elif key in meta.fields_db_projection:
                 field_object = meta.fields_map[key]
-                if field_object.generated:
+                if field_object.pk and field_object.generated:
                     self._custom_generated_pk = True
                 if value is None and not field_object.null:
                     raise ValueError(f"{key} is non nullable field, but null was passed")


### PR DESCRIPTION
Fixes #644

## Description
Add check if the field is `pk`, so we don't set `self._custom_generated_pk=True` when there is actually no custom generated `pk`

## Motivation and Context
Described in #644.

## How Has This Been Tested?
Run existing tests, all passed.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

