### PR TITLE
fix: Fix incorrect use of pk_attr instead of db_pk_column when using RelationalField as the primary key

### DIFF
--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -38,6 +38,7 @@ from tortoise.fields.data import IntField
 from tortoise.fields.relational import (
     BackwardFKRelation,
     BackwardOneToOneRelation,
+    RelationalField,
     ForeignKeyFieldInstance,
     ManyToManyFieldInstance,
     ManyToManyRelation,
@@ -618,6 +619,8 @@ class ModelMeta(type):
         meta.pk = fields_map.get(pk_attr)  # type: ignore
         if meta.pk:
             meta.db_pk_column = meta.pk.source_field or meta.pk_attr
+            if isinstance(meta.pk, RelationalField) and meta.pk.source_field is None:
+                meta.db_pk_column = f"{meta.db_pk_column}_id"
         meta._inited = False
         if not fields_map:
             meta.abstract = True


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When using RelationalField(pk=True) without specifying source_field, the value of meta.db_pk_column is the same as meta.pk_attr. Theoretically, the value of meta.db_pk_column should be f"{meta.db_pk_column}_id".
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I would like meta.db_pk_column to be recognized correctly when using RelationalField(pk=True).
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

