### PR TITLE
Support `safe` parameter during index creation by including `exists` in index templates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ Fixed
 - Fix `QuerySet` subclass being lost when `_clone` is run on the instance.
 - Fix bug in `.values` with `source_field`. (#844)
 - Fix `contrib.blacksheep` exception handlers, use builtin json response. (#914)
+- Fix Indexes defined in Meta class do not make use of `exists` parameter in their template (#928)
 Changed
 ^^^^^^^
 - Allow negative values with `IntEnumField`. (#889)

--- a/tortoise/contrib/postgres/indexes.py
+++ b/tortoise/contrib/postgres/indexes.py
@@ -4,7 +4,9 @@ from tortoise.indexes import Index
 
 
 class PostgreSQLIndex(Index, metaclass=ABCMeta):
-    INDEX_CREATE_TEMPLATE = "CREATE INDEX {index_name} ON {table_name} USING{index_type}({fields});"
+    INDEX_CREATE_TEMPLATE = (
+        "CREATE INDEX {exists}{index_name} ON {table_name} USING{index_type}({fields});"
+    )
 
 
 class BloomIndex(PostgreSQLIndex):

--- a/tortoise/indexes.py
+++ b/tortoise/indexes.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 class Index:
     INDEX_TYPE = ""
     INDEX_CREATE_TEMPLATE = (
-        "CREATE{index_type}INDEX {index_name} ON {table_name} ({fields}){extra};"
+        "CREATE{index_type}INDEX {exists}{index_name} ON {table_name} ({fields}){extra};"
     )
 
     def __init__(


### PR DESCRIPTION
Description of change:
Add exists to Index templates
Add tests for safe/unsafe index creation

Notes:

<!--- Provide a general summary of your changes in the Title above -->
Title says it all, current index templates don't support `exists` parameter despite it being passed to the format call.

This PR allows for safe index creation, ensuring that subsequent `generate_schemas` calls don't raise an exception

## Description
<!--- Describe your changes in detail -->
Not much more detail to be added.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
During a migration of my existing postgres code to Tortoise I noticed that user defined indexes in the meta class would raise exceptions on subsequent application startups.

Looking into `tortoise.backends.base.schema_generator:309-319` I noticed that a different conditional branch creates the SQL for user defined indexes, namely it calls `get_sql` function on the Index class, which does in fact pass `exists` to `format` but `exists` isn't used anywhere in either the base Index template, or the PostgreSQL Index template

<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/tortoise/tortoise-orm/issues/928

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested this manually by verifying that before the fix, calling `generate_schemas` twice for the model in the ticket would raise an exception.

After the fix this does not occur.

<!--- Include details of your testing environment, and the tests you ran to -->
Intel Mac
Added unit tests and verified after altering Index templates
Used the defined model in the [ticket](https://github.com/tortoise/tortoise-orm/issues/928) and ran a small script that would connect to my local postgres and call `generate_schemas`

<!--- see how your change affects other areas of the code, etc. -->
I see no downstream effects

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

