### PR TITLE
Pydantic model generator: config_class implemented

### DIFF
--- a/tests/testmodels.py
+++ b/tests/testmodels.py
@@ -11,6 +11,7 @@ from enum import Enum, IntEnum
 from typing import Union
 
 import pytz
+from pydantic import Extra as PydanticExtra
 
 from tortoise import fields
 from tortoise.exceptions import NoValuesFetched, ValidationError
@@ -802,3 +803,28 @@ class Pair(Model):
     id = fields.IntField(pk=True)
     left = fields.ForeignKeyField("models.Single", related_name="lefts", null=True)
     right = fields.ForeignKeyField("models.Single", related_name="rights", null=True)
+
+
+class CamelCaseAliasPerson(Model):
+    """A model that generates camelized aliases automatically by
+    configuring config_class.
+    """
+
+    id = fields.IntField(pk=True)
+    first_name = fields.CharField(max_length=255)
+    last_name = fields.CharField(max_length=255)
+    full_address = fields.TextField(null=True)
+
+    class PydanticMeta:
+        class PydanticConfig:
+            @staticmethod
+            def camelize_var(var_name: str):
+                var_parts: list[str] = var_name.split("_")
+                return var_parts[0] + "".join([part.title() for part in var_parts[1:]])
+
+            title = "My custom title"
+            extra = PydanticExtra.ignore
+            alias_generator = camelize_var
+            allow_population_by_field_name = True
+
+        config_class = PydanticConfig


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR makes pydatic model generator more flexible by allowing user to customize generated model's config class.

## Description
<!--- Describe your changes in detail -->
* Pydantic's config class became customizable.
* Custom config class can be specified in model's PydanticMeta and model creator function.
* Note: Model creator will ignore `fields` config(User should use include/exclude and computed options).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It makes pydantic model generator more flexible.
<!--- If it fixes an open issue, please link to the issue here. -->
This PR will fix #862, and #1042 can also be fixed using alias_generator config (as I used in CamelCaseAliasPerson test model)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I used the project's async-capable test case to test what I implemented.
<!--- Include details of your testing environment, and the tests you ran to -->
I tested my own unit tests using green on Python 3.10
<!--- see how your change affects other areas of the code, etc. -->
It seems it doesn't affect anything else [Total failed tests count(4) didn't increase after my changes].

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.