### PR TITLE
Additional Postgresql JSON Functions

### DIFF
--- a/tests/contrib/test_json_functions.py
+++ b/tests/contrib/test_json_functions.py
@@ -1,0 +1,89 @@
+from datetime import datetime
+from typing import List
+
+from tests.testmodels import JSONFields
+from tortoise.contrib import test
+
+
+class TestJSONFunctions(test.TestCase):
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
+        self.created_obj = await JSONFields.create(
+            data={
+                "test_val": "word1",
+                "test_int_val": 123,
+                "test_date_val": datetime(1970, 1, 1, 12, 36, 59, 123456),
+            }
+        )
+
+    async def get_filter(self, **kwargs) -> JSONFields:
+        return await JSONFields.get(data__filter=kwargs)
+
+    def match_ids(self, *args: List[JSONFields]):
+        for obj in args:
+            self.assertEqual(self.created_obj.id, obj.id)
+
+    @test.requireCapability(dialect="postgres")
+    async def test_postgres_json_in(self):
+        filtered_in = await self.get_filter(test_val__in=["word1", "word2"])
+        filtered_not_in = await self.get_filter(test_val__not_in=["word3", "word4"])
+
+        self.match_ids(filtered_in, filtered_not_in)
+
+    @test.requireCapability(dialect="postgres")
+    async def test_postgres_json_defaults(self):
+        filtered_not = await self.get_filter(test_val__not="word2")
+        filtered_isnull = await self.get_filter(test_val__isnull=False)
+        filtered_not_isnull = await self.get_filter(test_val__not_isnull=True)
+
+        self.match_ids(filtered_not, filtered_isnull, filtered_not_isnull)
+
+    @test.requireCapability(dialect="postgres")
+    async def test_postgres_json_int_comparisons(self):
+        filtered_gt = await self.get_filter(test_int_val__gt=100)
+        filtered_gte = await self.get_filter(test_int_val__gte=100)
+        filtered_lt = await self.get_filter(test_int_val__lt=200)
+        filtered_lte = await self.get_filter(test_int_val__lte=200)
+        filtered_range = await self.get_filter(test_int_val__range=[100, 200])
+
+        self.match_ids(filtered_gt, filtered_gte, filtered_lt, filtered_lte, filtered_range)
+
+    @test.requireCapability(dialect="postgres")
+    async def test_postgres_json_string_comparisons(self):
+        filtered_contains = await self.get_filter(test_val__contains="ord")
+        filtered_icontains = await self.get_filter(test_val__icontains="OrD")
+        filtered_startswith = await self.get_filter(test_val__startswith="wor")
+        filtered_istartswith = await self.get_filter(test_val__istartswith="wOr")
+        filtered_endswith = await self.get_filter(test_val__endswith="rd1")
+        filtered_iendswith = await self.get_filter(test_val__iendswith="Rd1")
+        filtered_iexact = await self.get_filter(test_val__iexact="wOrD1")
+
+        self.match_ids(
+            filtered_contains,
+            filtered_icontains,
+            filtered_startswith,
+            filtered_istartswith,
+            filtered_endswith,
+            filtered_iendswith,
+            filtered_iexact,
+        )
+
+    @test.requireCapability(dialect="postgres")
+    async def test_postgres_date_comparisons(self):
+        filtered_year = await self.get_filter(test_date_val__year=1970)
+        filtered_month = await self.get_filter(test_date_val__month=1)
+        filtered_day = await self.get_filter(test_date_val__day=1)
+        filtered_hour = await self.get_filter(test_date_val__hour=12)
+        filtered_minute = await self.get_filter(test_date_val__minute=36)
+        filtered_second = await self.get_filter(test_date_val__second=59.123456)
+        filtered_microsecond = await self.get_filter(test_date_val__microsecond=59123456)
+
+        self.match_ids(
+            filtered_year,
+            filtered_month,
+            filtered_day,
+            filtered_hour,
+            filtered_minute,
+            filtered_second,
+            filtered_microsecond,
+        )

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -119,9 +119,11 @@ class Tortoise:
                 return cls.apps[related_app_name][related_model_name]
             except KeyError:
                 if related_app_name not in cls.apps:
