### PR TITLE
Fix `bulk_create` doesn't work correctly with more than 1 update_fields

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,12 @@ Changelog
 
 0.18
 ====
+0.18.2
+------
+Fixed
+^^^^^
+- Fix `bulk_create` doesn't work correctly with more than 1 update_fields. (#1046)
+
 0.18.1
 ------
 Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tortoise-orm"
-version = "0.18.1"
+version = "0.18.2"
 description = "Easy async ORM for python, built with relations in mind"
 authors = ["Andrey Bondar <andrey@bondar.ru>", "Nickolas Grigoriadis <nagrigoriadis@gmail.com>", "long2ice <long2ice@gmail.com>"]
 license = "Apache-2.0"

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -18,4 +18,5 @@ class TestBasic(test.TestCase):
                 {"id": tournament.id, "name": "Updated name"},
                 {"id": tournament.id + 1, "name": "Test 2"},
             ],
+            sorted_key="id",
         )

--- a/tests/test_bulk.py
+++ b/tests/test_bulk.py
@@ -23,6 +23,18 @@ class TestBulk(test.TruncationTestCase):
         all_ = await UniqueName.all().values("name", "optional")
         self.assertListSortEqual(all_, [{"name": "name", "optional": "optional"}])
 
+    async def test_bulk_create_more_that_one_update_fields(self):
+        await UniqueName.bulk_create([UniqueName(name="name")])
+        await UniqueName.bulk_create(
+            [UniqueName(name="name", optional="optional", other_optional="other_optional")],
+            update_fields=["optional", "other_optional"],
+            on_conflict=["name"],
+        )
+        all_ = await UniqueName.all().values("name", "optional", "other_optional")
+        self.assertListSortEqual(
+            all_, [{"name": "name", "optional": "optional", "other_optional": "other_optional"}]
+        )
+
     async def test_bulk_create_with_batch_size(self):
         await UniqueName.bulk_create([UniqueName() for _ in range(1000)], batch_size=100)
         all_ = await UniqueName.all().values("id", "name")

--- a/tests/test_bulk.py
+++ b/tests/test_bulk.py
@@ -11,7 +11,9 @@ class TestBulk(test.TruncationTestCase):
         await UniqueName.bulk_create([UniqueName() for _ in range(1000)])
         all_ = await UniqueName.all().values("id", "name")
         inc = all_[0]["id"]
-        self.assertListSortEqual(all_, [{"id": val + inc, "name": None} for val in range(1000)])
+        self.assertListSortEqual(
+            all_, [{"id": val + inc, "name": None} for val in range(1000)], sorted_key="id"
+        )
 
     async def test_bulk_create_update_fields(self):
         await UniqueName.bulk_create([UniqueName(name="name")])
@@ -39,12 +41,16 @@ class TestBulk(test.TruncationTestCase):
         await UniqueName.bulk_create([UniqueName() for _ in range(1000)], batch_size=100)
         all_ = await UniqueName.all().values("id", "name")
         inc = all_[0]["id"]
-        self.assertListSortEqual(all_, [{"id": val + inc, "name": None} for val in range(1000)])
+        self.assertListSortEqual(
+            all_, [{"id": val + inc, "name": None} for val in range(1000)], sorted_key="id"
+        )
 
     async def test_bulk_create_with_specified(self):
         await UniqueName.bulk_create([UniqueName(id=id_) for id_ in range(1000, 2000)])
         all_ = await UniqueName.all().values("id", "name")
-        self.assertListSortEqual(all_, [{"id": id_, "name": None} for id_ in range(1000, 2000)])
+        self.assertListSortEqual(
+            all_, [{"id": id_, "name": None} for id_ in range(1000, 2000)], sorted_key="id"
+        )
 
     async def test_bulk_create_mix_specified(self):
         await UniqueName.bulk_create(
@@ -56,11 +62,11 @@ class TestBulk(test.TruncationTestCase):
         self.assertEqual(len(all_), 2000)
 
         self.assertListSortEqual(
-            all_[:1000], [{"id": id_, "name": None} for id_ in range(10000, 11000)]
+            all_[:1000], [{"id": id_, "name": None} for id_ in range(10000, 11000)], sorted_key="id"
         )
         inc = all_[1000]["id"]
         self.assertListSortEqual(
-            all_[1000:], [{"id": val + inc, "name": None} for val in range(1000)]
+            all_[1000:], [{"id": val + inc, "name": None} for val in range(1000)], sorted_key="id"
         )
 
     async def test_bulk_create_uuidpk(self):

--- a/tests/test_group_by.py
+++ b/tests/test_group_by.py
@@ -35,7 +35,9 @@ class TestGroupBy(test.TestCase):
             .values("author__name", "count")
         )
         self.assertListSortEqual(
-            ret, [{"author__name": "author1", "count": 10}, {"author__name": "author2", "count": 5}]
+            ret,
+            [{"author__name": "author1", "count": 10}, {"author__name": "author2", "count": 5}],
+            sorted_key="author__name",
         )
 
     async def test_count_filter_group_by(self):
