### PR TITLE
Remove obsolete loop._selector

### DIFF
--- a/tortoise/contrib/test/__init__.py
+++ b/tortoise/contrib/test/__init__.py
@@ -43,7 +43,6 @@ On success it will be marked as unexpected success.
 
 _CONFIG: dict = {}
 _CONNECTIONS: dict = {}
-_SELECTOR = None
 _LOOP: AbstractEventLoop = None  # type: ignore
 _MODULES: List[str] = []
 _CONN_MAP: dict = {}
@@ -100,7 +99,6 @@ def initializer(
     # pylint: disable=W0603
     global _CONFIG
     global _CONNECTIONS
-    global _SELECTOR
     global _LOOP
     global _TORTOISE_TEST_DB
     global _MODULES
@@ -112,7 +110,6 @@ def initializer(
 
     loop = loop or asyncio.get_event_loop()
     _LOOP = loop
-    _SELECTOR = loop._selector  # type: ignore
     loop.run_until_complete(_init_db(_CONFIG))
     _CONNECTIONS = Tortoise._connections.copy()
     _CONN_MAP = current_transaction_map.copy()
@@ -127,7 +124,6 @@ def finalizer() -> None:
     """
     _restore_default()
     loop = _LOOP
-    loop._selector = _SELECTOR  # type: ignore
     loop.run_until_complete(Tortoise._drop_databases())
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove obsolete loop._selector from contrib/test

## Motivation and Context
The loop._selector was introduced in commit 40f4945 with the ability to provide loop to the initializer. At that point, the loop was BaseSelectorEventLoop, which has a private _selector property.

In 743795d the BaseSelectorEventLoop was replaced by AbstractEventLoop, but the _selector artefact remains.

The problem can be easily identified, when you use uvloop, which implements AbstractEventLoop and is not a SelectorEventLoop.

Resolves: #532
See also: #533

## How Has This Been Tested?
I've tested it manually with an uvloop.Loop and it seems to work properly.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

