### PR TITLE
Fix: properly reveal type in Pydantic model

### DIFF
--- a/tests/contrib/test_pydantic.py
+++ b/tests/contrib/test_pydantic.py
@@ -3,6 +3,7 @@ import copy
 from tests.testmodels import Address, Employee, Event, JSONFields, Reporter, Team, Tournament
 from tortoise.contrib import test
 from tortoise.contrib.pydantic import pydantic_model_creator, pydantic_queryset_creator
+from tortoise.contrib.pydantic.base import _get_fetch_fields
 
 
 class TestPydantic(test.TestCase):
@@ -1292,3 +1293,24 @@ class TestPydanticCycle(test.TestCase):
                 "team_size": 2,
             },
         )
+
+
+class TestGetFetchFields(test.TestCase):
+    async def asyncSetUp(self) -> None:
+        await super(TestGetFetchFields, self).asyncSetUp()
+
+        self.Tournament_Pydantic = pydantic_model_creator(Tournament)
+        self.Employee_Pydantic = pydantic_model_creator(Employee)
+
+
+    def test_tournament_fields(self):
+        tourment_fields = _get_fetch_fields(self.Tournament_Pydantic, Tournament)
+        expected_fields = ['events__reporter', 'events__participants', 'events__address']
+
+        self.assertEqual(tourment_fields, expected_fields)
+
+    def test_employee_fields(self):
+        employee_fields = _get_fetch_fields(self.Employee_Pydantic, Employee)
+        expected_fields = ['talks_to__talks_to', 'talks_to__team_members', 'team_members__talks_to', 'team_members__team_members']
+
+        self.assertEqual(employee_fields, expected_fields)

--- a/tortoise/contrib/pydantic/base.py
+++ b/tortoise/contrib/pydantic/base.py
@@ -1,3 +1,4 @@
+import inspect
 from typing import TYPE_CHECKING, List, Type, Union
 
 import pydantic
@@ -20,7 +21,8 @@ def _get_fetch_fields(
     :return: The list of fields to be fetched
     """
     fetch_fields = []
-    for field_name, field_type in pydantic_class.__annotations__.items():
+    fields = inspect.get_annotations(pydantic_class, eval_str=True)
+    for field_name, field_type in fields.items():
         origin = getattr(field_type, "__origin__", None)
         if origin in (list, List, Union):
             field_type = field_type.__args__[0]

--- a/tortoise/contrib/pydantic/base.py
+++ b/tortoise/contrib/pydantic/base.py
@@ -1,4 +1,5 @@
-import inspect
+import sys
+
 from typing import TYPE_CHECKING, List, Type, Union
 
 import pydantic
@@ -21,8 +22,15 @@ def _get_fetch_fields(
     :return: The list of fields to be fetched
     """
     fetch_fields = []
-    fields = inspect.get_annotations(pydantic_class, eval_str=True)
-    for field_name, field_type in fields.items():
+
+    if sys.version_info.major == 3 and sys.version_info.minor >= 10:
+        import inspect
+
+        fields_pydantic = inspect.get_annotations(pydantic_class, eval_str=True)
+    else:
+        fields_pydantic = pydantic_class.__annotations__
+
+    for field_name, field_type in fields_pydantic.items():
         origin = getattr(field_type, "__origin__", None)
         if origin in (list, List, Union):
             field_type = field_type.__args__[0]


### PR DESCRIPTION
Support for annotation future. Resolves #1073

## Description
Changed type reveal method from `__annotations__` magic method to `inspect.get_annotations` with `eval_str` enabled.

## Motivation and Context
Possibility of using `from __future__ import annotations`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