@@ -69,6 +71,7 @@ class TestGroupBy(test.TestCase):
         self.assertListSortEqual(
             ret,
             [{"author__name": "author1", "sum": 45.0}, {"author__name": "author2", "sum": 10.0}],
+            sorted_key="author__name",
         )
 
     async def test_sum_filter_group_by(self):
@@ -101,7 +104,9 @@ class TestGroupBy(test.TestCase):
             .values("author__name", "avg")
         )
         self.assertListSortEqual(
-            ret, [{"author__name": "author1", "avg": 4.5}, {"author__name": "author2", "avg": 2}]
+            ret,
+            [{"author__name": "author1", "avg": 4.5}, {"author__name": "author2", "avg": 2}],
+            sorted_key="author__name",
         )
 
     async def test_avg_filter_group_by(self):
@@ -223,5 +228,7 @@ class TestGroupBy(test.TestCase):
             .values("upper_name", "count")
         )
         self.assertListSortEqual(
-            ret, [{"upper_name": "AUTHOR1", "count": 10}, {"upper_name": "AUTHOR2", "count": 5}]
+            ret,
+            [{"upper_name": "AUTHOR1", "count": 10}, {"upper_name": "AUTHOR2", "count": 5}],
+            sorted_key="upper_name",
         )

--- a/tests/test_values.py
+++ b/tests/test_values.py
@@ -153,6 +153,7 @@ class TestValues(test.TestCase):
                 {"name": "Championship", "name_slength": 12},
                 {"name": "Super Bowl", "name_slength": 10},
             ],
+            sorted_key="name",
         )
 
     async def test_values_list_annotations_trim(self):
@@ -170,5 +171,7 @@ class TestValues(test.TestCase):
 
         tournaments = await Tournament.annotate(name_trim=Trim("name")).values("name", "name_trim")
         self.assertListSortEqual(
-            tournaments, [{"name": "  x", "name_trim": "x"}, {"name": " y ", "name_trim": "y"}]
+            tournaments,
+            [{"name": "  x", "name_trim": "x"}, {"name": " y ", "name_trim": "y"}],
+            sorted_key="name",
         )

--- a/tests/testmodels.py
+++ b/tests/testmodels.py
@@ -314,6 +314,7 @@ class UniqueName(Model):
     id = fields.IntField(pk=True)
     name = fields.CharField(max_length=20, null=True, unique=True)
     optional = fields.CharField(max_length=20, null=True)
+    other_optional = fields.CharField(max_length=20, null=True)
 
 
 class UniqueTogetherFields(Model):

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -709,4 +709,4 @@ def run_async(coro: Coroutine) -> None:
         loop.run_until_complete(Tortoise.close_connections())
 
 
-__version__ = "0.18.1"
+__version__ = "0.18.2"

--- a/tortoise/contrib/test/__init__.py
+++ b/tortoise/contrib/test/__init__.py
@@ -202,6 +202,8 @@ class SimpleTestCase(unittest.IsolatedAsyncioTestCase):
             )
         elif isinstance(list1[0], tuple):
             super().assertListEqual(sorted(list1), sorted(list2))
+        else:
+            super().assertListEqual(list1, list2)
 
 
 class IsolatedTestCase(SimpleTestCase):

--- a/tortoise/contrib/test/__init__.py
+++ b/tortoise/contrib/test/__init__.py
@@ -195,15 +195,21 @@ class SimpleTestCase(unittest.IsolatedAsyncioTestCase):
         Tortoise._connections = {}
         Tortoise._inited = False
 
-    def assertListSortEqual(self, list1: List[Any], list2: List[Any], msg: Any = ...) -> None:
+    def assertListSortEqual(
+        self, list1: List[Any], list2: List[Any], msg: Any = ..., sorted_key: Optional[str] = None
+    ) -> None:
         if isinstance(list1[0], Model):
             super().assertListEqual(
-                sorted(list1, key=lambda x: x.pk), sorted(list2, key=lambda x: x.pk)
+                sorted(list1, key=lambda x: x.pk), sorted(list2, key=lambda x: x.pk), msg=msg
             )
-        elif isinstance(list1[0], tuple):
-            super().assertListEqual(sorted(list1), sorted(list2))
+        elif isinstance(list1[0], dict) and sorted_key:
+            super().assertListEqual(
+                sorted(list1, key=lambda x: x[sorted_key]),
+                sorted(list2, key=lambda x: x[sorted_key]),
+                msg=msg,
+            )
         else:
-            super().assertListEqual(list1, list2)
+            super().assertListEqual(sorted(list1), sorted(list2), msg=msg)
 
 
 class IsolatedTestCase(SimpleTestCase):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolve #1046 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

