### PR TITLE
Model printing requires the output of the primary key value

### DIFF
--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -749,11 +749,13 @@ class Model(metaclass=ModelMeta):
         return self
 
     def __str__(self) -> str:
+        if self.pk:
+            return f"<{self.__class__.__name__}: {self.pk}>"
         return f"<{self.__class__.__name__}>"
 
     def __repr__(self) -> str:
         if self.pk:
-            return f"<{self.__class__.__name__}: {self.pk}>"
+            return f"<{self.__class__.__name__}: {self}>"
         return f"<{self.__class__.__name__}>"
 
     def __hash__(self) -> int:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When you print a model,you can only got model's name, however it would be helpful to see also PK when you print the model instance.Also, some extra information was added  about the object in **repr** method

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Add more information about a model  in context of debugging. Instead of simple model name you also see pk
[open issue](https://github.com/tortoise/tortoise-orm/issues/1342).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
No test required.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

