### PR TITLE
add an option to return fields on update

### DIFF
--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -1032,6 +1032,7 @@ class UpdateQuery(AwaitableQuery):
         "orderings",
         "limit",
         "values",
+        "returning_columns",
     )
 
     def __init__(
@@ -1054,6 +1055,7 @@ class UpdateQuery(AwaitableQuery):
         self.limit = limit
         self.orderings = orderings
         self.values: List[Any] = []
+        self.returning_columns = []
 
     def _make_query(self) -> None:
         table = self.model._meta.basetable
@@ -1100,6 +1102,8 @@ class UpdateQuery(AwaitableQuery):
                 self.query = self.query.set(db_field, executor.parameter(count))
                 self.values.append(value)
                 count += 1
+        if self.returning_columns:
+            self.query = self.query.returning(*self.return_columns)
 
     def __await__(self) -> Generator[Any, None, int]:
         if self._db is None:
@@ -1107,8 +1111,13 @@ class UpdateQuery(AwaitableQuery):
         self._make_query()
         return self._execute().__await__()
 
-    async def _execute(self) -> int:
-        return (await self._db.execute_query(str(self.query), self.values))[0]
+    async def _execute(self) -> List[dict]:
+        res = await self._db.execute_query_dict(str(self.query))
+        return res
+
+    def returning(self, *columns):
+        self.return_columns = columns
+        return self    
 
 
 class DeleteQuery(AwaitableQuery):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Added a `returning` method for UpdateQuery to get an option to fetch changed data

## Description
This change

## Motivation and Context
I faced a need, to get some data from updated rows. It looks like related to [this](https://github.com/tortoise/tortoise-orm/issues/637) issue

## How Has This Been Tested?
Tested locally by adding `res = await Users(company_id=self. company_id).update(is_active=0).returning('id')`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

I understand, that this is 
1) a breaking change
2) maybe not the best way to put
but I really want this feature to help me know where to implement it better
