### PR TITLE
Fix typos in docs (foreign keys)

### DIFF
--- a/docs/models.rst
+++ b/docs/models.rst
@@ -288,7 +288,7 @@ or by directly accessing the DB-backing field:
     somemodel.tournament_id=the_tournament.pk
 
 
-Querying a relationship is typicall done by appending a double underscore, and then the foreign object's field. Then a normal query attr can be appended.
+Querying a relationship is typically done by appending a double underscore, and then the foreign object's field. Then a normal query attr can be appended.
 This can be chained if the next key is also a foreign object:
 
     :samp:`{FKNAME}__{FOREIGNFIELD}__gt=3`
@@ -297,9 +297,9 @@ This can be chained if the next key is also a foreign object:
 
     :samp:`{FKNAME}__{FOREIGNFK}__{VERYFOREIGNFIELD}__gt=3`
 
-There is however one major limiatation. We don't want to restrict foreign column names, or have ambiguity (e.g. a foreign object may have a field called ``isnull``)
+There is however one major limitation. We don't want to restrict foreign column names, or have ambiguity (e.g. a foreign object may have a field called ``isnull``)
 
-Then this would be entierly ambugious:
+Then this would be entirely ambigous:
 
     :samp:`{FKNAME}__isnull`
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I was scrolling through the docs, And found some typos in the Foreign Key section (models.rst)

Changed 
- `typicall` to `typically`
- `limiatation` to `limitation`
- `entierly ambugious` to `entirely ambigous`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Just wanted to help :)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This is a documentation change so it shouldn't be a breaking change.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.

