### PR TITLE
Clarify benchmark and fix spelling in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,13 +22,13 @@ Introduction
 
 Tortoise ORM is an easy-to-use ``asyncio`` ORM *(Object Relational Mapper)* inspired by Django.
 
-Tortoise ORM was build with relations in mind and admiration for the excellent and popular Django ORM.
-It's engraved in it's design that you are working not with just tables, you work with relational data.
+Tortoise ORM was built with relations in mind and admiration for the excellent and popular Django ORM.
+It's engraved in its design that you are working not with just tables, you work with relational data.
 
-You can find docs at `ReadTheDocs <http://tortoise-orm.readthedocs.io/en/latest/>`_
+You can find the docs at `ReadTheDocs <http://tortoise-orm.readthedocs.io/en/latest/>`_
 
 .. note::
-   Tortoise ORM is young project and breaking changes are to be expected.
+   Tortoise ORM is a young project and breaking changes are to be expected.
    We keep a `Changelog <http://tortoise-orm.readthedocs.io/en/latest/CHANGELOG.html>`_ and it will have possible breakage clearly documented.
 
 Tortoise ORM is supported on CPython >= 3.7 for SQLite, MySQL and PostgreSQL.
@@ -39,13 +39,13 @@ Why was Tortoise ORM built?
 Python has many existing and mature ORMs, unfortunately they are designed with an opposing paradigm of how I/O gets processed.
 ``asyncio`` is relatively new technology that has a very different concurrency model, and the largest change is regarding how I/O is handled.
 
-However, Tortoise ORM is not first attempt of building ``asyncio`` ORM, there are many cases of developers attempting to map synchronous python ORMs to the async world, initial attempts did not have a clean API.
+However, Tortoise ORM is not the first attempt of building an ``asyncio`` ORM. While there are many cases of developers attempting to map synchronous Python ORMs to the async world, initial attempts did not have a clean API.
 
 Hence we started Tortoise ORM.
 
 Tortoise ORM is designed to be functional, yet familiar, to ease the migration of developers wishing to switch to ``asyncio``.
 
-It also performs well when compared to other Python ORMs, trading places with Pony ORM:
+It also performs well when compared to other Python ORMs. In `our benchmarks <https://github.com/tortoise/orm-benchmarks>`_, where we measure different read and write operations (rows/sec, more is better), it's trading places with Pony ORM:
 
 .. image:: https://raw.githubusercontent.com/tortoise/tortoise-orm/develop/docs/ORM_Perf.png
     :target: https://github.com/tortoise/orm-benchmarks
@@ -53,19 +53,19 @@ It also performs well when compared to other Python ORMs, trading places with Po
 How is an ORM useful?
 ---------------------
 
-When you build an application or service that uses a relational database, there is a point when you can't just get away with just using parameterized queries or even query builder, you just keep repeating yourself, writing slightly different code for each entity.
+When you build an application or service that uses a relational database, there is a point where you can't get away with just using parameterized queries or even query builder. You just keep repeating yourself, writing slightly different code for each entity.
 Code has no idea about relations between data, so you end up concatenating your data almost manually.
-It is also easy to make a mistake in how you access your database, making it easy for SQL-injection attacks to occur.
-Your data rules are also distributed, increasing the complexity of managing your data, and even worse, is applied inconsistently.
+It is also easy to make mistakes in how you access your database, which can be exploited by SQL-injection attacks.
+Your data rules are also distributed, increasing the complexity of managing your data, and even worse, could lead to those rules being applied inconsistently.
 
-An ORM (Object Relational Mapper) is designed to address these issues, by centralising your data model and data rules, ensuring that your data is managed safely (providing immunity to SQL-injection) and keeps track of relationships so you don't have to.
+An ORM (Object Relational Mapper) is designed to address these issues, by centralising your data model and data rules, ensuring that your data is managed safely (providing immunity to SQL-injection) and keeping track of relationships so you don't have to.
 
 Getting Started
 ===============
 
 Installation
 ------------
