### PR TITLE
Implement pydantic.from_tortoise_orm for lists of models

### DIFF
--- a/tests/contrib/test_pydantic.py
+++ b/tests/contrib/test_pydantic.py
@@ -839,6 +839,40 @@ class TestPydantic(test.TestCase):
             },
         )
 
+    async def test_address_list(self):
+        addressp = await self.Address_Pydantic.from_tortoise_orm_list([await Address.get(street="Ocean")])
+        # print(addressp.json(indent=4))
+        addressdict = addressp[0].dict()
+
+        # Remove timestamps
+        del addressdict["event"]["tournament"]["created"]
+        del addressdict["event"]["modified"]
+
+        self.assertEqual(
+            addressdict,
+            {
+                "city": "Santa Monica",
+                "street": "Ocean",
+                "event": {
+                    "event_id": self.event.event_id,
+                    "name": "Test",
+                    "tournament": {
+                        "id": self.tournament.id,
+                        "name": "New Tournament",
+                        "desc": None,
+                    },
+                    "reporter": {"id": self.reporter.id, "name": "The Reporter"},
+                    "participants": [
+                        {"id": self.team1.id, "name": "Onesies", "alias": None},
+                        {"id": self.team2.id, "name": "T-Shirts", "alias": None},
+                    ],
+                    "token": self.event.token,
+                    "alias": None,
+                },
+                "event_id": self.address.event_id,
+            },
+        )
+
     async def test_tournament(self):
         tournamentp = await self.Tournament_Pydantic.from_tortoise_orm(
             await Tournament.all().first()

--- a/tests/contrib/test_pydantic.py
+++ b/tests/contrib/test_pydantic.py
@@ -841,7 +841,6 @@ class TestPydantic(test.TestCase):
 
     async def test_address_list(self):
         addressp = await self.Address_Pydantic.from_tortoise_orm_list([await Address.get(street="Ocean")])
-        # print(addressp.json(indent=4))
         addressdict = addressp[0].dict()
 
         # Remove timestamps

--- a/tortoise/contrib/pydantic/base.py
+++ b/tortoise/contrib/pydantic/base.py
@@ -87,6 +87,33 @@ class PydanticModel(BaseModel):
         return super().from_orm(obj)
 
     @classmethod
+    async def from_tortoise_orm_list(cls, objs: List["Model"]) -> "List[PydanticModel]":
+        """
+        Returns a list of serializable pydantic models instances built from the provided model instance list.
+
+        .. note::
+
+            This will prefetch all the relations automatically. It is probably what you want.
+
+            If you don't want this, or require a ``sync`` method, look to using ``.from_orm()``.
+
+            In that case you'd have to manage  prefetching yourself,
+            or exclude relational fields from being part of the model using
+            :class:`tortoise.contrib.pydantic.creator.PydanticMeta`, or you would be
+            getting ``OperationalError`` exceptions.
+
+            This is due to how the ``asyncio`` framework forces I/O to happen in explicit ``await``
+            statements. Hence we can only do lazy-fetching during an awaited method.
+
+        :param objs: The List of Model instances you want serialized.
+        """
+        res = []
+        for obj in objs:
+            res.push(self.from_tortoise_orm(obj)
+        await asyncio.gather(*res)
+        return res
+
+    @classmethod
     async def from_queryset_single(cls, queryset: "QuerySetSingle") -> "PydanticModel":
         """
         Returns a serializable pydantic model instance for a single model

--- a/tortoise/contrib/pydantic/base.py
+++ b/tortoise/contrib/pydantic/base.py
@@ -108,11 +108,7 @@ class PydanticModel(BaseModel):
 
         :param objs: The List of Model instances you want serialized.
         """
-        res = []
-        for obj in objs:
-            res.push(self.from_tortoise_orm(obj)
-        res = await asyncio.gather(*res)
-        return res
+        return await asyncio.gather(*(self.from_tortoise_orm(obj) for obj in objs))
 
     @classmethod
     async def from_queryset_single(cls, queryset: "QuerySetSingle") -> "PydanticModel":

--- a/tortoise/contrib/pydantic/base.py
+++ b/tortoise/contrib/pydantic/base.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING, List, Type, Union
 
+import asyncio
 import pydantic
 from pydantic import BaseModel  # pylint: disable=E0611
 

--- a/tortoise/contrib/pydantic/base.py
+++ b/tortoise/contrib/pydantic/base.py
@@ -111,7 +111,7 @@ class PydanticModel(BaseModel):
         res = []
         for obj in objs:
             res.push(self.from_tortoise_orm(obj)
-        await asyncio.gather(*res)
+        res = await asyncio.gather(*res)
         return res
 
     @classmethod


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR provides a new function, similar to `from_tortoise_orm` but for a list of models instead of a single one.

This way, if there's some common logic that returns multiple instances (via a `list`) of a `Model`, they can be easily converted into a list of `Pydantic Models`.
## Description
<!--- Describe your changes in detail -->
Added a function that iterates over the list of Models passed as parameter, and calls `from_tortoise_orm` for each one. It then `gathers` all coroutines and returns the result.

Basically, it's a wrapper around `from_tortoise_orm`
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've created the test `test_address_list` in `tests/contrib/test_pydantic.py`
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

