### PR TITLE
fix: use correct type hinting for QuerySetSingle

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Fixed
 - Fixed connection to `Oracle` database by adding database info to DBQ in connection string.
 - Fixed ORA-01435 error while using `Oracle` database (#1155)
 - Fixed processing of `ssl` option in MySQL connection string.
+- Fixed type hinting for `QuerySetSingle`.
 
 0.19.1
 ------

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -52,16 +52,15 @@ if TYPE_CHECKING:  # pragma: nocoverage
     from tortoise.models import Model
 
 MODEL = TypeVar("MODEL", bound="Model")
-T_co = TypeVar("T_co", covariant=True)
 
 
-class QuerySetSingle(Protocol[T_co]):
+class QuerySetSingle(Protocol[MODEL]):
     """
     Awaiting on this will resolve a single instance of the Model object, and not a sequence.
     """
 
     # pylint: disable=W0104
-    def __await__(self) -> Generator[Any, None, T_co]:
+    def __await__(self) -> Generator[Any, None, MODEL]:
         ...  # pragma: nocoverage
 
     def prefetch_related(self, *args: Union[str, Prefetch]) -> "QuerySetSingle[MODEL]":

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -52,27 +52,28 @@ if TYPE_CHECKING:  # pragma: nocoverage
     from tortoise.models import Model
 
 MODEL = TypeVar("MODEL", bound="Model")
+T_co = TypeVar("T_co", covariant=True)
 
 
-class QuerySetSingle(Protocol[MODEL]):
+class QuerySetSingle(Protocol[T_co]):
     """
     Awaiting on this will resolve a single instance of the Model object, and not a sequence.
     """
 
     # pylint: disable=W0104
-    def __await__(self) -> Generator[Any, None, MODEL]:
+    def __await__(self) -> Generator[Any, None, T_co]:
         ...  # pragma: nocoverage
 
-    def prefetch_related(self, *args: Union[str, Prefetch]) -> "QuerySetSingle[MODEL]":
+    def prefetch_related(self, *args: Union[str, Prefetch]) -> "QuerySetSingle[T_co]":
         ...  # pragma: nocoverage
 
-    def select_related(self, *args: str) -> "QuerySetSingle[MODEL]":
+    def select_related(self, *args: str) -> "QuerySetSingle[T_co]":
         ...  # pragma: nocoverage
 
-    def annotate(self, **kwargs: Function) -> "QuerySetSingle[MODEL]":
+    def annotate(self, **kwargs: Function) -> "QuerySetSingle[T_co]":
         ...  # pragma: nocoverage
 
-    def only(self, *fields_for_select: str) -> "QuerySetSingle[MODEL]":
+    def only(self, *fields_for_select: str) -> "QuerySetSingle[T_co]":
         ...  # pragma: nocoverage
 
     def values_list(self, *fields_: str, flat: bool = False) -> "ValuesListQuery":


### PR DESCRIPTION
## Description
This PR makes `QuerySetSingle`'s functions use `T_co` fully (like the class), instead of using `MODEL` for no reason.

## Motivation and Context
Honestly? The major reason why I did this is because the type hinting annoyed me when I was trying to use `prefetch_related` with a `QuerySetSingle`. Instead of returning the proper `QuerySetSingle` for the object, it returned, literally, `QuerySetSingle[MODEL]`, which wasn't all that helpful. I saw that this was a bug other people had too, and decided to fix it just because it seemed simple enough.

After doing this, `prefetch_related` does work as expected with `QuerySetSingle`.

Fixes #701.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed. (Besides for the ones that were failing before this change.)

