### PR TITLE
fix ForeignKeyField is none when fk is integer 0 #1274

### DIFF
--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -357,6 +357,16 @@ class TestRelations(test.TestCase):
         )
         self.assertIsNone(pair.right.extra)  # should be None
 
+    async def test_0_value_fk(self):
+        """ForegnKeyField should exits even if the the source_field looks like false, but not None
+        src: https://github.com/tortoise/tortoise-orm/issues/1274
+        """
+        extra = await Extra.create(id=0)
+        single = await Single.create(extra=extra)
+
+        single_reload = await Single.get(id=single.id)
+        assert await single_reload.extra is not None
+
 
 class TestDoubleFK(test.TestCase):
     select_match = r'SELECT [`"]doublefk[`"].[`"]name[`"] [`"]name[`"]'

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -107,7 +107,7 @@ def _fk_getter(
         return getattr(self, _key)
     except AttributeError:
         value = getattr(self, relation_field)
-        if value:
+        if value is not None:
             return ftype.filter(**{to_field: value}).first()
         return NoneAwaitable
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes a bug in _fk_getter when fk is 0, similar to #1055 

## Motivation and Context

## How Has This Been Tested?
I test case is added in this PR

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ x ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.

