### PR TITLE
feat(filter): add contains for json field

### DIFF
--- a/tortoise/filters.py
+++ b/tortoise/filters.py
@@ -314,6 +314,12 @@ def get_json_filter(field_name: str, source_field: str):
         f"{field_name}__contains": {
             "field": actual_field_name,
             "source_field": source_field,
+            "operator": contains,
+            "value_encoder": string_encoder,
+        },
+        f"{field_name}__json_contains": {
+            "field": actual_field_name,
+            "source_field": source_field,
             "operator": json_contains,
         },
         f"{field_name}__contained_by": {


### PR DESCRIPTION
fix #1161

## Description

rename contains to json_contains for json_fields.

## Motivation and Context

contains for JSONField behavior is not the same with other field, it's very strong and unexpected.

## How Has This Been Tested?

## Checklist:

This is a breaking change, I will update test / docs latter if tortoise team think it's ok to proceed.

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

