### PR TITLE
Fix broken Pepy link in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Tortoise ORM
 .. image:: https://readthedocs.org/projects/tortoise-orm/badge/?version=latest
    :target: http://tortoise-orm.readthedocs.io/en/latest/
 .. image:: https://pepy.tech/badge/tortoise-orm/month
-   :target: https://pepy.tech/project/tortoise-orm/month
+   :target: https://pepy.tech/project/tortoise-orm
 .. image:: https://github.com/tortoise/tortoise-orm/workflows/ci/badge.svg
    :target: https://github.com/tortoise/tortoise-orm/actions?query=workflow:ci
 .. image:: https://coveralls.io/repos/github/tortoise/tortoise-orm/badge.svg
@@ -101,11 +101,11 @@ You can start writing models like this:
 
     from tortoise.models import Model
     from tortoise import fields
-    
+
     class Tournament(Model):
         id = fields.IntField(pk=True)
         name = fields.TextField()
-    
+
         def __str__(self):
             return self.name
 
@@ -115,7 +115,7 @@ You can start writing models like this:
         name = fields.TextField()
         tournament = fields.ForeignKeyField('models.Tournament', related_name='events')
         participants = fields.ManyToManyField('models.Team', related_name='events', through='event_team')
-    
+
         def __str__(self):
             return self.name
 
@@ -123,7 +123,7 @@ You can start writing models like this:
     class Team(Model):
         id = fields.IntField(pk=True)
         name = fields.TextField()
-    
+
         def __str__(self):
             return self.name
 
@@ -167,7 +167,7 @@ After that you can start using your models:
     # Create instance by save
     tournament = Tournament(name='New Tournament')
     await tournament.save()
-    
+
     # Or by .create()
     await Event.create(name='Without participants', tournament=tournament)
     event = await Event.create(name='Test', tournament=tournament)
@@ -175,15 +175,15 @@ After that you can start using your models:
     for i in range(2):
         team = await Team.create(name='Team {}'.format(i + 1))
         participants.append(team)
-    
+
     # M2M Relationship management is quite straightforward
     # (also look for methods .remove(...) and .clear())
     await event.participants.add(*participants)
-    
+
     # You can query a related entity with async for
     async for team in event.participants:
         pass
-    
+
     # After making a related query you can iterate with regular for,
     # which can be extremely convenient when using it with other packages,
     # for example some kind of serializers with nested support
@@ -195,11 +195,11 @@ After that you can start using your models:
     selected_events = await Event.filter(
         participants=participants[0].id
     ).prefetch_related('participants', 'tournament')
-    
+
     # Tortoise supports variable depth of prefetching related entities
     # This will fetch all events for Team and in those events tournaments will be prefetched
     await Team.all().prefetch_related('events__tournament')
-    
+
     # You can filter and order by related models too
     await Tournament.filter(
         events__name__in=['Test', 'Prod']


### PR DESCRIPTION
This PR tries to fix broken Pepy link in README.rst, also removes some redundant indentations.