### PR TITLE
Allow negative values with `IntEnumField`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Changelog
 - Add `Model.raw` method to support the raw sql query.
 - Fix `QuerySet` subclass being lost when `_clone` is run on the instance.
 - Fix bug in `.values` with `source_field`. (#844)
+- Allow negative values with `IntEnumField`. (#889)
 
 0.17.7
 ------

--- a/tests/fields/test_enum.py
+++ b/tests/fields/test_enum.py
@@ -13,6 +13,12 @@ class BadIntEnum1(IntEnum):
 
 
 class BadIntEnum2(IntEnum):
+    python_programming = -32769
+    database_design = 2
+    system_administration = 3
+
+
+class BadIntEnumIfGenerated(IntEnum):
     python_programming = -1
     database_design = 2
     system_administration = 3
@@ -82,15 +88,25 @@ class TestIntEnumFields(test.TestCase):
 
     def test_range1_fails(self):
         with self.assertRaisesRegex(
-            ConfigurationError, "The valid range of IntEnumField's values is 0..32767!"
+            ConfigurationError, "The valid range of IntEnumField's values is -32768..32767!"
         ):
             IntEnumField(BadIntEnum1)
 
     def test_range2_fails(self):
         with self.assertRaisesRegex(
-            ConfigurationError, "The valid range of IntEnumField's values is 0..32767!"
+            ConfigurationError, "The valid range of IntEnumField's values is -32768..32767!"
         ):
             IntEnumField(BadIntEnum2)
+
+    def test_range3_generated_fails(self):
+        with self.assertRaisesRegex(
+            ConfigurationError, "The valid range of IntEnumField's values is 1..32767!"
+        ):
+            IntEnumField(BadIntEnumIfGenerated, generated=True)
+
+    def test_range3_manual(self):
+        fld = IntEnumField(BadIntEnumIfGenerated)
+        self.assertIs(fld.enum_type, BadIntEnumIfGenerated)
 
     def test_auto_description(self):
         fld = IntEnumField(testmodels.Service)

--- a/tortoise/fields/data.py
+++ b/tortoise/fields/data.py
@@ -531,16 +531,23 @@ class BinaryField(Field, bytes):  # type: ignore
 
 class IntEnumFieldInstance(SmallIntField):
     def __init__(
-        self, enum_type: Type[IntEnum], description: Optional[str] = None, **kwargs: Any
+        self,
+        enum_type: Type[IntEnum],
+        description: Optional[str] = None,
+        generated: bool = False,
+        **kwargs: Any,
     ) -> None:
         # Validate values
+        minimum = 1 if generated else -32768
         for item in enum_type:
             try:
                 value = int(item.value)
             except ValueError:
                 raise ConfigurationError("IntEnumField only supports integer enums!")
-            if not 0 <= value < 32768:
-                raise ConfigurationError("The valid range of IntEnumField's values is 0..32767!")
+            if not minimum <= value < 32768:
+                raise ConfigurationError(
+                    "The valid range of IntEnumField's values is {}..32767!".format(minimum)
+                )
 
         # Automatic description for the field if not specified by the user
         if description is None:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This permits negative values for a non-generated `IntEnumField`.

## Motivation and Context
Fixes #889.

## How Has This Been Tested?
Tests updated to check the new minimum both for generated and non-generated fields.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.*
  (there are 4 existing test failures from develop)