### PR TITLE
fix bug with select_related not yielding null #up

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Changelog
 - Fix columns count with annotations in `_make_query`. (#776)
 - Make functions nested. (#828)
 - Add `db_constraint` in field describe.
+- Fix `select_related` behaviour for forward relation. (#825)
 
 0.17.5
 ------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,13 +9,16 @@ Changelog
 
 0.17
 ====
+0.17.7
+------
+- Fix `select_related` behaviour for forward relation. (#825)
+
 0.17.6
 ------
 - Add `RawSQL` expression.
 - Fix columns count with annotations in `_make_query`. (#776)
 - Make functions nested. (#828)
 - Add `db_constraint` in field describe.
-- Fix `select_related` behaviour for forward relation. (#825)
 
 0.17.5
 ------

--- a/tests/testmodels.py
+++ b/tests/testmodels.py
@@ -305,6 +305,7 @@ class NoID(Model):
 
 
 class UniqueName(Model):
+    id = fields.IntField(pk=True)
     name = fields.CharField(max_length=20, null=True, unique=True)
 
 
@@ -743,3 +744,32 @@ class ManagerModel(Model):
 
     class Meta:
         manager = StatusManager()
+
+
+class Extra(Model):
+    """Dumb model, has no fk.
+    src: https://github.com/tortoise/tortoise-orm/pull/826#issuecomment-883341557
+    """
+
+    id = fields.IntField(pk=True)
+    # currently, tortoise don't save models with single pk field for some reason \_0_/
+    some_name = fields.CharField(default=lambda: str(uuid.uuid4()), max_length=64)
+
+
+class Single(Model):
+    """Dumb model, having single fk
+    src: https://github.com/tortoise/tortoise-orm/pull/826#issuecomment-883341557
+    """
+
+    id = fields.IntField(pk=True)
+    extra = fields.ForeignKeyField("models.Extra", related_name="singles", null=True)
+
+
+class Pair(Model):
+    """Dumb model, having double fk
+    src: https://github.com/tortoise/tortoise-orm/pull/826#issuecomment-883341557
+    """
+
+    id = fields.IntField(pk=True)
+    left = fields.ForeignKeyField("models.Single", related_name="lefts", null=True)
+    right = fields.ForeignKeyField("models.Single", related_name="rights", null=True)


### PR DESCRIPTION
Fixed (a bug ???) when select_related yielded unfilled instances of related objects instead of just nulls.
## Description
Ran into this unexpected behaviour with something like this:
```
class B(Model):
      id = fields.UUIDField(pk=True)
class A(Model):
    the_b = fields.OneToOneField(
        "models.B", related_name="the_a", on_delete=fields.SET_NULL, null=True
    )
```
then i got it like:
```
a1 = await A.create(the_b=await B.create())
a2 = await A.create(the_b=None)
a = A.all().select_related('the_b').get(id=a2.id)
# and for some reason the next checks failed
assert a.the_b is None
assert a.the_b == a2.the_b
```
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Looks like this packages follows the ideas of django-orm and duplicates its best features in most cases, so i thought, like at least select_related behaviour should be same as it in django-orm. 
linked to this issue https://github.com/tortoise/tortoise-orm/issues/825.
## How Has This Been Tested?
tested this with code like the one above. + as import dep in my pet proj, just assured that it don't gives me issues anymore.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

