### PR TITLE
fix mysql database url documentation examples

### DIFF
--- a/docs/databases.rst
+++ b/docs/databases.rst
@@ -39,7 +39,7 @@ The supported ``DB_TYPE``:
 ``postgres``:
     Typically in the form of :samp:`postgres://postgres:pass@db.host:5432/somedb`
 ``mysql``:
-    Typically in the form of :samp:`mysql://myuser:mypass:pass@db.host:3306/somedb`
+    Typically in the form of :samp:`mysql://myuser:mypass@db.host:3306/somedb`
 
 Capabilities
 ============
@@ -129,7 +129,7 @@ In case any of ``user``, ``password``, ``host``, ``port`` parameters is missing,
 MySQL/MariaDB
 =============
 
-DB URL is typically in the form of :samp:`mysql://myuser:mypass:pass@db.host:3306/somedb`
+DB URL is typically in the form of :samp:`mysql://myuser:mypass@db.host:3306/somedb`
 
 Required Parameters
 -------------------


### PR DESCRIPTION
## Description
documentation for database url's on the mysql side were a little confusing. Example:

For [postgres](https://tortoise-orm.readthedocs.io/en/latest/databases.html#postgresql) it shows

```
postgres://postgres:pass@db.host:5432/somedb
```

For [mysql](https://tortoise-orm.readthedocs.io/en/latest/databases.html#mysql-mariadb) it shows
```
mysql://myuser:mypass:pass@db.host:3306/somedb
```

this change removes the `:pass` from the mysql url in the two locations I could find it was used to instead appear like so

```
mysql://myuser:mypass@db.host:3306/somedb
```

## Motivation and Context
Adds clarity and removes doubts present in the documentation that maybe the mysql version of the database url should also have `.pass` included in addition to the database pass

## How Has This Been Tested?
it hasn't been tested

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

