### PR TITLE
Replace root loggers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Changelog
 - Fix `select_related` behaviour for forward relation. (#825)
 - Fix bug in nested `QuerySet` and `Manager`. (#864)
 - Add `Concat` function for MySQL/PostgreSQL. (#873)
+- Fix all logging to use Tortoise's logger instead of root logger. (#879)
+- Rename `db_client` logger to `tortoise.db_client`.
 
 0.17.6
 ------

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -2,9 +2,9 @@
 Logging
 =======
 
-Current tortoise has two loggers, `db_client` and `tortoise`.
+Current tortoise has two loggers, `tortoise.db_client` and `tortoise`.
 
-`db_client` logging the information about execute query, and `tortoise` logging the information about runtime.
+`tortoise.db_client` logging the information about execute query, and `tortoise` logging the information about runtime.
 
 If you want control the behavior of tortoise logging, such as print debug sql, you can configure it yourself like following.
 
@@ -21,7 +21,7 @@ If you want control the behavior of tortoise logging, such as print debug sql, y
     sh.setFormatter(fmt)
 
     # will print debug sql
-    logger_db_client = logging.getLogger("db_client")
+    logger_db_client = logging.getLogger("tortoise.db_client")
     logger_db_client.setLevel(logging.DEBUG)
     logger_db_client.addHandler(sh)
 

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -1,7 +1,6 @@
 import asyncio
 import importlib
 import json
-import logging
 import os
 import warnings
 from contextvars import ContextVar
@@ -23,11 +22,10 @@ from tortoise.fields.relational import (
     OneToOneFieldInstance,
 )
 from tortoise.filters import get_m2m_filters
+from tortoise.log import logger
 from tortoise.models import Model, ModelMeta
 from tortoise.transactions import current_transaction_map
 from tortoise.utils import generate_schema_for_client
-
-logger = logging.getLogger("tortoise")
 
 
 class Tortoise:

--- a/tortoise/backends/base/client.py
+++ b/tortoise/backends/base/client.py
@@ -1,5 +1,4 @@
 import asyncio
-import logging
 from typing import Any, List, Optional, Sequence, Tuple, Type, Union
 
 from pypika import Query
@@ -7,6 +6,7 @@ from pypika import Query
 from tortoise.backends.base.executor import BaseExecutor
 from tortoise.backends.base.schema_generator import BaseSchemaGenerator
 from tortoise.exceptions import TransactionManagementError
+from tortoise.log import db_client_logger
 from tortoise.transactions import current_transaction_map
 
 
@@ -102,7 +102,7 @@ class BaseDBAsyncClient:
     capabilities: Capabilities = Capabilities("")
 
     def __init__(self, connection_name: str, fetch_inserted: bool = True, **kwargs: Any) -> None:
-        self.log = logging.getLogger("db_client")
+        self.log = db_client_logger
         self.connection_name = connection_name
         self.fetch_inserted = fetch_inserted
 

--- a/tortoise/backends/base/schema_generator.py
+++ b/tortoise/backends/base/schema_generator.py
@@ -1,10 +1,10 @@
-import logging
 from hashlib import sha256
 from typing import TYPE_CHECKING, Any, List, Set, Type, cast
 
 from tortoise.exceptions import ConfigurationError
 from tortoise.fields import JSONField, TextField, UUIDField
 from tortoise.indexes import Index
+from tortoise.log import logger
 
 if TYPE_CHECKING:  # pragma: nocoverage
     from tortoise.backends.base.client import BaseDBAsyncClient
@@ -12,8 +12,6 @@ if TYPE_CHECKING:  # pragma: nocoverage
     from tortoise.models import Model
 
 # pylint: disable=R0201
-
-logger = logging.getLogger("tortoise")
 
 
 class BaseSchemaGenerator:

--- a/tortoise/backends/base/schema_generator.py
+++ b/tortoise/backends/base/schema_generator.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Any, List, Set, Type, cast
 from tortoise.exceptions import ConfigurationError
 from tortoise.fields import JSONField, TextField, UUIDField
 from tortoise.indexes import Index
-from tortoise.log import logger
 
 if TYPE_CHECKING:  # pragma: nocoverage
     from tortoise.backends.base.client import BaseDBAsyncClient

--- a/tortoise/contrib/aiohttp/__init__.py
+++ b/tortoise/contrib/aiohttp/__init__.py
@@ -1,10 +1,10 @@
-import logging
 from types import ModuleType
 from typing import Dict, Iterable, Optional, Union
 
 from aiohttp import web  # pylint: disable=E0401
 
 from tortoise import Tortoise
+from tortoise.log import logger
 
 
 def register_tortoise(
@@ -79,14 +79,14 @@ def register_tortoise(
 
     async def init_orm(app):  # pylint: disable=W0612
         await Tortoise.init(config=config, config_file=config_file, db_url=db_url, modules=modules)
-        logging.info(f"Tortoise-ORM started, {Tortoise._connections}, {Tortoise.apps}")
+        logger.info(f"Tortoise-ORM started, {Tortoise._connections}, {Tortoise.apps}")
         if generate_schemas:
-            logging.info("Tortoise-ORM generating schema")
+            logger.info("Tortoise-ORM generating schema")
             await Tortoise.generate_schemas()
 
     async def close_orm(app):  # pylint: disable=W0612
         await Tortoise.close_connections()
-        logging.info("Tortoise-ORM shutdown")
+        logger.info("Tortoise-ORM shutdown")
 
     app.on_startup.append(init_orm)
     app.on_cleanup.append(close_orm)

--- a/tortoise/contrib/blacksheep/__init__.py
+++ b/tortoise/contrib/blacksheep/__init__.py
@@ -1,4 +1,3 @@
-import logging
 from types import ModuleType
 from typing import Dict, Iterable, Optional, Union
 
@@ -7,6 +6,7 @@ from blacksheep.server import Application
 
 from tortoise import Tortoise
 from tortoise.exceptions import DoesNotExist, IntegrityError
+from tortoise.log import logger
 
 
 def register_tortoise(
@@ -86,15 +86,15 @@ def register_tortoise(
     @app.on_start
     async def init_orm(context) -> None:  # pylint: disable=W0612
         await Tortoise.init(config=config, config_file=config_file, db_url=db_url, modules=modules)
-        logging.info("Tortoise-ORM started, %s, %s", Tortoise._connections, Tortoise.apps)
+        logger.info("Tortoise-ORM started, %s, %s", Tortoise._connections, Tortoise.apps)
         if generate_schemas:
-            logging.info("Tortoise-ORM generating schema")
+            logger.info("Tortoise-ORM generating schema")
             await Tortoise.generate_schemas()
 
     @app.on_stop
     async def close_orm(context) -> None:  # pylint: disable=W0612
         await Tortoise.close_connections()
-        logging.info("Tortoise-ORM shutdown")
+        logger.info("Tortoise-ORM shutdown")
 
     if add_exception_handlers:
 

--- a/tortoise/contrib/fastapi/__init__.py
+++ b/tortoise/contrib/fastapi/__init__.py
@@ -1,4 +1,3 @@
-import logging
 from types import ModuleType
 from typing import Dict, Iterable, Optional, Union
 
@@ -8,6 +7,7 @@ from pydantic import BaseModel  # pylint: disable=E0611
 
 from tortoise import Tortoise
 from tortoise.exceptions import DoesNotExist, IntegrityError
+from tortoise.log import logger
 
 
 class HTTPNotFoundError(BaseModel):
@@ -91,15 +91,15 @@ def register_tortoise(
     @app.on_event("startup")
     async def init_orm() -> None:  # pylint: disable=W0612
         await Tortoise.init(config=config, config_file=config_file, db_url=db_url, modules=modules)
-        logging.info("Tortoise-ORM started, %s, %s", Tortoise._connections, Tortoise.apps)
+        logger.info("Tortoise-ORM started, %s, %s", Tortoise._connections, Tortoise.apps)
         if generate_schemas:
-            logging.info("Tortoise-ORM generating schema")
+            logger.info("Tortoise-ORM generating schema")
             await Tortoise.generate_schemas()
 
     @app.on_event("shutdown")
     async def close_orm() -> None:  # pylint: disable=W0612
         await Tortoise.close_connections()
-        logging.info("Tortoise-ORM shutdown")
+        logger.info("Tortoise-ORM shutdown")
 
     if add_exception_handlers:
 

--- a/tortoise/contrib/quart/__init__.py
+++ b/tortoise/contrib/quart/__init__.py
@@ -6,6 +6,7 @@ from typing import Dict, Iterable, Optional, Union
 from quart import Quart  # pylint: disable=E0401
 
 from tortoise import Tortoise
+from tortoise.log import logger
 
 
 def register_tortoise(
@@ -83,15 +84,15 @@ def register_tortoise(
     @app.before_serving
     async def init_orm() -> None:  # pylint: disable=W0612
         await Tortoise.init(config=config, config_file=config_file, db_url=db_url, modules=modules)
-        logging.info("Tortoise-ORM started, %s, %s", Tortoise._connections, Tortoise.apps)
+        logger.info("Tortoise-ORM started, %s, %s", Tortoise._connections, Tortoise.apps)
         if _generate_schemas:
-            logging.info("Tortoise-ORM generating schema")
+            logger.info("Tortoise-ORM generating schema")
             await Tortoise.generate_schemas()
 
     @app.after_serving
     async def close_orm() -> None:  # pylint: disable=W0612
         await Tortoise.close_connections()
-        logging.info("Tortoise-ORM shutdown")
+        logger.info("Tortoise-ORM shutdown")
 
     @app.cli.command()  # type: ignore
     def generate_schemas() -> None:  # pylint: disable=E0102
@@ -104,6 +105,6 @@ def register_tortoise(
             await Tortoise.generate_schemas()
             await Tortoise.close_connections()
 
-        logging.basicConfig(level=logging.DEBUG)
+        logger.basicConfig(level=logging.DEBUG)
         loop = asyncio.get_event_loop()
         loop.run_until_complete(inner())

--- a/tortoise/contrib/quart/__init__.py
+++ b/tortoise/contrib/quart/__init__.py
@@ -105,6 +105,6 @@ def register_tortoise(
             await Tortoise.generate_schemas()
             await Tortoise.close_connections()
 
-        logger.basicConfig(level=logging.DEBUG)
+        logger.setLevel(logging.DEBUG)
         loop = asyncio.get_event_loop()
         loop.run_until_complete(inner())

--- a/tortoise/contrib/sanic/__init__.py
+++ b/tortoise/contrib/sanic/__init__.py
@@ -1,10 +1,10 @@
-import logging
 from types import ModuleType
 from typing import Dict, Iterable, Optional, Union
 
 from sanic import Sanic  # pylint: disable=E0401
 
 from tortoise import Tortoise
+from tortoise.log import logger
 
 
 def register_tortoise(
@@ -80,12 +80,12 @@ def register_tortoise(
     @app.listener("before_server_start")
     async def init_orm(app, loop):  # pylint: disable=W0612
         await Tortoise.init(config=config, config_file=config_file, db_url=db_url, modules=modules)
-        logging.info("Tortoise-ORM started, %s, %s", Tortoise._connections, Tortoise.apps)
+        logger.info("Tortoise-ORM started, %s, %s", Tortoise._connections, Tortoise.apps)
         if generate_schemas:
-            logging.info("Tortoise-ORM generating schema")
+            logger.info("Tortoise-ORM generating schema")
             await Tortoise.generate_schemas()
 
     @app.listener("after_server_stop")
     async def close_orm(app, loop):  # pylint: disable=W0612
         await Tortoise.close_connections()
-        logging.info("Tortoise-ORM shutdown")
+        logger.info("Tortoise-ORM shutdown")

--- a/tortoise/contrib/starlette/__init__.py
+++ b/tortoise/contrib/starlette/__init__.py
@@ -1,10 +1,10 @@
-import logging
 from types import ModuleType
 from typing import Dict, Iterable, Optional, Union
 
 from starlette.applications import Starlette  # pylint: disable=E0401
 
 from tortoise import Tortoise
+from tortoise.log import logger
 
 
 def register_tortoise(
@@ -80,12 +80,12 @@ def register_tortoise(
     @app.on_event("startup")
     async def init_orm() -> None:  # pylint: disable=W0612
         await Tortoise.init(config=config, config_file=config_file, db_url=db_url, modules=modules)
-        logging.info("Tortoise-ORM started, %s, %s", Tortoise._connections, Tortoise.apps)
+        logger.info("Tortoise-ORM started, %s, %s", Tortoise._connections, Tortoise.apps)
         if generate_schemas:
-            logging.info("Tortoise-ORM generating schema")
+            logger.info("Tortoise-ORM generating schema")
             await Tortoise.generate_schemas()
 
     @app.on_event("shutdown")
     async def close_orm() -> None:  # pylint: disable=W0612
         await Tortoise.close_connections()
-        logging.info("Tortoise-ORM shutdown")
+        logger.info("Tortoise-ORM shutdown")

--- a/tortoise/log.py
+++ b/tortoise/log.py
@@ -1,4 +1,4 @@
 import logging
 
 logger = logging.getLogger("tortoise")
-db_client_logger = logging.getLogger("db_client")
+db_client_logger = logging.getLogger("tortoise.db_client")

--- a/tortoise/log.py
+++ b/tortoise/log.py
@@ -1,0 +1,4 @@
+import logging
+
+logger = logging.getLogger("tortoise")
+db_client_logger = logging.getLogger("db_client")

--- a/tortoise/utils.py
+++ b/tortoise/utils.py
@@ -1,4 +1,5 @@
 from typing import TYPE_CHECKING
+
 from tortoise.log import logger
 
 if TYPE_CHECKING:  # pragma: nocoverage

--- a/tortoise/utils.py
+++ b/tortoise/utils.py
@@ -1,7 +1,5 @@
-import logging
 from typing import TYPE_CHECKING
-
-logger = logging.getLogger("tortoise")
+from tortoise.log import logger
 
 if TYPE_CHECKING:  # pragma: nocoverage
     from tortoise.backends.base.client import BaseDBAsyncClient


### PR DESCRIPTION
* Move logger to its own module
* Use tortoise.log.logger in contrib packages
* Use tortoise.log loggers everywhere else
<!--- Provide a general summary of your changes in the Title above -->

## Description
Moves all loggers to `tortoise.log` and uses them in contrib modules too.
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Solves #879. Moved loggers to their own `tortoise.log` file to avoid circular imports

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Not too sure how to test it. I'm willing to test it if anyone has an idea how 😅 .

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes (no existing tests for logging).
- [x] All new and existing tests passed.


P.D.: This is only my second public PR, please be kind :heart:
