### PR TITLE
Changed type hint for index fields from Set to Tuple

### DIFF
--- a/tortoise/contrib/mysql/indexes.py
+++ b/tortoise/contrib/mysql/indexes.py
@@ -1,4 +1,4 @@
-from typing import Optional, Set
+from typing import Optional, Tuple
 
 from pypika.terms import Term
 
@@ -11,7 +11,7 @@ class FullTextIndex(Index):
     def __init__(
         self,
         *expressions: Term,
-        fields: Optional[Set[str]] = None,
+        fields: Optional[Tuple[str]] = None,
         name: Optional[str] = None,
         parser_name: Optional[str] = None,
     ):

--- a/tortoise/contrib/postgres/indexes.py
+++ b/tortoise/contrib/postgres/indexes.py
@@ -1,4 +1,4 @@
-from typing import Optional, Set
+from typing import Optional, Tuple
 
 from pypika.terms import Term, ValueWrapper
 
@@ -13,7 +13,7 @@ class PostgreSQLIndex(PartialIndex):
     def __init__(
         self,
         *expressions: Term,
-        fields: Optional[Set[str]] = None,
+        fields: Optional[Tuple[str]] = None,
         name: Optional[str] = None,
         condition: Optional[dict] = None,
     ):

--- a/tortoise/indexes.py
+++ b/tortoise/indexes.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional, Set, Type
+from typing import TYPE_CHECKING, Optional, Tuple, Type
 
 from pypika.terms import Term, ValueWrapper
 
@@ -16,7 +16,7 @@ class Index:
     def __init__(
         self,
         *expressions: Term,
-        fields: Optional[Set[str]] = None,
+        fields: Optional[Tuple[str]] = None,
         name: Optional[str] = None,
     ):
         """
@@ -69,7 +69,7 @@ class PartialIndex(Index):
     def __init__(
         self,
         *expressions: Term,
-        fields: Optional[Set[str]] = None,
+        fields: Optional[Tuple[str]] = None,
         name: Optional[str] = None,
         condition: Optional[dict] = None,
     ):


### PR DESCRIPTION
Order of index fields is important. Set is unordered collection, should use Tuple instead.

