### PR TITLE
Unpin pytz version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ python = "^3.7"
 pypika-tortoise = "^0.1.0"
 iso8601 = "^0.1.13"
 aiosqlite = "^0.16.0"
-pytz = "^2020.4"
+pytz = "*"
 ciso8601 = { version = "^2.1.2", markers = "sys_platform != 'win32' and implementation_name == 'cpython'", optional = true }
 uvloop = { version = "^0.14.0", markers = "sys_platform != 'win32' and implementation_name == 'cpython'", optional = true }
 python-rapidjson = { version = "*", optional = true }


### PR DESCRIPTION
## Description
pytz uses year-based versioning, not SemVer, so keeping the version pinned doesn't protect against breaking changes, and does mean the current timezone data is outdated.

## Motivation and Context
pytz 2021.1 is out now, and Tortoise is considered incompatible with it.

## How Has This Been Tested?
Force-installed pytz 2021.1 in my project and made sure it still works.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

