### PR TITLE
Fix pydantic_model_creator not validates JSONField

### DIFF
--- a/tortoise/contrib/pydantic/creator.py
+++ b/tortoise/contrib/pydantic/creator.py
@@ -399,7 +399,7 @@ def pydantic_model_creator(
                 pannotations[fname] = annotation
         # Json fields
         elif field_type is fields.JSONField:
-            pannotations[fname] = Any  # type: ignore
+            pannotations[fname] = pydantic.Json[Any]
         # Any other tortoise fields
         else:
             annotation = annotations.get(fname, None)


### PR DESCRIPTION
## Description
Makes a pedantic model created by pydantic_model_creator to validate JSONField


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/tortoise/tortoise-orm/issues/1251#issue-1372065040

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

