### PR TITLE
WIP: Make querysets' methods limit and offset optional

### DIFF
--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -414,12 +414,15 @@ class QuerySet(AwaitableQuery[MODEL]):
         queryset._orderings = new_ordering
         return queryset
 
-    def limit(self, limit: int) -> "QuerySet[MODEL]":
+    def limit(self, limit: Optional[int]) -> "QuerySet[MODEL]":
         """
         Limits QuerySet to given length.
 
         :raises ParamsError: Limit should be non-negative number.
         """
+        if limit is None:
+            return self
+
         if limit < 0:
             raise ParamsError("Limit should be non-negative number")
 
@@ -427,12 +430,15 @@ class QuerySet(AwaitableQuery[MODEL]):
         queryset._limit = limit
         return queryset
 
-    def offset(self, offset: int) -> "QuerySet[MODEL]":
+    def offset(self, offset: Optional[int]) -> "QuerySet[MODEL]":
         """
         Query offset for QuerySet.
 
         :raises ParamsError: Offset should be non-negative number.
         """
+        if offset is None:
+            return self
+
         if offset < 0:
             raise ParamsError("Offset should be non-negative number")
 


### PR DESCRIPTION
## Description
Now None can be pass to methods offset and limit :
```python
limit = None
offset = None
(
    queryset
    .limit(limit)
    .offset(offset)
)
```

As proposed in #919, it allows to always call a limit with a default value at None. Then no SQL request is made with maxsize limit, or to use an offset with a 0 value.

## Modifications
If their position parameter is None, then it simply return the queryset itself without cloning it. Considering that queryset has not changed we don't need to clone but it might be against rule of pure functional programming.

## How Has This Been Tested?
Not tested yet

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

