### PR TITLE
Make `delete` query work with `limit` and `order_by`.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Changelog
 - Add more `index` types.
 - Add `force_index`, `use_index` to `queryset`.
 - Fix `F` in update error with `update_fields`.
+- Make `delete` query work with `limit` and `order_by`. (#697)
 
 0.17.1
 ------

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -230,6 +230,16 @@ class TestQueryset(test.TestCase):
         #     [10, 13, 16, 19, 22, 25, 28, 31, 34, 37]
         # )
 
+    async def test_delete_limit(self):
+        await IntFields.all().limit(1).delete()
+        self.assertEqual(await IntFields.all().count(), 29)
+
+    async def test_delete_limit_order_by(self):
+        await IntFields.all().limit(1).order_by("-id").delete()
+        self.assertEqual(await IntFields.all().count(), 29)
+        with self.assertRaises(DoesNotExist):
+            await IntFields.get(intnum=97)
+
     async def test_async_iter(self):
         counter = 0
         async for _ in IntFields.all():

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -230,10 +230,12 @@ class TestQueryset(test.TestCase):
         #     [10, 13, 16, 19, 22, 25, 28, 31, 34, 37]
         # )
 
+    @test.requireCapability(support_update_limit_order_by=True)
     async def test_delete_limit(self):
         await IntFields.all().limit(1).delete()
         self.assertEqual(await IntFields.all().count(), 29)
 
+    @test.requireCapability(support_update_limit_order_by=True)
     async def test_delete_limit_order_by(self):
         await IntFields.all().limit(1).order_by("-id").delete()
         self.assertEqual(await IntFields.all().count(), 29)

--- a/tortoise/backends/asyncpg/client.py
+++ b/tortoise/backends/asyncpg/client.py
@@ -49,7 +49,7 @@ class AsyncpgDBClient(BaseDBAsyncClient):
     query_class = PostgreSQLQuery
     executor_class = AsyncpgExecutor
     schema_generator = AsyncpgSchemaGenerator
-    capabilities = Capabilities("postgres")
+    capabilities = Capabilities("postgres", support_update_limit_order_by=False)
     connection_class = asyncpg.connection.Connection
     loop = None
 

--- a/tortoise/backends/asyncpg/schema_generator.py
+++ b/tortoise/backends/asyncpg/schema_generator.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:  # pragma: nocoverage
 class AsyncpgSchemaGenerator(BaseSchemaGenerator):
     DIALECT = "postgres"
     TABLE_COMMENT_TEMPLATE = "COMMENT ON TABLE \"{table}\" IS '{comment}';"
-    COLUMN_COMMNET_TEMPLATE = 'COMMENT ON COLUMN "{table}"."{column}" IS \'{comment}\';'
+    COLUMN_COMMENT_TEMPLATE = 'COMMENT ON COLUMN "{table}"."{column}" IS \'{comment}\';'
     GENERATED_PK_TEMPLATE = '"{field_name}" {generated_sql}'
 
     def __init__(self, client: "AsyncpgDBClient") -> None:
@@ -31,7 +31,7 @@ class AsyncpgSchemaGenerator(BaseSchemaGenerator):
         return ""
 
     def _column_comment_generator(self, table: str, column: str, comment: str) -> str:
-        comment = self.COLUMN_COMMNET_TEMPLATE.format(
+        comment = self.COLUMN_COMMENT_TEMPLATE.format(
             table=table, column=column, comment=self._escape_comment(comment)
         )
         if comment not in self.comments_array:

--- a/tortoise/backends/base/client.py
+++ b/tortoise/backends/base/client.py
@@ -28,6 +28,8 @@ class Capabilities:
         DDL statement, and not as a separate statement.
     :param supports_transactions: Indicates that this DB supports transactions.
     :param support_for_update: Indicates that this DB supports SELECT ... FOR UPDATE SQL statement.
+    :param support_index_hint: Support force index or use index.
+    :param support_update_limit_order_by: support update/delete with limit and order by.
     """
 
     def __init__(

--- a/tortoise/backends/base/client.py
+++ b/tortoise/backends/base/client.py
@@ -43,6 +43,8 @@ class Capabilities:
         support_for_update: bool = True,
         # Support force index or use index?
         support_index_hint: bool = False,
+        # support update/delete with limit and order by
+        support_update_limit_order_by: bool = True,
     ) -> None:
         super().__setattr__("_mutable", True)
 
@@ -53,6 +55,7 @@ class Capabilities:
         self.supports_transactions = supports_transactions
         self.support_for_update = support_for_update
         self.support_index_hint = support_index_hint
+        self.support_update_limit_order_by = support_update_limit_order_by
         super().__setattr__("_mutable", False)
 
     def __setattr__(self, attr: str, value: Any) -> None:

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -570,6 +570,8 @@ class QuerySet(AwaitableQuery[MODEL]):
             q_objects=self._q_objects,
             annotations=self._annotations,
             custom_filters=self._custom_filters,
+            limit=self._limit,
+            orderings=self._orderings,
         )
 
     def update(self, **kwargs: Any) -> "UpdateQuery":
@@ -952,7 +954,7 @@ class UpdateQuery(AwaitableQuery):
 
 
 class DeleteQuery(AwaitableQuery):
-    __slots__ = ("q_objects", "annotations", "custom_filters")
+    __slots__ = ("q_objects", "annotations", "custom_filters", "orderings", "limit")
 
     def __init__(
         self,
@@ -961,15 +963,22 @@ class DeleteQuery(AwaitableQuery):
         q_objects: List[Q],
         annotations: Dict[str, Any],
         custom_filters: Dict[str, Dict[str, Any]],
+        limit: Optional[int],
+        orderings: List[Tuple[str, str]],
     ) -> None:
         super().__init__(model)
         self.q_objects = q_objects
         self.annotations = annotations
         self.custom_filters = custom_filters
         self._db = db
+        self.limit = limit
+        self.orderings = orderings
 
     def _make_query(self) -> None:
         self.query = copy(self.model._meta.basequery)
+        self.resolve_ordering(
+            self.model, self.model._meta.basetable, self.orderings, self.annotations
+        )
         self.resolve_filters(
             model=self.model,
             q_objects=self.q_objects,
@@ -977,6 +986,8 @@ class DeleteQuery(AwaitableQuery):
             custom_filters=self.custom_filters,
         )
         self.query._delete_from = True
+        if self.limit:
+            self.query._limit = self.limit
 
     def __await__(self) -> Generator[Any, None, int]:
         if self._db is None:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Make `delete` query work with `limit` and `order_by`. (#697)
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix https://github.com/tortoise/tortoise-orm/issues/697
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
add tests
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

