### PR TITLE
fix: init multiple times will overwrite the previous db_config

### DIFF
--- a/tortoise/connection.py
+++ b/tortoise/connection.py
@@ -25,7 +25,10 @@ class ConnectionHandler:
         self._create_db: bool = False
 
     async def _init(self, db_config: "DBConfigType", create_db: bool):
-        self._db_config = db_config
+        if self._db_config is None:
+            self._db_config = db_config
+        else:
+            self._db_config.update(db_config)
         self._create_db = create_db
         await self._init_connections()
 


### PR DESCRIPTION
## Description
When use `Tortoise.init` multiple times, last `init` will overwrite previous db_config.This will lead to `tortoise.exceptions.OperationalError: no such table: xxx`


## Motivation and Context
In a plugin scenario, different plugins may do their own `Tortoise.init`.

## How Has This Been Tested?
I tried `Tortoise.init` with different `db_config` several times in my project, and it worked fine, connecting to multiple databases.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

