### PR TITLE
Update FastAPI example test to use AnyIO

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Changelog
 Fixed
 ^^^^^
 - Mixin does not work. (#1133)
+- FastAPI example test not working. (#1029)
 
 0.19.1
 ------

--- a/examples/fastapi/_tests.py
+++ b/examples/fastapi/_tests.py
@@ -1,6 +1,5 @@
 # mypy: no-disallow-untyped-decorators
 # pylint: disable=E0611,E0401
-import asyncio
 from typing import Generator
 
 import pytest
@@ -19,12 +18,7 @@ def client() -> Generator:
     finalizer()
 
 
-@pytest.fixture(scope="module")
-def event_loop(client: TestClient) -> Generator:
-    yield client.task.get_loop()  # type: ignore
-
-
-def test_create_user(client: TestClient, event_loop: asyncio.AbstractEventLoop):  # nosec
+def test_create_user(client: TestClient):  # nosec
     response = client.post("/users", json={"username": "admin"})
     assert response.status_code == 200, response.text
     data = response.json()
@@ -36,5 +30,5 @@ def test_create_user(client: TestClient, event_loop: asyncio.AbstractEventLoop):
         user = await Users.get(id=user_id)
         return user
 
-    user_obj = event_loop.run_until_complete(get_user_by_db())
+    user_obj = client.portal.call(get_user_by_db)
     assert user_obj.id == user_id


### PR DESCRIPTION
## Description
- Use `client.portal.call` rather than `client.get_event_loop().run_until_complete` to run async function `get_user_by_db()`.
- Replace `event_loop` fixture with `portal` fixture which just ensures that the portal has been instantiated within the client so that the `Optional` can be dropped from the type hint.
 
## Motivation and Context
Fixes https://github.com/tortoise/tortoise-orm/issues/1029. See comment https://github.com/tortoise/tortoise-orm/issues/1029#issuecomment-1143104900 for details.

## How Has This Been Tested?
I ran `make test` and ensured all tests passed.

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
~- [ ] My change requires a change to the documentation.~
~- [ ] I have updated the documentation accordingly.~
~- [ ] I have added tests to cover my changes.~

- Did not add tests since this was to fix an existing test.
- It looks like documentation should automatically pull the updated example code.

