### PR TITLE
Fix typo in docs

### DIFF
--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -833,7 +833,7 @@ class Model(metaclass=ModelMeta):
         """
         Register listener to current model class for special Signal.
 
-        :param signal: one of tortoise.signals.Signal
+        :param signal: one of tortoise.signals.Signals
         :param listener: callable listener
 
         :raises ConfigurationError: When listener is not callable


### PR DESCRIPTION
## Description
Fixes a typo in the models docs

## Motivation and Context
`Signals` is the actual name of the enum

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

