### PR TITLE
Add support for queryset slicing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Added
 - Add __eq__ method to Q to more easily test dynamically-built queries (#1506)
 - Added PlainToTsQuery function for postgres (#1347)
 - Allow field's default keyword to be async function (#1498)
+- Add support for queryset slicing. (#1341)
 
 Fixed
 ^^^^^

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -53,6 +53,7 @@ Contributors
 * Paul Serov ``@thakryptex``
 * Stanislav Zmiev ``@Ovsyanka83``
 * Waket Zheng ``@waketzheng``
+* Yuval Ben-Arie ``@yuvalbenarie``
 
 Special Thanks
 ==============


### PR DESCRIPTION
## Description
Add syntactic sugar in the form for queryset slicing, to enable `qs[x:y]` instead of `qs.offset(x).limit(y-x)`

## Motivation and Context
This change brings us a bit closer to being Django-compatible.
The feature is used extensively by paginators in the form of `qs[page_count*page_size:(page_count+1)*page_size]`.

## How Has This Been Tested?
Added new tests to compare the new functionality against existing comparable operations.
 
## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

