### PR TITLE
Adjust M2M tables creation when using custom association class

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,10 @@ Changelog
 
 0.17
 ====
+0.17.3
+------
+- Fix duplicates when using custom through association class on M2M relations
+
 0.17.2
 ------
 - Add more `index` types.

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -45,6 +45,8 @@ Contributors
 * Eugene Dubovskoy ``@drjackild``
 * Lương Quang Mạnh ``@lqmanh``
 * Mykyta Holubakha ``@Hummer12007``
+* Tiago Barrionuevo ``@tiabogar``
+* Isaque Alves ``@isaquealves``
 
 Special Thanks
 ==============

--- a/tests/schema/models_no_auto_create_m2m.py
+++ b/tests/schema/models_no_auto_create_m2m.py
@@ -1,0 +1,61 @@
+"""
+This example demonstrates SQL Schema generation for each DB type supported.
+"""
+
+from tortoise import fields
+from tortoise.fields import SET_NULL
+from tortoise.models import Model
+
+
+class Tournament(Model):
+    tid = fields.SmallIntField(pk=True)
+    name = fields.CharField(max_length=100, description="Tournament name", index=True)
+    created = fields.DatetimeField(auto_now_add=True, description="Created */'`/* datetime")
+
+    class Meta:
+        table_description = "What Tournaments */'`/* we have"
+
+
+class Event(Model):
+    id = fields.BigIntField(pk=True, description="Event ID")
+    name = fields.TextField()
+    tournament = fields.ForeignKeyField(
+        "models.Tournament", related_name="events", description="FK to tournament"
+    )
+    participants = fields.ManyToManyField(
+        "models.Team",
+        related_name="events",
+        through="teamevents",
+        description="How participants relate",
+        on_delete=SET_NULL,
+    )
+    modified = fields.DatetimeField(auto_now=True)
+    prize = fields.DecimalField(max_digits=10, decimal_places=2, null=True)
+    token = fields.CharField(max_length=100, description="Unique token", unique=True)
+    key = fields.CharField(max_length=100)
+
+    class Meta:
+        table_description = "This table contains a list of all the events"
+        unique_together = [("name", "prize"), ["tournament", "key"]]
+
+
+class TeamEvent(Model):
+    team = fields.ForeignKeyField("models.Team", related_name="teams")
+    event = fields.ForeignKeyField("models.Event", related_name="events")
+    score = fields.IntField()
+
+    class Meta:
+        table = "teamevents"
+        table_description = "How participants relate"
+        unique_together = ("team", "event")
+
+
+class Team(Model):
+    name = fields.CharField(max_length=50, pk=True, description="The TEAM name (and PK)")
+    key = fields.IntField()
+    manager = fields.ForeignKeyField("models.Team", related_name="team_members", null=True)
+    talks_to = fields.ManyToManyField("models.Team", related_name="gets_talked_to")
+
+    class Meta:
+        table_description = "The TEAMS!"
+        indexes = [("manager", "key"), ["manager_id", "name"]]

--- a/tests/schema/test_generate_schema.py
+++ b/tests/schema/test_generate_schema.py
@@ -715,7 +715,7 @@ CREATE SPATIAL INDEX `idx_index_geometr_0b4dfb` ON `index` (`geometry`);""",
         sql = get_schema_sql(Tortoise.get_connection("default"), safe=False)
         self.assertEqual(
             sql.strip(),
-            """CREATE TABLE `team` (
+            r"""CREATE TABLE `team` (
     `name` VARCHAR(50) NOT NULL  PRIMARY KEY COMMENT 'The TEAM name (and PK)',
     `key` INT NOT NULL,
     `manager_id` VARCHAR(50),

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -154,7 +154,7 @@ class Tortoise:
                     model._meta.db_table = model.__name__.lower()
 
                 # TODO: refactor to share logic between FK & O2O
-                for field in model._meta.fk_fields:
+                for field in sorted(model._meta.fk_fields):
                     fk_object = cast(ForeignKeyFieldInstance, model._meta.fields_map[field])
                     reference = fk_object.model_name
                     related_app_name, related_model_name = split_reference(reference)

--- a/tortoise/backends/base/schema_generator.py
+++ b/tortoise/backends/base/schema_generator.py
@@ -182,7 +182,10 @@ class BaseSchemaGenerator:
         fields_with_index = []
         m2m_tables_for_create = []
         references = set()
+        models_to_create: "List[Type[Model]]" = []
 
+        self._get_models_to_create(models_to_create)
+        models_tables = [model._meta.db_table for model in models_to_create]
         for field_name, column_name in model._meta.fields_db_projection.items():
             field_object = model._meta.fields_map[field_name]
             comment = (
@@ -345,7 +348,7 @@ class BaseSchemaGenerator:
 
         for m2m_field in model._meta.m2m_fields:
             field_object = cast("ManyToManyFieldInstance", model._meta.fields_map[m2m_field])
-            if field_object._generated:
+            if field_object._generated or field_object.through in models_tables:
                 continue
             m2m_create_string = self.M2M_TABLE_TEMPLATE.format(
                 exists="IF NOT EXISTS " if safe else "",


### PR DESCRIPTION
Adjust creation of many to many relations when using a custom `through` association class.

## Description
Allow easy use of custom M2M classes handling additional attributes. This PR contains part of #454 but using an already updated code base, with appropriate tests and no conflicts.

## Motivation and Context
When using custom association classes to handle ManyToMany relations some duplicates on sql migration result were found , breaking things in some scenarios, like integration tests.  

Relates do PR #454
Fixes #438 
Fixes #574 

## How Has This Been Tested?

Tests were performed using tox under python-3.8 and python-3.9


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

