### PR TITLE
when USE_TZ=False, datetimes must be timezone naive

### DIFF
--- a/tortoise/backends/sqlite/executor.py
+++ b/tortoise/backends/sqlite/executor.py
@@ -43,10 +43,7 @@ def to_db_datetime(
         self.auto_now
         or (self.auto_now_add and getattr(instance, self.model_field_name, None) is None)
     ):
-        if timezone.get_use_tz():
-            value = datetime.datetime.now(tz=pytz.utc)
-        else:
-            value = datetime.datetime.now(tz=timezone.get_default_timezone())
+        value = timezone.now()
         setattr(instance, self.model_field_name, value)
         return value.isoformat(" ")
     if isinstance(value, datetime.datetime):

--- a/tortoise/exceptions.py
+++ b/tortoise/exceptions.py
@@ -75,3 +75,9 @@ class ValidationError(BaseORMException):
     """
     The ValidationError is raised when validators of field validate failed.
     """
+
+class TimezoneError(BaseORMException):
+    """
+    The TimezoneError is raised when a timezone-naive datetime is used with timezone support enabled
+    or when a timezone-aware datetime is used with timezone support disabled
+    """

--- a/tortoise/timezone.py
+++ b/tortoise/timezone.py
@@ -5,7 +5,7 @@ from typing import Optional
 import pytz
 
 
-def get_use_tz() -> bool:
+def should_use_tz() -> bool:
     """
     Get use_tz from env set in Tortoise config.
     """
@@ -23,10 +23,10 @@ def now() -> datetime:
     """
     Return an aware datetime.datetime, depending on use_tz and timezone.
     """
-    if get_use_tz():
-        return datetime.now(tz=pytz.utc)
-    else:
+    if should_use_tz():
         return datetime.now(get_default_timezone())
+    else:
+        return datetime.utcnow()
 
 
 def get_default_timezone() -> tzinfo:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This changes the USE_TZ setting to  control whether Tortoise is dealing with timezone aware or timezone naive datetimes. 
When USE_TZ=False, all datetimes should be timezone naive.
When USE_TZ=True, all datetimes should be timezone aware, with the timezone being specified by the TIMEZONE setting. 

## Motivation and Context
Currently, USE_TZ is a misnomer. It suggests you can either use TZ aware datetimes, or you can use TZ naive datetimes. It's implementation does something different - all datetimes are aware, but in USE_TZ=False they are UTC. 

This makes the USE_TZ setting useless, as `USE_TZ=False` == `USE_TZ=True, TIMEZONE=UTC`.
https://github.com/tortoise/tortoise-orm/issues/631

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

