### PR TITLE
Add PostgreSQL function `plainto_tsquery`

### DIFF
--- a/docs/contrib/postgres.rst
+++ b/docs/contrib/postgres.rst
@@ -28,6 +28,7 @@ Functions
 
 .. autoclass:: tortoise.contrib.postgres.functions.ToTsVector
 .. autoclass:: tortoise.contrib.postgres.functions.ToTsQuery
+.. autoclass:: tortoise.contrib.postgres.functions.PlainToTsQuery
 
 Search
 ======

--- a/tortoise/contrib/postgres/functions.py
+++ b/tortoise/contrib/postgres/functions.py
@@ -19,6 +19,15 @@ class ToTsQuery(Function):  # type: ignore
         super(ToTsQuery, self).__init__("TO_TSQUERY", field)
 
 
+class PlainToTsQuery(Function):  # type: ignore
+    """
+    plainto_tsquery function
+    """
+
+    def __init__(self, field: Term):
+        super(PlainToTsQuery, self).__init__("PLAINTO_TSQUERY", field)
+
+
 class Random(Function):  # type: ignore
     """
     Generate random number.

--- a/tortoise/contrib/postgres/search.py
+++ b/tortoise/contrib/postgres/search.py
@@ -1,6 +1,6 @@
+from typing import Union
 from pypika.enums import Comparator
-from pypika.terms import BasicCriterion, Term
-
+from pypika.terms import BasicCriterion, Term, Function
 from tortoise.contrib.postgres.functions import ToTsQuery, ToTsVector
 
 
@@ -9,5 +9,9 @@ class Comp(Comparator):  # type: ignore
 
 
 class SearchCriterion(BasicCriterion):  # type: ignore
-    def __init__(self, field: Term, expr: Term):
-        super().__init__(Comp.search, ToTsVector(field), ToTsQuery(expr))
+    def __init__(self, field: Term, expr: Union[Term, Function]):
+        if isinstance(expr, Function):
+            _expr = expr
+        else:
+            _expr = ToTsQuery(expr)
+        super().__init__(Comp.search, ToTsVector(field), _expr)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds the `plainto_tsquery` PostgreSQL function that can be used for a full-text search.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently, the search can be done only using the function `to_tsquery`. While `to_tsquery` offers access to more features is less forgiving about its input than `plainto_tsquery`. 
For example, let's say that we have a model `Element` with an attribute `name` and we want to search for "Pont d'en ".
```python
Element.filter(name__search="Pont d'en ")
```
The above query will fail because the single quote `'`. However, it will succeed using `plainto_tsquery`. 
```python
Element.filter(name__search=PlainToTsQuery("Pont d'en "))
```

The `plainto_tsquery` function in PostgreSQL can be used to search for elements where their name contains a single quote or an apostrophe. For instance, if there are elements in a database with the names "Pont d’en Gil" (with an apostrophe) or "Pont d'en Gil" (with a single quote), these elements would be fetched regardless of whether the special character is an apostrophe or a single quote.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

