### PR TITLE
Re-added support for __set_name__ as the Python class datamodel presc…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Changelog
 Added
 ^^^^^
 - Added psycopg backend support.
+- Added __set_name__ support for custom fields
 Fixed
 ^^^^^
 - Fix `bulk_create` doesn't work correctly with more than 1 update_fields. (#1046)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -50,6 +50,7 @@ Contributors
 * Vinay Karanam ``@vinayinvicible``
 * Aleksandr Rozum ``@rozumalex``
 * Mojix Coder ``@MojixCoder``
+* Rick van Hattem ``@wolph``
 
 Special Thanks
 ==============

--- a/tests/fields/subclass_fields.py
+++ b/tests/fields/subclass_fields.py
@@ -76,3 +76,12 @@ class IntEnumField(IntField):
             return self.enum_type(value)
         except ValueError:
             raise ValueError(f"Database value {value} does not exist on Enum {self.enum_type}.")
+
+
+class NamedField(CharField):
+    def __init__(self, name: str, **kwargs):
+        super().__init__(128, **kwargs)
+        self.name = name
+
+    def __set_name__(self, owner: Type[Any], name: str) -> None:
+        assert self.name == name

--- a/tests/fields/subclass_models.py
+++ b/tests/fields/subclass_models.py
@@ -1,6 +1,6 @@
 from enum import Enum, IntEnum
 
-from tests.fields.subclass_fields import EnumField, IntEnumField
+from tests.fields.subclass_fields import EnumField, IntEnumField, NamedField
 from tortoise import fields
 from tortoise.models import Model
 
@@ -29,3 +29,7 @@ class ContactTypeEnum(IntEnum):
 class Contact(Model):
     id = fields.IntField(pk=True)
     type = IntEnumField(ContactTypeEnum, default=ContactTypeEnum.other)
+
+
+class NamedFields(Model):
+    a = NamedField("a")

--- a/tortoise/fields/base.py
+++ b/tortoise/fields/base.py
@@ -168,6 +168,13 @@ class Field(metaclass=_FieldMeta):
         self.model: Type["Model"] = model  # type: ignore
         self.reference: "Optional[Field]" = None
 
+    def __set_name__(self, owner: Type[Any], name: str) -> None:
+        """Set the name of the field on the model and the model.
+        Needed because Mypy is not yet __set_name__ aware:
+        https://github.com/python/mypy/issues/8057
+        """
+        ...
+
     def to_db_value(self, value: Any, instance: "Union[Type[Model], Model]") -> Any:
         """
         Converts from the Python type to the DB type.

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -619,8 +619,13 @@ class ModelMeta(type):
             meta.abstract = True
 
         new_class = super().__new__(mcs, name, bases, attrs)
-        for field in meta.fields_map.values():
+        for name, field in meta.fields_map.items():
             field.model = new_class  # type: ignore
+
+            # Call __set_name__ so fields know their own attribute name and parent model
+            # https://docs.python.org/3/reference/datamodel.html#object.__set_name__
+            if hasattr(field, "__set_name__"):
+                field.__set_name__(new_class, name)
 
         for fname, comment in _get_comments(new_class).items():  # type: ignore
             if fname in fields_map:


### PR DESCRIPTION
The Python class datamodel normally supports the [__set_name__](https://docs.python.org/3/reference/datamodel.html#object.__set_name__) method on a class, allowing you to do:
```python
class A:
    x = C()  # Automatically calls: x.__set_name__(A, 'x')
```

This is a very useful feature for custom fields but the `Model` metaclass has removed this functionality. With this small patch it's re-added.

## Description

Add `__set_name__` support to the `Model` metaclass
Add a `__set_name__` type stub to `Field` because mypy doesn't support `__set_name__` yet: https://github.com/python/mypy/issues/8057
Added a test to confirm it works

## Motivation and Context

I'm building a native Postgres enum field, and having the name of the field available in the class makes this a lot easier.
Instead of doing this:
```python
class SomeModel(Model):
    some_enum = EnumField('some_enum')
```

I can now do:
```python
class SomeModel(Model):
    some_enum = EnumField()
```

## How Has This Been Tested?

I've added a simple test to confirm that the test works. And I've run `make test` and `make style ci`

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

