### PR TITLE
Add documentation for logger's formatter with syntax coloration

### DIFF
--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -30,7 +30,7 @@ If you want control the behavior of tortoise logging, such as print debug sql, y
     logger_tortoise.addHandler(sh)
 
 
-You can also use your own formatter to add syntax coloration to sql :
+You can also use your own formatter to add syntax coloration to sql, by using `pygments <https://pygments.org/>` :
 
 .. code-block:: python3
 

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -29,3 +29,64 @@ If you want control the behavior of tortoise logging, such as print debug sql, y
     logger_tortoise.setLevel(logging.DEBUG)
     logger_tortoise.addHandler(sh)
 
+
+You can also use your own formatter to add syntax coloration to sql :
+
+.. code-block:: python3
+
+    import logging
+
+    from pygments import highlight
+    from pygments.formatters.terminal import TerminalFormatter
+    from pygments.lexers.sql import PostgresLexer
+
+    postgres = PostgresLexer()
+    terminal_formatter = TerminalFormatter()
+
+
+    class PygmentsFormatter(logging.Formatter):
+        def __init__(
+            self,
+            fmt="{asctime} - {name}:{lineno} - {levelname} - {message}",
+            datefmt="%H:%M:%S",
+        ):
+            self.datefmt = datefmt
+            self.fmt = fmt
+            logging.Formatter.__init__(self, None, datefmt)
+
+        def format(self, record: logging.LogRecord):
+            """Format the logging record with slq's syntax coloration."""
+            own_records = {
+                attr: val
+                for attr, val in record.__dict__.items()
+                if not attr.startswith("_")
+            }
+            message = record.getMessage()
+            name = record.name
+            asctime = self.formatTime(record, self.datefmt)
+
+            if name == "tortoise.db_client":
+                if (
+                    record.levelname == "DEBUG"
+                    and not message.startswith("Created connection pool")
+                    and not message.startswith("Closed connection pool")
+                ):
+                    message = highlight(message, postgres, terminal_formatter).rstrip()
+
+            own_records.update(
+                {
+                    "message": message,
+                    "name": name,
+                    "asctime": asctime,
+                }
+            )
+
+            return self.fmt.format(**own_records)
+
+
+
+    # Then replace the formatter above by the following one
+    fmt = PygmentsFormatter(
+        fmt="{asctime} - {name}:{lineno} - {levelname} - {message}",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )


### PR DESCRIPTION
Just a little trick one might like.

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.

There's no need for changelog, is there ?

```python
import logging

from pygments import highlight
from pygments.formatters.terminal import TerminalFormatter
from pygments.lexers.sql import PostgresLexer

postgres = PostgresLexer()
terminal_formatter = TerminalFormatter()


class PygmentsFormatter(logging.Formatter):
    def __init__(
        self,
        fmt="{asctime} - {name}:{lineno} - {levelname} - {message}",
        datefmt="%H:%M:%S",
    ):
        self.datefmt = datefmt
        self.fmt = fmt
        logging.Formatter.__init__(self, None, datefmt)

    def format(self, record: logging.LogRecord):
        """Format the logging record with slq's syntax coloration."""
        own_records = {
            attr: val
            for attr, val in record.__dict__.items()
            if not attr.startswith("_")
        }
        message = record.getMessage()
        name = record.name
        asctime = self.formatTime(record, self.datefmt)

        if name == "tortoise.db_client":
            if (
                record.levelname == "DEBUG"
                and not message.startswith("Created connection pool")
                and not message.startswith("Closed connection pool")
            ):
                message = highlight(message, postgres, terminal_formatter).rstrip()

        own_records.update(
            {
                "message": message,
                "name": name,
                "asctime": asctime,
            }
        )

        return self.fmt.format(**own_records)
```

