### PR TITLE
Set SqliteClient SULOB capability  to False

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Changelog
 - Fix `select_related` behaviour for forward relation. (#825)
 - Fix bug in nested `QuerySet` and `Manager`. (#864)
 - Add `Concat` function for MySQL/PostgreSQL. (#873)
+- Set SqliteClient capability `support_update_limit_order_by=False`
 
 0.17.6
 ------

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -206,6 +206,7 @@ class TestQueryset(test.TestCase):
         with self.assertRaises(MultipleObjectsReturned):
             await IntFields.get(intnum_null=80)
 
+    @test.requireCapability(support_update_limit_order_by=True)
     async def test_delete(self):
         # Test delete
         await (await IntFields.get(intnum=40)).delete()

--- a/tortoise/backends/sqlite/client.py
+++ b/tortoise/backends/sqlite/client.py
@@ -41,7 +41,12 @@ class SqliteClient(BaseDBAsyncClient):
     query_class = SQLLiteQuery
     schema_generator = SqliteSchemaGenerator
     capabilities = Capabilities(
-        "sqlite", daemon=False, requires_limit=True, inline_comment=True, support_for_update=False
+        "sqlite",
+        daemon=False,
+        requires_limit=True,
+        inline_comment=True,
+        support_for_update=False,
+        support_update_limit_order_by=False,
     )
 
     def __init__(self, file_path: str, **kwargs: Any) -> None:


### PR DESCRIPTION
Set SqliteClient capability `support_update_limit_order_by=False`

## Description

Here set SqliteClient capability `support_update_limit_order_by=False` and add requireCapability to `test_queryset.test_delete()`, so that `make test_sqlite` skip these 4 test cases while sqlite db not [enable_update_delete_limit](https://www.sqlite.org/compile.html#enable_update_delete_limit) .

## Motivation and Context

run `make test_sqlite` on brand new "develop" branch,  there exists 4 errors, exists after #698 commit.

```bash
================================================================== short test summary info ===================================================================
FAILED tests/test_queryset.py::TestQueryset::test_delete - tortoise.exceptions.OperationalError: near "ORDER": syntax error
FAILED tests/test_queryset.py::TestQueryset::test_delete_limit - tortoise.exceptions.OperationalError: near "LIMIT": syntax error
FAILED tests/test_queryset.py::TestQueryset::test_delete_limit_order_by - tortoise.exceptions.OperationalError: near "ORDER": syntax error
FAILED tests/test_update.py::TestUpdate::test_update_with_limit_ordering - tortoise.exceptions.OperationalError: near "ORDER": syntax error
```
Simply track back, It seems related to my sqlite on Mac.  Have anyone else ever met these errors, Or it is purely wrong local environment myself？

Do i misunderstand the standard ?

    * Deficiencies: assume it is working right.
    * Features: assume it doesn't have it.

**If PR accepted, it may lose convenience usage for users whose sqlite already enable_update_delete_limit.** Maybe need overwrite connection's capabilities.

```python
await Tortoise.init(config=TORTOISE_ORM_SQLITE3)
print(Tortoise.get_connection("default").capabilities.support_update_limit_order_by)
#False

# Overwrite, if user's sqlite support this capability
Tortoise.get_connection("default").capabilities = Capabilities(
            "sqlite",
            daemon=False,
            requires_limit=True,
            inline_comment=True,
            support_for_update=False,
            support_update_limit_order_by=True,
)

print(Tortoise.get_connection("default").capabilities.support_update_limit_order_by)
#True
```


## How Has This Been Tested?

no new test case, only add requireCapability to `test_queryset.test_delete()`. `make test_sqlite` passed.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

