### PR TITLE
Add new backward FK filters for `IS NULL` and `NOT IS NULL`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Changelog
 - Add `force_index`, `use_index` to `queryset`.
 - Fix `F` in update error with `update_fields`.
 - Make `delete` query work with `limit` and `order_by`. (#697)
+- Filter backward FK fields with `IS NULL` and `NOT IS NULL` filters (#700)
 
 0.17.1
 ------

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,6 +1,6 @@
 from decimal import Decimal
 
-from tests.testmodels import BooleanFields, CharFields, DecimalFields
+from tests.testmodels import BooleanFields, CharFields, DecimalFields, CharPkModel, CharFkRelatedModel
 from tortoise.contrib import test
 from tortoise.exceptions import FieldError
 
@@ -239,4 +239,111 @@ class TestDecimalFieldFilters(test.TestCase):
                 decimal__range=(Decimal("1.2344"), Decimal("1.2346"))
             ).values_list("decimal", flat=True),
             [Decimal("1.2345")],
+        )
+
+
+class TestCharFkFieldFilters(test.TestCase):
+    async def setUp(self):
+        model1 = await CharPkModel.create(id=17)
+        model2 = await CharPkModel.create(id=12)
+        await CharPkModel.create(id=2001)
+        await CharFkRelatedModel.create(model=model1)
+        await CharFkRelatedModel.create(model=model1)
+        await CharFkRelatedModel.create(model=model2)
+
+    async def test_bad_param(self):
+        with self.assertRaisesRegex(
+            FieldError, "Unknown filter param 'bad_param'. Allowed base values are"
+        ):
+            await CharPkModel.filter(bad_param="moo")
+
+    async def test_equal(self):
+        self.assertEqual(
+            set(await CharPkModel.filter(id=2001).values_list("id", flat=True)), {"2001"}
+        )
+
+    async def test_not(self):
+        self.assertEqual(
+            set(await CharPkModel.filter(id__not=2001).values_list("id", flat=True)),
+            {"17", "12"},
+        )
+
+    async def test_in(self):
+        self.assertSetEqual(
+            set(await CharPkModel.filter(id__in=[17, 12]).values_list("id", flat=True)),
+            {"17", "12"},
+        )
+
+    async def test_in_empty(self):
+        self.assertEqual(
+            await CharPkModel.filter(id__in=[]).values_list("id", flat=True),
+            [],
+        )
+
+    async def test_not_in(self):
+        self.assertSetEqual(
+            set(
+                await CharPkModel.filter(id__not_in=[17, 12]).values_list("id", flat=True)
+            ),
+            {"2001"},
+        )
+
+    async def test_not_in_empty(self):
+        self.assertSetEqual(
+            set(await CharPkModel.filter(id__not_in=[]).values_list("id", flat=True)),
+            {"17", "12", "2001"},
+        )
+
+    async def test_isnull(self):
+        self.assertSetEqual(
+            set(await CharPkModel.filter(children__isnull=True).values_list("id", flat=True)),
+            {"2001"},
+        )
+        self.assertSetEqual(
+            set(await CharPkModel.filter(children__isnull=False).values_list("id", flat=True)),
+            {"17", "17", "12"},  # TODO: [4/7/2021 by Mykola] Not sure if this is an expected behavior
+        )
+
+    async def test_not_isnull(self):
+        self.assertSetEqual(
+            set(await CharPkModel.filter(children__not_isnull=True).values_list("id", flat=True)),
+            {"17", "17", "12"},
+        )
+        self.assertSetEqual(
+            set(
+                await CharPkModel.filter(children__not_isnull=False).values_list("id", flat=True)
+            ),
+            {"2001"},
+        )
+
+    async def test_gte(self):
+        self.assertSetEqual(
+            set(await CharPkModel.filter(id__gte=17).values_list("id", flat=True)),
+            {"17", "2001"},
+        )
+
+    async def test_lte(self):
+        self.assertSetEqual(
+            set(await CharPkModel.filter(id__lte=17).values_list("id", flat=True)),
+            {"12", "17"},
+        )
+
+    async def test_gt(self):
+        self.assertSetEqual(
+            set(await CharPkModel.filter(id__gt=17).values_list("id", flat=True)), {"2001"}
+        )
+
+    async def test_lt(self):
+        self.assertSetEqual(
+            set(await CharPkModel.filter(id__lt=17).values_list("id", flat=True)), {"12"}
+        )
+
+    async def test_sorting(self):
+        self.assertEqual(
+            await CharPkModel.all().order_by("id").values_list("id", flat=True),
+            ["12", "17", "2001"],
+        )
+        self.assertEqual(
+            await CharPkModel.all().order_by("-id").values_list("id", flat=True),
+            ["2001", "17", "12"],
         )

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,6 +1,12 @@
 from decimal import Decimal
 
-from tests.testmodels import BooleanFields, CharFields, DecimalFields, CharPkModel, CharFkRelatedModel
+from tests.testmodels import (
+    BooleanFields,
+    CharFields,
+    DecimalFields,
+    CharPkModel,
+    CharFkRelatedModel,
+)
 from tortoise.contrib import test
 from tortoise.exceptions import FieldError
 
