### PR TITLE
Fix work with Oracle and added new 'schema' attribute to Model's Meta

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,11 +10,13 @@ Changelog
 ====
 0.19.2
 ------
+Added
+^^^^^
+- Added `schema` attribute to Model's Meta to specify exact schema to use with the model.
 Fixed
 ^^^^^
 - Mixin does not work. (#1133)
 - `using_db` wrong position in model shortcut methods. (#1150)
-- Added `schema` attribute to Model's Meta to specify exact schema to use with the model.
 - Fixed connection to `Oracle` database by adding database info to DBQ in connection string.
 - Fixed ORA-01435 error while using `Oracle` database (#1155)
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Fixed
 ^^^^^
 - Mixin does not work. (#1133)
 - `using_db` wrong position in model shortcut methods. (#1150)
+- Added `schema` attribute to Model's Meta to specify exact schema to use with the model.
+- Fixed connection to Oracle database by adding database info to DBQ in connection string.
 
 0.19.1
 ------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,8 @@ Fixed
 - Mixin does not work. (#1133)
 - `using_db` wrong position in model shortcut methods. (#1150)
 - Added `schema` attribute to Model's Meta to specify exact schema to use with the model.
-- Fixed connection to Oracle database by adding database info to DBQ in connection string.
+- Fixed connection to `Oracle` database by adding database info to DBQ in connection string.
+- Fixed ORA-01435 error while using `Oracle` database (#1155)
 
 0.19.1
 ------

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -50,6 +50,7 @@ Contributors
 * Vinay Karanam ``@vinayinvicible``
 * Aleksandr Rozum ``@rozumalex``
 * Mojix Coder ``@MojixCoder``
+* Paul Serov ``@thakryptex``
 
 Special Thanks
 ==============

--- a/docs/databases.rst
+++ b/docs/databases.rst
@@ -179,7 +179,7 @@ MySQL optional parameters are pass-though parameters to the driver, see `here <h
 MSSQL/Oracle
 ============
 
-DB URL is typically in the form of :samp:`mssql or oracle://myuser:mypass@db.host:1433/somedb?driver=the odbc driver`
+DB URL is typically in the form of :samp:`mssql or oracle://myuser:mypass@db.host:1433/somedb?driver={the odbc driver}`
 
 Required Parameters
 -------------------
@@ -195,7 +195,7 @@ Required Parameters
 ``database``:
     Database to use.
 ``driver``:
-    The ODBC driver to use.
+    The ODBC driver to use. Actual name of the ODBC driver in your `odbcinst.ini` file (you can find it's location using `odbcinst -j` command). It requires `unixodbc` to be installed in your system.
 
 Optional parameters:
 --------------------
@@ -209,7 +209,13 @@ MSSQL/Oracle optional parameters are pass-though parameters to the driver, see `
 ``pool_recycle`` (defaults to ``-1``):
     Pool recycle timeout in seconds.
 ``echo`` (defaults to ``False``):
-    Set to `True`` to echo SQL queries (debug only)
+    Set to ``True`` to echo SQL queries (debug only)
+
+Encoding in Oracle:
+============
+
+If you get ``???`` values in Varchar fields instead of your actual text (russian/chinese/etc), then set ``NLS_LANG`` variable in your client environment to support UTF8. For example, `"American_America.UTF8"`.
+
 
 Passing in custom SSL Certificates
 ==================================

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -182,6 +182,11 @@ The ``Meta`` class
 
         Set to ``True`` to indicate this is an abstract class
 
+    .. attribute:: schema
+        :annotation: = ""
+
+        Set this to configure a schema name, where table exists
+
     .. attribute:: table
         :annotation: = ""
 

--- a/tests/contrib/test_pydantic.py
+++ b/tests/contrib/test_pydantic.py
@@ -1,6 +1,15 @@
 import copy
 
-from tests.testmodels import Address, Employee, Event, JSONFields, Reporter, Team, Tournament, User
+from tests.testmodels import (
+    Address,
+    Employee,
+    Event,
+    JSONFields,
+    Reporter,
+    Team,
+    Tournament,
+    User,
+)
 from tortoise.contrib import test
 from tortoise.contrib.pydantic import pydantic_model_creator, pydantic_queryset_creator
 

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -1,6 +1,13 @@
 import datetime
 
-from tests.testmodels import DatetimeFields, Event, IntFields, Reporter, Team, Tournament
+from tests.testmodels import (
+    DatetimeFields,
+    Event,
+    IntFields,
+    Reporter,
+    Team,
+    Tournament,
+)
 from tortoise.contrib import test
 from tortoise.contrib.test.condition import NotEQ
 from tortoise.expressions import F, Q

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -1,4 +1,12 @@
-from tests.testmodels import Event, IntFields, MinRelation, Node, Reporter, Tournament, Tree
+from tests.testmodels import (
+    Event,
+    IntFields,
+    MinRelation,
+    Node,
+    Reporter,
+    Tournament,
+    Tree,
+)
 from tortoise import connections
 from tortoise.contrib import test
 from tortoise.contrib.test.condition import NotEQ

--- a/tests/test_unique_together.py
+++ b/tests/test_unique_together.py
@@ -1,4 +1,8 @@
-from tests.testmodels import Tournament, UniqueTogetherFields, UniqueTogetherFieldsWithFK
+from tests.testmodels import (
+    Tournament,
+    UniqueTogetherFields,
+    UniqueTogetherFieldsWithFK,
+)
 from tortoise.contrib import test
 from tortoise.exceptions import IntegrityError
 

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -438,8 +438,8 @@ class Tortoise:
         for app in cls.apps.values():
             for model in app.values():
                 model._meta.finalise_model()
-                model._meta.basetable = Table(model._meta.db_table)
-                model._meta.basequery = model._meta.db.query_class.from_(model._meta.db_table)
+                model._meta.basetable = Table(name=model._meta.db_table, schema=model._meta.schema)
+                model._meta.basequery = model._meta.db.query_class.from_(model._meta.basetable)
                 model._meta.basequery_all_fields = model._meta.basequery.select(
                     *model._meta.db_fields
                 )

--- a/tortoise/backends/asyncpg/client.py
+++ b/tortoise/backends/asyncpg/client.py
@@ -14,7 +14,10 @@ from tortoise.backends.base.client import (
     TransactionContext,
     TransactionContextPooled,
 )
-from tortoise.backends.base_postgres.client import BasePostgresClient, translate_exceptions
+from tortoise.backends.base_postgres.client import (
+    BasePostgresClient,
+    translate_exceptions,
+)
 from tortoise.exceptions import (
     DBConnectionError,
     IntegrityError,

--- a/tortoise/backends/base/config_generator.py
+++ b/tortoise/backends/base/config_generator.py
@@ -164,7 +164,7 @@ def expand_db_url(db_url: str, testing: bool = False) -> dict:
         raise ConfigurationError("Port is not an integer")
     if vmap.get("username"):
         # Pass username as None, instead of empty string,
-        # to let asyncpg retrieve username from evionment variable or OS user
+        # to let asyncpg retrieve username from environment variable or OS user
         params[vmap["username"]] = url.username or None
     if vmap.get("password"):
         # asyncpg accepts None for password, but aiomysql not

--- a/tortoise/backends/base_postgres/client.py
+++ b/tortoise/backends/base_postgres/client.py
@@ -1,6 +1,16 @@
 import abc
 from functools import wraps
-from typing import Any, Callable, List, Optional, SupportsInt, Tuple, Type, TypeVar, Union
+from typing import (
+    Any,
+    Callable,
+    List,
+    Optional,
+    SupportsInt,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
 
 from pypika import PostgreSQLQuery
 

--- a/tortoise/backends/mssql/client.py
+++ b/tortoise/backends/mssql/client.py
@@ -2,10 +2,18 @@ from typing import Any, SupportsInt
 
 from pypika.dialects import MSSQLQuery
 
-from tortoise.backends.base.client import Capabilities, TransactionContext, TransactionContextPooled
+from tortoise.backends.base.client import (
+    Capabilities,
+    TransactionContext,
+    TransactionContextPooled,
+)
 from tortoise.backends.mssql.executor import MSSQLExecutor
 from tortoise.backends.mssql.schema_generator import MSSQLSchemaGenerator
-from tortoise.backends.odbc.client import ODBCClient, ODBCTransactionWrapper, translate_exceptions
+from tortoise.backends.odbc.client import (
+    ODBCClient,
+    ODBCTransactionWrapper,
+    translate_exceptions,
+)
 
 
 class MSSQLClient(ODBCClient):

--- a/tortoise/backends/oracle/client.py
+++ b/tortoise/backends/oracle/client.py
@@ -43,7 +43,10 @@ class OracleClient(ODBCClient):
     ) -> None:
         super().__init__(**kwargs)
         self.password = password
-        self.dsn = f"DRIVER={driver};DBQ={host}:{port};UID={user};PWD={password};"
+        dbq = f'{host}:{port}'
+        if self.database:
+            dbq += f'/{self.database}'
+        self.dsn = f"DRIVER={driver};DBQ={dbq};UID={user};PWD={password};"
 
     def _in_transaction(self) -> "TransactionContext":
         return TransactionContextPooled(TransactionWrapper(self))

--- a/tortoise/backends/oracle/client.py
+++ b/tortoise/backends/oracle/client.py
@@ -20,7 +20,11 @@ from tortoise.backends.base.client import (
     TransactionContext,
     TransactionContextPooled,
 )
-from tortoise.backends.odbc.client import ODBCClient, ODBCTransactionWrapper, translate_exceptions
+from tortoise.backends.odbc.client import (
+    ODBCClient,
+    ODBCTransactionWrapper,
+    translate_exceptions,
+)
 from tortoise.backends.oracle.executor import OracleExecutor
 from tortoise.backends.oracle.schema_generator import OracleSchemaGenerator
 
@@ -44,9 +48,9 @@ class OracleClient(ODBCClient):
         super().__init__(**kwargs)
         self.user = user.upper()
         self.password = password
-        dbq = f'{host}:{port}'
+        dbq = f"{host}:{port}"
         if self.database:
-            dbq += f'/{self.database}'
+            dbq += f"/{self.database}"
         self.dsn = f"DRIVER={driver};DBQ={dbq};UID={user};PWD={password};"
 
     def _in_transaction(self) -> "TransactionContext":
@@ -97,7 +101,7 @@ class OraclePoolConnectionWrapper(PoolConnectionWrapper):
 
     async def __aenter__(self):
         connection = await super(OraclePoolConnectionWrapper, self).__aenter__()  # type: ignore
-        if getattr(self.client, 'database', False) and not hasattr(connection, "current_schema"):
+        if getattr(self.client, "database", False) and not hasattr(connection, "current_schema"):
             await connection.execute(f'ALTER SESSION SET CURRENT_SCHEMA = "{self.client.user}"')
             await connection.execute("ALTER SESSION SET NLS_DATE_FORMAT = 'YYYY-MM-DD'")
             await connection.execute(

--- a/tortoise/backends/sqlite/client.py
+++ b/tortoise/backends/sqlite/client.py
@@ -17,7 +17,11 @@ from tortoise.backends.base.client import (
 )
 from tortoise.backends.sqlite.executor import SqliteExecutor
 from tortoise.backends.sqlite.schema_generator import SqliteSchemaGenerator
-from tortoise.exceptions import IntegrityError, OperationalError, TransactionManagementError
+from tortoise.exceptions import (
+    IntegrityError,
+    OperationalError,
+    TransactionManagementError,
+)
 
 FuncType = Callable[..., Any]
 F = TypeVar("F", bound=FuncType)

--- a/tortoise/expressions.py
+++ b/tortoise/expressions.py
@@ -1,5 +1,16 @@
 import operator
-from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Tuple, Type, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
 
 from pypika import Case as PypikaCase
 from pypika import Field as PypikaField
@@ -11,7 +22,11 @@ from pypika.terms import Term
 from pypika.utils import format_alias_sql
 
 from tortoise.exceptions import ConfigurationError, FieldError, OperationalError
-from tortoise.fields.relational import BackwardFKRelation, ForeignKeyFieldInstance, RelationalField
+from tortoise.fields.relational import (
+    BackwardFKRelation,
+    ForeignKeyFieldInstance,
+    RelationalField,
+)
 from tortoise.query_utils import QueryModifier, _get_joins_for_related_field
 
 if TYPE_CHECKING:  # pragma: nocoverage

--- a/tortoise/fields/__init__.py
+++ b/tortoise/fields/__init__.py
@@ -1,4 +1,11 @@
-from tortoise.fields.base import CASCADE, NO_ACTION, RESTRICT, SET_DEFAULT, SET_NULL, Field
+from tortoise.fields.base import (
+    CASCADE,
+    NO_ACTION,
+    RESTRICT,
+    SET_DEFAULT,
+    SET_NULL,
+    Field,
+)
 from tortoise.fields.data import (
     BigIntField,
     BinaryField,

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -218,7 +218,7 @@ class MetaInfo:
         self.abstract: bool = getattr(meta, "abstract", False)
         self.manager: Manager = getattr(meta, "manager", Manager())
         self.db_table: str = getattr(meta, "table", "")
-        self.schema: str = getattr(meta, "schema", None)
+        self.schema: Optional[str] = getattr(meta, "schema", None)
         self.app: Optional[str] = getattr(meta, "app", None)
         self.unique_together: Tuple[Tuple[str, ...], ...] = get_together(meta, "unique_together")
         self.indexes: Tuple[Tuple[str, ...], ...] = get_together(meta, "indexes")

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -178,6 +178,7 @@ class MetaInfo:
     __slots__ = (
         "abstract",
         "db_table",
+        "schema",
         "app",
         "fields",
         "db_fields",
@@ -217,6 +218,7 @@ class MetaInfo:
         self.abstract: bool = getattr(meta, "abstract", False)
         self.manager: Manager = getattr(meta, "manager", Manager())
         self.db_table: str = getattr(meta, "table", "")
+        self.schema: str = getattr(meta, "schema", None)
         self.app: Optional[str] = getattr(meta, "app", None)
         self.unique_together: Tuple[Tuple[str, ...], ...] = get_together(meta, "unique_together")
         self.indexes: Tuple[Tuple[str, ...], ...] = get_together(meta, "indexes")

--- a/tortoise/query_utils.py
+++ b/tortoise/query_utils.py
@@ -5,7 +5,11 @@ from pypika import Table
 from pypika.terms import Criterion
 
 from tortoise.exceptions import OperationalError
-from tortoise.fields.relational import BackwardFKRelation, ManyToManyFieldInstance, RelationalField
+from tortoise.fields.relational import (
+    BackwardFKRelation,
+    ManyToManyFieldInstance,
+    RelationalField,
+)
 
 if TYPE_CHECKING:  # pragma: nocoverage
     from tortoise.queryset import QuerySet


### PR DESCRIPTION
## Description
- Updated the connection string for Oracle Client (DBQ key).
- Added new `schema` attribute to Model's Meta.
- Fixed ORA-01435 error while using Oracle database (#1155).
- Updated docs.

## Motivation and Context
- I had a problem, that I can't connect to existing Oracle database. It was throwing an error that database info is not provided or something like that. So I've checked how it was written and found that existing connection string for Oracle connection wasn't full. That lead me to the first fix: I updated the connection string for Oracle Client.
- Then I had a problem that I need to specify the schema that I'm working on (as for MsSQL and Oracle, because I have several DB). And I found in code that it was almost ready to set schema and properly paste it into queries. So few changes and that worked.
- Then I had a error from Oracle that user doesn't exists. I created an issue #1155. Then I finally found the reason of this message. And fixed it. It was putting database name into query, while schema name was needed. So I've passed user attribute instead of database attribute, because in Oracle database schema name is equal to a username.

## How Has This Been Tested?
I've run all of the existing tests and they all passed.
And I've tested this code in my project, that it do exactly what I wanted and what wasn't working before.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

