### PR TITLE
Fixed: MySQL ssl option cast

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Fixed
 - `using_db` wrong position in model shortcut methods. (#1150)
 - Fixed connection to `Oracle` database by adding database info to DBQ in connection string.
 - Fixed ORA-01435 error while using `Oracle` database (#1155)
+- Fixed processing of `ssl` option in MySQL connection string.
 
 0.19.1
 ------

--- a/tests/backends/test_db_url.py
+++ b/tests/backends/test_db_url.py
@@ -311,7 +311,7 @@ class TestConfigGenerator(test.SimpleTestCase):
     def test_mysql_params(self):
         res = expand_db_url(
             "mysql://root:@127.0.0.1:3306/test?AHA=5&moo=yes&maxsize=20&minsize=5"
-            "&connect_timeout=1.5&echo=1"
+            "&connect_timeout=1.5&echo=1&ssl=True"
         )
         self.assertEqual(
             res,
@@ -331,6 +331,7 @@ class TestConfigGenerator(test.SimpleTestCase):
                     "echo": True,
                     "charset": "utf8mb4",
                     "sql_mode": "STRICT_TRANS_TABLES",
+                    "ssl": True,
                 },
             },
         )

--- a/tortoise/backends/base/config_generator.py
+++ b/tortoise/backends/base/config_generator.py
@@ -82,6 +82,7 @@ DB_LOOKUP: Dict[str, Dict[str, Any]] = {
             "no_delay": bool,
             "use_unicode": bool,
             "pool_recycle": int,
+            "ssl": bool,
         },
     },
     "mssql": {


### PR DESCRIPTION
Added cast of `ssl` option for MySQL backend.

## Description
Added `ssl` option to `cast` dictionary in `config_generator.py`.

## Motivation and Context
When using `ssl` option in MySQL connection string like `mysql://root:root@localhost:3306/db?ssl=True` it passed to driver as string. So we get `AttributeError: 'str' object has no attribute 'wrap_bio'` because driver expects `bool` or `SSLContext`.

After casting `ssl` option value to `bool` connection established successsfully.

## How Has This Been Tested?

Tested manually on Azure hosted MySQL server.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

