### PR TITLE
Lift annotation field's priority in make query

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Changelog
 - Fix bug in nested `QuerySet` and `Manager`. (#864)
 - Add `Concat` function for MySQL/PostgreSQL. (#873)
 - Patch for use_index/force_index mutable problem when making query. (#888)
+- Lift annotation field's priority in make query. (#883)
 
 0.17.6
 ------

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -454,3 +454,10 @@ class TestQueryset(test.TestCase):
     async def test_raw_sql_filter(self):
         ret = await Tournament.filter(pk=RawSQL("id + 1"))
         self.assertEqual(ret, [])
+
+    async def test_annotation_field_priorior_to_model_field(self):
+        # Sometimes, field name in annotates also exist in model field sets
+        # and may need lift the former's priority in select query construction.
+        t1 = await Tournament.create(name="1")
+        ret = await Tournament.filter(pk=t1.pk).annotate(id=RawSQL("id + 1")).values("id")
+        self.assertEqual(ret, [{"id": t1.pk + 1}])

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -1326,15 +1326,10 @@ class ValuesListQuery(FieldSelectQuery):
         ]
         if self.flat:
             func = columns[0][1]
-
-            def flatmap(entry):
-                return func(entry["0"])  # noqa
-
+            flatmap = lambda entry: func(entry["0"])  # noqa
             return list(map(flatmap, result))
 
-        def listmap(entry):
-            return tuple(func(entry[column]) for column, func in columns)  # noqa
-
+        listmap = lambda entry: tuple(func(entry[column]) for column, func in columns)  # noqa
         return list(map(listmap, result))
 
 


### PR DESCRIPTION
Lift annotation field's priority in make query when duplicate with model field

## Description

This PR modified `Tortoise.queryset.FieldSelectQuery.add_field_to_select_query()` method by lifting `if field in self.annotations` block before `if field in self.model._meta.fields_db_projection`.

before this PR

```python
Model.filter(id=1).annotate(id=F("id")+1).values("id").sql()
# SELECT `id` `id` FROM `model` where `id`=1

```

after this PR

```python
Model.filter(id=1).annotate(id=F("id")+1).values("id").sql()
# SELECT `id`+1 `id` FROM `model` where `id`=1
```

## Motivation and Context

Sometimes, field name in annotations already exist in model field set, and users want to pick annotated field in `.values(<field>)`.

Suppose a request to calculate aggregation for given metrics: `GET /?metrics=m1,m2,m3`, and expect a response with same field name(frontend don't know backend logic):

before this PR

```python
async def get_average(request):
    metrics = request.query_params.get('metrics').split(',')
    data = await Model.all().annotate(
            **{f"some_{m}_chareacter": AVG(m) for m in metrics}
        ).values(
            **{m: f"some_{m}_chareacter" for m in metrics}
        )
    return JSONResponse(data)
```

after this PR

```python
async def get_average(request):
    metrics = request.query_params.get('metrics').split(',')
    data = await Model.all().annotate(**{m: AVG(m) for m in metrics}).values(*metrics)
    return JSONResponse(data)
```

## How Has This Been Tested?

add test `test_queryset.TestQueryset.test_annotation_field_priorior_to_model_field()`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

