### PR TITLE
Patch for use_index/force_index mutable problem when making query

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Changelog
 - Fix `select_related` behaviour for forward relation. (#825)
 - Fix bug in nested `QuerySet` and `Manager`. (#864)
 - Add `Concat` function for MySQL/PostgreSQL. (#873)
+- Patch for use_index/force_index mutable problem when making query. (#888)
 
 0.17.6
 ------

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -346,11 +346,23 @@ class TestQueryset(test.TestCase):
             "SELECT `id` `id` FROM `intfields` FORCE INDEX (`index_name`) WHERE `id`=1",
         )
 
+        sql_again = IntFields.filter(pk=1).only("id").force_index("index_name").sql()
+        self.assertEqual(
+            sql_again,
+            "SELECT `id` `id` FROM `intfields` FORCE INDEX (`index_name`) WHERE `id`=1",
+        )
+
     @test.requireCapability(support_index_hint=True)
     async def test_use_index(self):
         sql = IntFields.filter(pk=1).only("id").use_index("index_name").sql()
         self.assertEqual(
             sql,
+            "SELECT `id` `id` FROM `intfields` USE INDEX (`index_name`) WHERE `id`=1",
+        )
+
+        sql_again = IntFields.filter(pk=1).only("id").use_index("index_name").sql()
+        self.assertEqual(
+            sql_again,
             "SELECT `id` `id` FROM `intfields` USE INDEX (`index_name`) WHERE `id`=1",
         )
 

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -880,8 +880,10 @@ class QuerySet(AwaitableQuery[MODEL]):
                     path=(None, field),
                 )
         if self._force_indexes:
+            self.query._force_indexes = []
             self.query = self.query.force_index(*self._force_indexes)
         if self._use_indexes:
+            self.query._use_indexes = []
             self.query = self.query.use_index(*self._use_indexes)
 
     def __await__(self) -> Generator[Any, None, List[MODEL]]:


### PR DESCRIPTION
Patch for use_index/force_index mutable problem when making query, it's a bug from pypika (https://github.com/kayak/pypika/pull/631).

## Description

before this PR

```python
sql = IntFields.filter(pk=1).only("id").use_index("index_name").sql()
# "SELECT `id` `id` FROM `intfields` USE INDEX (`index_name`) WHERE `id`=1"
# (if run again)
sql_again = IntFields.filter(pk=1).only("id").use_index("index_name").sql()
# "SELECT `id` `id` FROM `intfields` USE INDEX (`index_name`, `index_name`) WHERE `id`=1"

```

As show above, queryset's sql from same model will "remember" used indexes before. The same for forced indexes. The problem is caused by lines bellow, related to pypika.

```python
if self._force_indexes:
    self.query = self.query.force_index(*self._force_indexes)
if self._use_indexes:
    self.query = self.query.use_index(*self._use_indexes)
```

`pypika.queries.QueryBuilder.__copy__()` forgets shallow copy `_use_indexes`, `_force_indexes` when they both are python list and mutable.

## Motivation and Context

**Before pypika fix that problem, this PR add a patch by setting** `self.query._use_indexes = []` and `self.query._force_indexes = []` manualy.

```python
if self._force_indexes:
    self.query._force_indexes = []
    self.query = self.query.force_index(*self._force_indexes)
if self._use_indexes:
    self.query._use_indexes = []
    self.query = self.query.use_index(*self._use_indexes)
```

## How Has This Been Tested?

modify `test_queryset.TestQueryset.test_force_index()`, `test_queryset.TestQueryset.test_use_index`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

