### PR TITLE
Fix: models_paths argument in tortoise.init_models() was lacking str …

### DIFF
--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -374,7 +374,7 @@ class Tortoise:
     @classmethod
     def init_models(
         cls,
-        models_paths: Iterable[Union[ModuleType, str]],
+        models_paths: Iterable[Union[ModuleType, str]] | str,
         app_label: str,
         _init_relations: bool = True,
     ) -> None:
@@ -390,9 +390,13 @@ class Tortoise:
 
         :raises ConfigurationError: If models are invalid.
         """
-        app_models: List[Type[Model]] = []
-        for models_path in models_paths:
-            app_models += cls._discover_models(models_path, app_label)
+        app_models: List[Type[Model]]
+        if isinstance(models_paths, str):
+            app_models = cls._discover_models(models_paths, app_label)
+        else:
+            app_models = []
+            for models_path in models_paths:
+                app_models += cls._discover_models(models_path, app_label)
 
         cls.apps[app_label] = {model.__name__: model for model in app_models}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`models_paths` argument in `tortoise.init_models()` was lacking `str` support.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`poetry run make testall`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed. 4 failed
