### PR TITLE
Update _clone to work with QuerySet subclasses

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Changelog
 0.17.8
 ------
 - Add `Model.raw` method to support the raw sql query.
+- Fix `QuerySet` subclass being lost when `_clone` is run on the instance.
 
 0.17.7
 ------

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -319,7 +319,7 @@ class QuerySet(AwaitableQuery[MODEL]):
         self._use_indexes: Set[str] = set()
 
     def _clone(self) -> "QuerySet[MODEL]":
-        queryset = self.__class__.__new__(QuerySet)
+        queryset = self.__class__.__new__(self.__class__)
         queryset.fields = self.fields
         queryset.model = self.model
         queryset.query = self.query


### PR DESCRIPTION
## Description
Previously, any calls to `_clone` would result in the new QuerySet instance being initialized as a standard QuerySet. This updates `_clone` to use the active class instead. This is a tiny change.

## Motivation and Context
This allows the use of custom QuerySet classes which can have convenience methods for filtering, etc. Custom QuerySets are a [very helpful feature](https://docs.djangoproject.com/en/dev/topics/db/managers/) of Django.

## How Has This Been Tested?
I've tested the changes locally in my app. There shouldn't be any issues as this simply replaces the hardcoding of `QuerySet` with `self.__class__`. For a standard QuerySet, this will yield the same result. I haven't had time to get the test suite running yet.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

