### PR TITLE
Move codespell check in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ endif
 	#pylint -d C,W,R $(checkfiles)
 	#bandit -r $(checkfiles)
 	twine check dist/*
+	codespell $(checkfiles)
 
 lint: deps build
 ifneq ($(shell which black),)
@@ -39,7 +40,6 @@ endif
 	#pylint $(checkfiles)
 	bandit -r $(checkfiles)
 	twine check dist/*
-	codespell $(checkfiles)
 
 test: deps
 	$(py_warn) TORTOISE_TEST_DB=sqlite://:memory: pytest $(pytest_opts)


### PR DESCRIPTION
## Description
Accidently put it under the lint section instead of the checks in #1165 

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
