### PR TITLE
Include annotations length in select columns count to fix IndexError

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Changelog
 0.17.6
 ------
 - Add `RawSQL` expression.
+- Fix columns count with annotations in `_make_query`
 
 0.17.5
 ------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ Changelog
 0.17.6
 ------
 - Add `RawSQL` expression.
-- Fix columns count with annotations in `_make_query`
+- Fix columns count with annotations in `_make_query`. (#776)
 
 0.17.5
 ------

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -833,7 +833,12 @@ class QuerySet(AwaitableQuery[MODEL]):
             self.query = copy(self.model._meta.basequery).select(*db_fields_for_select)
         else:
             self.query = copy(self.model._meta.basequery_all_fields)
-            append_item = (self.model, len(self.model._meta.db_fields) + len(self._annotations), table, self.model)
+            append_item = (
+                self.model,
+                len(self.model._meta.db_fields) + len(self._annotations),
+                table,
+                self.model,
+            )
             if append_item not in self._select_related_idx:
                 self._select_related_idx.append(append_item)
         self.resolve_ordering(

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -833,7 +833,7 @@ class QuerySet(AwaitableQuery[MODEL]):
             self.query = copy(self.model._meta.basequery).select(*db_fields_for_select)
         else:
             self.query = copy(self.model._meta.basequery_all_fields)
-            append_item = (self.model, len(self.model._meta.db_fields), table, self.model)
+            append_item = (self.model, len(self.model._meta.db_fields) + len(self._annotations), table, self.model)
             if append_item not in self._select_related_idx:
                 self._select_related_idx.append(append_item)
         self.resolve_ordering(


### PR DESCRIPTION
## Description
Currently when we try to use annotate and select_related in one query, there will be an error
```
    lambda x: x.split(".")[1],
IndexError: list index out of range
```
It happens, because when we calculate columns to be selected from a model we include only number of columns that are presented in the model https://github.com/tortoise/tortoise-orm/blob/develop/tortoise/queryset.py#L836. When we use `select_related`, in executor we try to map columns by their indexes from `select_related_idx ` https://github.com/tortoise/tortoise-orm/blob/develop/tortoise/backends/base/executor.py#L137 . So, because we don't include number of annotation columns in our calculation, we get an error, because executor tries to fetch annotation column and split it by `.`, expecting a column from the related model.
Also I've added a test for this issue, without my fix this test would fail.

## Motivation and Context
This is a fix for this issue https://github.com/tortoise/tortoise-orm/issues/776

## How Has This Been Tested?
I've run `make test`, there are 4 failed tests
```
4 failed, 975 passed, 25 skipped, 4 xfailed in 27.72s
```
But they failed even without my changes.
Also I've run `test_mysql`, it completed successfully:
```
985 passed, 20 skipped, 3 xfailed, 1 warning in 42.44s
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

