### PR TITLE
WIP: Add value type hints to built-in fields

### DIFF
--- a/tortoise/fields/base.py
+++ b/tortoise/fields/base.py
@@ -1,5 +1,18 @@
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Type, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Generic,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    overload,
+)
 
 from pypika.terms import Term
 
@@ -8,6 +21,8 @@ from tortoise.validators import Validator
 
 if TYPE_CHECKING:  # pragma: nocoverage
     from tortoise.models import Model
+
+VALUE = TypeVar("VALUE")
 
 # TODO: Replace this with an enum
 CASCADE = "CASCADE"
@@ -28,7 +43,7 @@ class _FieldMeta(type):
         return type.__new__(mcs, name, bases, attrs)
 
 
-class Field(metaclass=_FieldMeta):
+class Field(Generic[VALUE], metaclass=_FieldMeta):
     """
     Base Field type.
 
@@ -124,9 +139,24 @@ class Field(metaclass=_FieldMeta):
     SQL_TYPE: str = None  # type: ignore
     GENERATED_SQL: str = None  # type: ignore
 
-    # This method is just to make IDE/Linters happy
-    def __new__(cls, *args: Any, **kwargs: Any) -> "Field":
+    # These methods are just to make IDE/Linters happy:
+
+    def __new__(cls, *args: Any, **kwargs: Any) -> "Field[VALUE]":
         return super().__new__(cls)
+
+    @overload
+    def __get__(self, instance: None, owner: Type["Model"]) -> "Field[VALUE]":
+        ...
+
+    @overload
+    def __get__(self, instance: "Model", owner: Type["Model"]) -> VALUE:
+        ...
+
+    def __get__(self, instance: Optional["Model"], owner: Type["Model"]):
+        ...
+
+    def __set__(self, instance: Optional["Model"], value: VALUE) -> None:
+        ...
 
     def __init__(
         self,

--- a/tortoise/fields/data.py
+++ b/tortoise/fields/data.py
@@ -62,7 +62,7 @@ except ImportError:  # pragma: nocoverage
     pass
 
 
-class IntField(Field, int):
+class IntField(Field[int], int):
     """
     Integer field. (32-bit signed)
 
@@ -95,7 +95,7 @@ class IntField(Field, int):
         GENERATED_SQL = "INT NOT NULL PRIMARY KEY AUTO_INCREMENT"
 
 
-class BigIntField(Field, int):
+class BigIntField(Field[int], int):
     """
     Big integer field. (64-bit signed)
 
@@ -128,7 +128,7 @@ class BigIntField(Field, int):
         GENERATED_SQL = "BIGINT NOT NULL PRIMARY KEY AUTO_INCREMENT"
 
 
-class SmallIntField(Field, int):
+class SmallIntField(Field[int], int):
     """
     Small integer field. (16-bit signed)
 
@@ -161,7 +161,7 @@ class SmallIntField(Field, int):
         GENERATED_SQL = "SMALLINT NOT NULL PRIMARY KEY AUTO_INCREMENT"
 
 
-class CharField(Field, str):  # type: ignore
+class CharField(Field[str], str):  # type: ignore
     """
     Character field.
 
@@ -189,7 +189,7 @@ class CharField(Field, str):  # type: ignore
         return f"VARCHAR({self.max_length})"
 
 
-class TextField(Field, str):  # type: ignore
+class TextField(Field[str], str):  # type: ignore
     """
     Large Text field.
     """
@@ -219,7 +219,7 @@ class TextField(Field, str):  # type: ignore
         SQL_TYPE = "LONGTEXT"
 
 
-class BooleanField(Field):
+class BooleanField(Field[bool]):
     """
     Boolean field.
     """
@@ -232,7 +232,7 @@ class BooleanField(Field):
         SQL_TYPE = "INT"
 
 
-class DecimalField(Field, Decimal):
+class DecimalField(Field[Decimal], Decimal):
     """
     Accurate decimal field.
 
@@ -276,7 +276,7 @@ class DecimalField(Field, Decimal):
             return functions.Cast(term, SqlTypes.NUMERIC)
 
 
-class DatetimeField(Field, datetime.datetime):
+class DatetimeField(Field[datetime.datetime], datetime.datetime):
     """
     Datetime field.
 
@@ -359,7 +359,7 @@ class DatetimeField(Field, datetime.datetime):
         return desc
 
 
-class DateField(Field, datetime.date):
+class DateField(Field[datetime.date], datetime.date):
     """
     Date field.
     """
@@ -386,7 +386,7 @@ class DateField(Field, datetime.date):
         return return_value
 
 
-class TimeDeltaField(Field, datetime.timedelta):
+class TimeDeltaField(Field[datetime.timedelta], datetime.timedelta):
     """
     A field for storing time differences.
     """
@@ -410,7 +410,7 @@ class TimeDeltaField(Field, datetime.timedelta):
         return (value.days * 86400000000) + (value.seconds * 1000000) + value.microseconds
 
 
-class FloatField(Field, float):
+class FloatField(Field[float], float):
     """
     Float (double) field.
     """
@@ -424,7 +424,7 @@ class FloatField(Field, float):
         SQL_TYPE = "DOUBLE"
 
 
-class JSONField(Field, dict, list):  # type: ignore
+class JSONField(Field[Union[dict, list]], dict, list):  # type: ignore
     """
     JSON field.
 
@@ -483,7 +483,7 @@ class JSONField(Field, dict, list):  # type: ignore
         return value
 
 
-class UUIDField(Field, UUID):
+class UUIDField(Field[UUID], UUID):
     """
     UUID Field
 
@@ -511,7 +511,7 @@ class UUIDField(Field, UUID):
         return UUID(value)
 
 
-class BinaryField(Field, bytes):  # type: ignore
+class BinaryField(Field[bytes], bytes):  # type: ignore
     """
     Binary field.
 


### PR DESCRIPTION
## Description

This change makes `Field` a generic class, and implements stub `__get__` and `__set__` methods such that the field type will match the value it's replaced with, when accessed via an instance.

## Motivation and Context

As the `Field` class isn't used as a descriptor (values are applied directly to instances of models), type checkers see attributes typed as the field instances themselves, rather than the types they represent.

## How Has This Been Tested?

Functional tests continue to pass (no change to runtime usage is expected).

Static typing tests need some work -- currently there are plenty of type errors.  The types of attributes on models receiving a relation object itself can be set to the actual return type `ForeignKeyFieldInstance[TModel]` rather than `ForeignKeyRelation[TModel]` (which only needs declaring in order to set the generic's type; by default it'd get `ForeignKeyRelation[Any]`).  `Optional[TModel]` is invalid for nullable fields though which may need some extra thought.

Any suggestions on how to approach the necessary test work would be appreciated.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.