-                    raise ConfigurationError(f"No app with name '{related_app_name}' registered."
-                                             f" Please check your model names in ForeignKeyFields"
-                                             f" and configurations.")
+                    raise ConfigurationError(
+                        f"No app with name '{related_app_name}' registered."
+                        f" Please check your model names in ForeignKeyFields"
+                        f" and configurations."
+                    )
                 raise ConfigurationError(
                     f"No model with name '{related_model_name}' registered in"
                     f" app '{related_app_name}'."

--- a/tortoise/backends/base/executor.py
+++ b/tortoise/backends/base/executor.py
@@ -42,7 +42,8 @@ if TYPE_CHECKING:  # pragma: nocoverage
     from tortoise.queryset import QuerySet
 
 EXECUTOR_CACHE: Dict[
-    Tuple[str, Optional[str], str], Tuple[list, str, list, str, Dict[str, Callable], str, Dict[str, str]]
+    Tuple[str, Optional[str], str],
+    Tuple[list, str, list, str, Dict[str, Callable], str, Dict[str, str]],
 ] = {}
 
 

--- a/tortoise/contrib/postgres/json_functions.py
+++ b/tortoise/contrib/postgres/json_functions.py
@@ -3,9 +3,34 @@ import operator
 from typing import Any, Callable, Dict, List
 
 from pypika.enums import JSONOperators
+from pypika.functions import Cast
 from pypika.terms import BasicCriterion, Criterion, Term, ValueWrapper
 
-from tortoise.filters import is_null, not_equal, not_null
+from tortoise.fields.data import DatetimeField
+from tortoise.filters import (
+    between_and,
+    contains,
+    ends_with,
+    extract_day_equal,
+    extract_hour_equal,
+    extract_microsecond_equal,
+    extract_minute_equal,
+    extract_month_equal,
+    extract_quarter_equal,
+    extract_second_equal,
+    extract_week_equal,
+    extract_year_equal,
+    insensitive_contains,
+    insensitive_ends_with,
+    insensitive_exact,
+    insensitive_starts_with,
+    is_in,
+    is_null,
+    not_equal,
+    not_in,
+    not_null,
+    starts_with,
+)
 
 
 def postgres_json_contains(field: Term, value: str) -> Criterion:
@@ -20,6 +45,29 @@ operator_keywords = {
     "not": not_equal,
     "isnull": is_null,
     "not_isnull": not_null,
+    "in": is_in,
+    "not_in": not_in,
+    "gte": operator.ge,
+    "gt": operator.gt,
+    "lte": operator.le,
+    "lt": operator.lt,
+    "range": between_and,
+    "contains": contains,
+    "startswith": starts_with,
+    "endswith": ends_with,
+    "iexact": insensitive_exact,
+    "icontains": insensitive_contains,
+    "istartswith": insensitive_starts_with,
+    "iendswith": insensitive_ends_with,
+    "year": extract_year_equal,
+    "quarter": extract_quarter_equal,
+    "month": extract_month_equal,
+    "week": extract_week_equal,
+    "day": extract_day_equal,
+    "hour": extract_hour_equal,
+    "minute": extract_minute_equal,
+    "second": extract_second_equal,
+    "microsecond": extract_microsecond_equal,
 }
 
 
@@ -38,27 +86,48 @@ def _get_json_criterion(items: List):
 def _create_json_criterion(items: List, field_term: Term, operator_: Callable, value: str):
     if len(items) == 1:
         term = items.pop(0)
-        return operator_(
-            BasicCriterion(JSONOperators.GET_TEXT_VALUE, field_term, ValueWrapper(term)), value
+        criteria = (
+            BasicCriterion(JSONOperators.GET_TEXT_VALUE, field_term, ValueWrapper(term)),
+            value,
+        )
+    else:
+        criteria = (
+            BasicCriterion(JSONOperators.GET_JSON_VALUE, field_term, _get_json_criterion(items)),
+            value,
         )
 
-    return operator_(
-        BasicCriterion(JSONOperators.GET_JSON_VALUE, field_term, _get_json_criterion(items)), value
-    )
+    if operator_ in [
+        extract_day_equal,
+        extract_hour_equal,
+        extract_microsecond_equal,
+        extract_minute_equal,
+        extract_month_equal,
+        extract_quarter_equal,
+        extract_second_equal,
+        extract_week_equal,
+        extract_year_equal,
+    ]:
+        criteria = Cast(criteria[0], "timestamp"), criteria[1]
+
+    return operator_(*criteria)
 
 
-def _serialize_value(value: Any):
-    if type(value) in [dict, list]:
+def _serialize_value(value: Any, operator_: Callable):
+    if type(value) in [dict, list] and operator_ in [is_null, not_null, not_equal, operator.eq]:
         return json.dumps(value)
+    elif type(value) in [dict, list, tuple]:
+        return list(map(str, value))
+    elif type(value) is int:
+        return str(value)
+
     return value
 
 
 def postgres_json_filter(field: Term, value: Dict) -> Criterion:
     ((key, filter_value),) = value.items()
-    filter_value = _serialize_value(filter_value)
     key_parts = [int(item) if item.isdigit() else str(item) for item in key.split("__")]
     operator_ = operator.eq
     if key_parts[-1] in operator_keywords:
         operator_ = operator_keywords[str(key_parts.pop(-1))]
-
+    filter_value = _serialize_value(filter_value, operator_)
     return _create_json_criterion(key_parts, field, operator_, filter_value)


### PR DESCRIPTION
Added more JSON filter functions under postgresql.

## Description
Added most of the normal query API's to postgres's contrib json functions. Everything except for `search` command has been added along with tests.

## Motivation and Context
It solved the lack of the ability to query the values inside of json functions, leading to less support for different queries.
[Issue #1206 Solved](https://github.com/tortoise/tortoise-orm/issues/1206)

## How Has This Been Tested?
I wrote a pytest for my all JSON functions implemented.
I created a simple Model with a JSONField, and tested each operation.
Does not affect other parts of code

## Checklist:
- [ X] My code follows the code style of this project.
- [ X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [ X] I have read the **CONTRIBUTING** document.
- [ X] I have added tests to cover my changes.
- [ X] All new and existing tests passed.

