### PR TITLE
Fix for None values in prefetch when fk_id==0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,12 @@ Changelog
 
 0.18
 ====
+0.18.3
+------
+Fixed
+^^^^^
+- Fix for prefetch_related with foreign key id == 0.
+
 0.18.2
 ------
 Fixed

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -239,6 +239,13 @@ class TestRelations(test.TestCase):
         event2 = await Event.filter(name="Test").prefetch_related("tournament")
         self.assertEqual(event2[0].tournament, tournament)
 
+    async def test_prefetch_related_fk_id_zero(self):
+        tournament = await Tournament.create(id=0, name="New Tournament")
+        await Event.create(name="Test", tournament_id=tournament.id)
+
+        event2 = await Event.filter(name="Test").prefetch_related("tournament")
+        self.assertEqual(event2[0].tournament, tournament)
+
     async def test_prefetch_related_rfk(self):
         tournament = await Tournament.create(name="New Tournament")
         event = await Event.create(name="Test", tournament_id=tournament.id)

--- a/tortoise/backends/base/executor.py
+++ b/tortoise/backends/base/executor.py
@@ -511,7 +511,7 @@ class BaseExecutor:
         related_objects_for_fetch: Dict[str, list] = {}
         relation_key_field = f"{field}_id"
         for instance in instance_list:
-            if getattr(instance, relation_key_field):
+            if getattr(instance, relation_key_field) != None:
                 key = cast(RelationalField, instance._meta.fields_map[field]).to_field
                 if key not in related_objects_for_fetch:
                     related_objects_for_fetch[key] = []


### PR DESCRIPTION
## Description
This PR fixes a bug with `prefetch_related` not actually being prefetched for entries with `fk_id==0`.
It happened because `getattr` returned `0` which is interpreted as `False` for `if` condition check.

## Motivation and Context
I have a table where foreign key id = 0 is a valid value.
Somehow `prefetch_related` always sets `fk_id` to `None` and  `fk` to `NoneAwaitable` for such records.

## How Has This Been Tested?
My project runs on Postgres and It works well. It doesn't break anything else.
I've made a simplest test for this case.
The change doesn't affect other tests, but I only ran `make test`

## Checklist:
- [ ] My code follows the code style of this project. (NOT SURE)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

