### PR TITLE
Add `Concat` function , also support nested

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Changelog
 ------
 - Fix `select_related` behaviour for forward relation. (#825)
 - Fix bug in nested `QuerySet` and `Manager`. (#864)
+- Add `Concat` function for MySQL/PostgreSQL. (#873)
 
 0.17.6
 ------

--- a/docs/functions.rst
+++ b/docs/functions.rst
@@ -29,6 +29,8 @@ Functions apply a transform on each instance of a Field.
 
 .. autoclass:: tortoise.functions.Upper
 
+.. autoclass:: tortoise.functions.Concat
+
 
 Aggregates
 ==========

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -149,6 +149,8 @@ class TestAggregation(test.TestCase):
         ret = await Book.all().annotate(max_name=Lower(Max("name"))).values("max_name")
         self.assertEqual(ret, [{"max_name": "third!"}])
 
+    @test.requireCapability(dialect="mysql")
+    @test.requireCapability(dialect="postgres")
     async def test_concat_functions(self):
         author = await Author.create(name="Some One")
         await Book.create(name="Physics Book", author=author, rating=4, subject="physics ")

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -154,7 +154,9 @@ class TestAggregation(test.TestCase):
         await Book.create(name="Physics Book", author=author, rating=4, subject="physics ")
         await Book.create(name="Mathematics Book", author=author, rating=3, subject=" mathematics")
         await Book.create(name="No-subject Book", author=author, rating=3)
-        ret = await Book.all().annotate(
-            long_info=Max(Concat("name", "(", Coalesce(Trim("subject"), "others"), ")"))
-        ).values("long_info")
+        ret = (
+            await Book.all()
+            .annotate(long_info=Max(Concat("name", "(", Coalesce(Trim("subject"), "others"), ")")))
+            .values("long_info")
+        )
         self.assertEqual(ret, [{"long_info": "Physics Book(physics)"}])

--- a/tests/testmodels.py
+++ b/tests/testmodels.py
@@ -35,6 +35,7 @@ class Book(Model):
     name = fields.CharField(max_length=255)
     author = fields.ForeignKeyField("models.Author", related_name="books")
     rating = fields.FloatField()
+    subject = fields.CharField(max_length=255, null=True)
 
 
 class BookNoConstraint(Model):

--- a/tortoise/functions.py
+++ b/tortoise/functions.py
@@ -106,7 +106,7 @@ class Function:
     def _resolve_default_values(self, model: "Type[Model]", table: Table) -> Iterator[Any]:
         for default_value in self.default_values:
             if isinstance(default_value, Function):
-                yield default_value.resolve(model, table)['field']
+                yield default_value.resolve(model, table)["field"]
             else:
                 yield default_value
 
@@ -237,9 +237,10 @@ class Concat(Function):
     Concate field or constant text.
 
      :samp:`Concat("{FIELD_NAME}", {ANOTHER_FIELD_NAMES or CONSTANT_TEXT}, *args)`
-     """
+    """
 
     database_func = functions.Concat
+
 
 ##############################################################################
 # Aggregate functions

--- a/tortoise/functions.py
+++ b/tortoise/functions.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Optional, Type, Union, cast
+from typing import TYPE_CHECKING, Any, Iterator, Optional, Type, Union, cast
 
 from pypika import Case, Table, functions
 from pypika.functions import DistinctOptionFunction
@@ -103,6 +103,13 @@ class Function:
 
         return {"joins": joins, "field": field}
 
+    def _resolve_default_values(self, model: "Type[Model]", table: Table) -> Iterator[Any]:
+        for default_value in self.default_values:
+            if isinstance(default_value, Function):
+                yield default_value.resolve(model, table)['field']
+            else:
+                yield default_value
+
     def resolve(self, model: "Type[Model]", table: Table) -> dict:
         """
         Used to resolve the Function statement for SQL generation.
@@ -113,19 +120,21 @@ class Function:
         :return: Dict with keys ``"joins"`` and ``"fields"``
         """
 
+        default_values = self._resolve_default_values(model, table)
+
         if isinstance(self.field, str):
             function = self._resolve_field_for_model(model, table, self.field)
-            function["field"] = self._get_function_field(function["field"], *self.default_values)
+            function["field"] = self._get_function_field(function["field"], *default_values)
             return function
         elif isinstance(self.field, Function):
             function = self.field.resolve(model, table)
-            function["field"] = self._get_function_field(function["field"], *self.default_values)
+            function["field"] = self._get_function_field(function["field"], *default_values)
             return function
 
         field, field_object = F.resolver_arithmetic_expression(model, self.field)
         if self.populate_field_object:
             self.field_object = field_object
-        return {"joins": [], "field": self._get_function_field(field, *self.default_values)}
+        return {"joins": [], "field": self._get_function_field(field, *default_values)}
 
 
 class Aggregate(Function):
@@ -222,6 +231,15 @@ class Upper(Function):
 
     database_func = functions.Upper
 
+
+class Concat(Function):
+    """
+    Concate field or constant text.
+
+     :samp:`Concat("{FIELD_NAME}", {ANOTHER_FIELD_NAMES or CONSTANT_TEXT}, *args)`
+     """
+
+    database_func = functions.Concat
 
 ##############################################################################
 # Aggregate functions

--- a/tortoise/functions.py
+++ b/tortoise/functions.py
@@ -235,6 +235,7 @@ class Upper(Function):
 class Concat(Function):
     """
     Concate field or constant text.
+    Be care, DB like sqlite3 has no support for `CONCAT`.
 
      :samp:`Concat("{FIELD_NAME}", {ANOTHER_FIELD_NAMES or CONSTANT_TEXT}, *args)`
     """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add `Concat` function , also support nested
## Description
<!--- Describe your changes in detail -->
Add `Concat` function, and slightly modified `tortoise.functions.Function` for better support nested Tortoise function in `Concat`.

Now you can:

```python
from tortoise.functions import Max, Concat, Coalesce, Trim

Book.all().annotate(
  long_info=Max(Concat("name", "(", Coalesce(Trim("subject"), "others"), ")"))
  ).values(
    "long_info"
  ).sql()

# SELECT MAX(CONCAT(`name`,'(',COALESCE(TRIM(`subject`),'others'),')')) `long_info` FROM `book`
#----if not modify  tortoise.functions.Function, result will be ----#
# SELECT MAX(CONCAT(`name`,'(',<tortoise.functions.Coalesce object at 0x10edf87d0>,')')) `long_info` FROM `book`
```
**Limitation**: `Concat` is subclass of `Tortoise.functions.Function`, like `Max`, `Upper`,.., it requires `Field` or str of Field name as first input argument, So `Concat("constant-str", F("field"), ...)` won't work.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`Concat` is a common requirement, but not seen in Tortoise. I guess that because the api is different, it can feed in more than one `Field `. I'm not sure whether this pr will do harm to this rule. 

If this pr not be allowed, what is better work around for people do want to use `Concat`? 

have tried below, absolutely not work -_-

```python
from pypika import functions as fn
from tortoise.functions import Function
from tortoise.functions import Max

class Concat(Function):
    database_func = fn.Concat

Book.all().annotate(
  long_info=Max(Concat("name", "(", fn.Coalesce(fn.Trim("subject"), "others"), ")"))
  ).values(
    "long_info"
  ).sql()

# SELECT MAX(CONCAT(`name`,'(',COALESCE(TRIM('subject'),'others'),')')) `long_info` FROM `book`
```

Slight difference vs pr, it treat field "subject" as plain str.

<!--- If it fixes an open issue, please link to the issue here. -->

related to #828  #829 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

add tests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

