### PR TITLE
Fix mutable default value

### DIFF
--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -661,7 +661,7 @@ class Model(metaclass=ModelMeta):
             if callable(field_object.default):
                 setattr(self, key, field_object.default())
             else:
-                setattr(self, key, field_object.default)
+                setattr(self, key, deepcopy(field_object.default))
 
     def _set_kwargs(self, kwargs: dict) -> Set[str]:
         meta = self._meta


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes this bug

```python3
class SomeModel(Model):
    some_field: list = JSONField(default=[])

...

async def main():
    model_1 = SomeModel()
    model_1.some_field.append(1)
    model_2 = SomeModel()
    print(model_2.some_field)
    # Prints [1]
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The model should create a new instance of the default variable every time it is created so that they can be safely modified.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Python 3.9.7

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

