### PR TITLE
Add support for timezone-naive datetime fields

### DIFF
--- a/tortoise/fields/data.py
+++ b/tortoise/fields/data.py
@@ -284,9 +284,9 @@ class DatetimeField(Field, datetime.datetime):
     You can opt to set neither or only ONE of them.
 
     ``auto_now`` (bool):
-        Always set to ``datetime.utcnow()`` on save.
+        Always set to ``tortoise.timezone.now()`` on save.
     ``auto_now_add`` (bool):
-        Set to ``datetime.utcnow()`` on first save only.
+        Set to ``tortoise.timezone.now()`` on first save only.
     """
 
     SQL_TYPE = "TIMESTAMP"
@@ -295,7 +295,7 @@ class DatetimeField(Field, datetime.datetime):
         SQL_TYPE = "DATETIME(6)"
 
     class _db_postgres:
-        SQL_TYPE = "TIMESTAMPTZ"
+        SQL_TYPE = "TIMESTAMPTZ" if get_use_tz() else "TIMESTAMP"
 
     def __init__(self, auto_now: bool = False, auto_now_add: bool = False, **kwargs: Any) -> None:
         if auto_now_add and auto_now:

--- a/tortoise/fields/data.py
+++ b/tortoise/fields/data.py
@@ -14,7 +14,7 @@ from pypika.terms import Term
 from tortoise import timezone
 from tortoise.exceptions import ConfigurationError, FieldError
 from tortoise.fields.base import Field
-from tortoise.timezone import get_timezone, get_use_tz, localtime
+from tortoise.timezone import get_timezone, get_use_tz
 from tortoise.validators import MaxLengthValidator
 
 try:

--- a/tortoise/fields/data.py
+++ b/tortoise/fields/data.py
@@ -314,10 +314,8 @@ class DatetimeField(Field, datetime.datetime):
                 value = datetime.datetime.fromtimestamp(value)
             else:
                 value = parse_datetime(value)
-            if timezone.is_naive(value):
+            if get_use_tz():
                 value = timezone.make_aware(value, get_timezone())
-            else:
-                value = localtime(value)
         self.validate(value)
         return value
 

--- a/tortoise/timezone.py
+++ b/tortoise/timezone.py
@@ -24,9 +24,9 @@ def now() -> datetime:
     Return an aware datetime.datetime, depending on use_tz and timezone.
     """
     if get_use_tz():
-        return datetime.now(tz=pytz.utc)
+        return datetime.now(tz=get_default_timezone())
     else:
-        return datetime.now(get_default_timezone())
+        return datetime.utcnow()
 
 
 def get_default_timezone() -> tzinfo:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Supports timezone-naive datetime fields. 

This is a work in progress, hoping to get input from others on the best way to implement this.

The way I see it we can do a few things, not limited to this list:
* continue with the approach i've laid out here (`use_tz` tells the ORM whether to use tz aware timestamps or no)
* create a field on individual DateTime columns to change behavior for timezone aware/naive on individual objects

I don't see why both of these can't be implemented, but it'd be my priority to work on supporting option #1 here. 

## Motivation and Context
It's critical tortoise supports timestamp fields  that are timezone-naive. At the moment, _all_ DateTime fields use timezone-aware, with the default to be UTC timezone. Unfortunately, underlying database may already be using `timestamp without time zone` and as such, this completely breaks being able to use tables with timezone-naive timestamp fields.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I have not fixed tests or created ones specifically for timezone-naive datetimes. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

