### PR TITLE
Fix run_async RuntimeError

### DIFF
--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -683,7 +683,11 @@ def run_async(coro: Coroutine) -> None:
 
         run_async(do_stuff())
     """
-    loop = asyncio.get_event_loop()
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
     try:
         loop.run_until_complete(coro)
     finally:


### PR DESCRIPTION
## Description
`run_async` helper function raising `RuntimeError` sometimes when the event_loop is None.
My working case for this `RuntimeError` to occur is calling the `run_async` function inside a `prefect.flow`, which is just a wrapped function provided by another package named `prefect` for workflow orchestration.

## Motivation and Context
`RuntimeError` raised by `asyncio.get_event_loop` not properly dealt by `run_async` function.
The event_loop is newly generated if get None then set to asyncio's event_loop 

## How Has This Been Tested?
NA

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.