-First you have to install tortoise like this:
+First you have to install Tortoise ORM like this:
 
 .. code-block:: bash
 
@@ -93,7 +93,7 @@ Or another asyncio MySQL driver `asyncmy <https://github.com/long2ice/asyncmy>`_
 Quick Tutorial
 --------------
 
-Primary entity of tortoise is ``tortoise.models.Model``.
+The primary entity of tortoise is ``tortoise.models.Model``.
 You can start writing models like this:
 
 
@@ -128,7 +128,7 @@ You can start writing models like this:
             return self.name
 
 
-After you defined all your models, tortoise needs you to init them, in order to create backward relations between models and match your db client with appropriate models.
+After you defined all your models, tortoise needs you to init them, in order to create backward relations between models and match your db client with the appropriate models.
 
 You can do it like this:
 
@@ -148,7 +148,7 @@ You can do it like this:
         await Tortoise.generate_schemas()
 
 
-Here we create connection to SQLite database in the local directory called ``db.sqlite3``, and then we discover & initialise models.
+Here we create a connection to an SQLite database in the local directory called ``db.sqlite3``. Then we discover and initialise the models.
 
 Tortoise ORM currently supports the following databases:
 
@@ -180,24 +180,24 @@ After that you can start using your models:
     # (also look for methods .remove(...) and .clear())
     await event.participants.add(*participants)
     
-    # You can query related entity just with async for
+    # You can query a related entity with async for
     async for team in event.participants:
         pass
     
-    # After making related query you can iterate with regular for,
-    # which can be extremely convenient for using with other packages,
+    # After making a related query you can iterate with regular for,
+    # which can be extremely convenient when using it with other packages,
     # for example some kind of serializers with nested support
     for team in event.participants:
         pass
 
 
-    # Or you can make preemptive call to fetch related objects
+    # Or you can make a preemptive call to fetch related objects
     selected_events = await Event.filter(
         participants=participants[0].id
     ).prefetch_related('participants', 'tournament')
     
     # Tortoise supports variable depth of prefetching related entities
-    # This will fetch all events for team and in those events tournaments will be prefetched
+    # This will fetch all events for Team and in those events tournaments will be prefetched
     await Team.all().prefetch_related('events__tournament')
     
     # You can filter and order by related models too
@@ -208,15 +208,15 @@ After that you can start using your models:
 Migration
 =========
 
-Tortoise ORM use `Aerich <https://github.com/tortoise/aerich>`_ as database migrations tool, see more detail at it's `docs <https://github.com/tortoise/aerich>`_.
+Tortoise ORM uses `Aerich <https://github.com/tortoise/aerich>`_ as its database migration tool, see more detail at its `docs <https://github.com/tortoise/aerich>`_.
 
 Contributing
 ============
 
-Please have a look at the `Contribution Guide <docs/CONTRIBUTING.rst>`_
+Please have a look at the `Contribution Guide <docs/CONTRIBUTING.rst>`_.
 
 
 License
 =======
 
-This project is licensed under the Apache License - see the `LICENSE.txt <LICENSE.txt>`_ file for details
+This project is licensed under the Apache License - see the `LICENSE.txt <LICENSE.txt>`_ file for details.


### PR DESCRIPTION

## Description
Clarify the benchmarks and fix a couple of spelling mistakes in the readme:
```
It also performs well when compared to other Python ORMs, trading places with Pony ORM:
---- to ----
It also performs well when compared to other Python ORMs.
In our benchmarks, where we measure different read and write operations (rows/sec, more is better),
it's trading places with Pony ORM:
```

## Motivation and Context
The benchmarks in the README are a great visual aid, but I misunderstood them, when I saw them the first time. I first thought that more is worse (taking more time) when actually, more is better (more rows/sec). Silly me.

While I was at it, I also fixed a few obvious spelling mistakes.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