@@ -282,9 +288,7 @@ class TestCharFkFieldFilters(test.TestCase):
 
     async def test_not_in(self):
         self.assertSetEqual(
-            set(
-                await CharPkModel.filter(id__not_in=[17, 12]).values_list("id", flat=True)
-            ),
+            set(await CharPkModel.filter(id__not_in=[17, 12]).values_list("id", flat=True)),
             {"2001"},
         )
 
@@ -301,7 +305,11 @@ class TestCharFkFieldFilters(test.TestCase):
         )
         self.assertSetEqual(
             set(await CharPkModel.filter(children__isnull=False).values_list("id", flat=True)),
-            {"17", "17", "12"},  # TODO: [4/7/2021 by Mykola] Not sure if this is an expected behavior
+            {
+                "17",
+                "17",
+                "12",
+            },  # TODO: [4/7/2021 by Mykola] Not sure if this is an expected behavior
         )
 
     async def test_not_isnull(self):
@@ -310,9 +318,7 @@ class TestCharFkFieldFilters(test.TestCase):
             {"17", "17", "12"},
         )
         self.assertSetEqual(
-            set(
-                await CharPkModel.filter(children__not_isnull=False).values_list("id", flat=True)
-            ),
+            set(await CharPkModel.filter(children__not_isnull=False).values_list("id", flat=True)),
             {"2001"},
         )
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -3,9 +3,9 @@ from decimal import Decimal
 from tests.testmodels import (
     BooleanFields,
     CharFields,
-    DecimalFields,
-    CharPkModel,
     CharFkRelatedModel,
+    CharPkModel,
+    DecimalFields,
 )
 from tortoise.contrib import test
 from tortoise.exceptions import FieldError

--- a/tortoise/filters.py
+++ b/tortoise/filters.py
@@ -289,6 +289,20 @@ def get_backward_fk_filters(field_name: str, field: BackwardFKRelation) -> Dict[
             "table": Table(field.related_model._meta.db_table),
             "value_encoder": partial(related_list_encoder, field=target_table_pk),
         },
+        f"{field_name}__isnull": {
+            "field": field.related_model._meta.pk_attr,
+            "backward_key": field.relation_field,
+            "operator": is_null,
+            "table": Table(field.related_model._meta.db_table),
+            "value_encoder": target_table_pk.to_db_value,  # not sure if this key is needed
+        },
+        f"{field_name}__not_isnull": {
+            "field": field.related_model._meta.pk_attr,
+            "backward_key": field.relation_field,
+            "operator": not_null,
+            "table": Table(field.related_model._meta.db_table),
+            "value_encoder": target_table_pk.to_db_value,  # not sure if this key is needed
+        }
     }
 
 

--- a/tortoise/filters.py
+++ b/tortoise/filters.py
@@ -294,15 +294,13 @@ def get_backward_fk_filters(field_name: str, field: BackwardFKRelation) -> Dict[
             "backward_key": field.relation_field,
             "operator": is_null,
             "table": Table(field.related_model._meta.db_table),
-            "value_encoder": target_table_pk.to_db_value,  # not sure if this key is needed
         },
         f"{field_name}__not_isnull": {
             "field": field.related_model._meta.pk_attr,
             "backward_key": field.relation_field,
             "operator": not_null,
             "table": Table(field.related_model._meta.db_table),
-            "value_encoder": target_table_pk.to_db_value,  # not sure if this key is needed
-        }
+        },
     }
 
 

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -663,7 +663,7 @@ class Model(metaclass=ModelMeta):
                 passed_fields.add(meta.fields_map[key].source_field)
             elif key in meta.fields_db_projection:
                 field_object = meta.fields_map[key]
-                if field_object.generated:
+                if field_object.pk and field_object.generated:
                     self._custom_generated_pk = True
                 if value is None and not field_object.null:
                     raise ValueError(f"{key} is non nullable field, but null was passed")


### PR DESCRIPTION
This PR adds a new type of filters for FK fields: `IS NULL` and `NOT IS NULL`

## Description
I've just wanted to add filters to be able to use something like
```python
await Model.filter(fk_field__isnull=True)
```
and I've copied them from regular field filters

## Motivation and Context
You can now filter rows that have no backward-FK-related rows in DB. Works really nice with Postgres, haven't tested with other types of DB.
It creates SQL like this
```SQL
SELECT "monobankaccount"."date_updated",
       "monobankaccount"."balance"
FROM "monobankaccount"
         LEFT OUTER JOIN "monobankclient" "monobankaccount__monobank_client"
                         ON "monobankaccount__monobank_client"."id" = "monobankaccount"."monobank_client_id"
         LEFT OUTER JOIN "monobankcard" ON "monobankaccount"."id" = "monobankcard"."monobank_account_id"
WHERE "monobankaccount__monobank_client"."user_id" = 1
  AND "monobankcard"."id" IS NULL
```

## How Has This Been Tested?
I've run the tests inside `tests/` dir and only 3 failed (they failed even before the changes made).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

P.S. There are 2 other commits that I didn't want to include in this PR, but I don't know how to get rid of them. Please let me know if you have a solution.
