### PR TITLE
Fix fetching related object with ID = 0

### DIFF
--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -75,6 +75,24 @@ class TestRelations(test.TestCase):
         result = await Event.filter(pk=event.pk).values_list("event_id", "participants__name")
         self.assertEqual(len(result), 2)
 
+    async def test_fetch_fk_zero(self):
+        tournament_0 = await Tournament.create(name="tournament zero", id=0)
+        tournament_1 = await Tournament.create(name="tournament one", id=1)
+        await Event.create(name="event-one", tournament=tournament_1)
+        await Event.create(name="event-zero", tournament=tournament_0)
+
+        for name in ("event-one", "event-zero"):
+            e = await Event.get(name=name)
+            id_before_fetch = e.tournament_id
+            await e.fetch_related("tournament")
+            id_after_fetch = e.tournament_id
+            self.assertEqual(id_before_fetch, id_after_fetch)
+
+        event_0 = await Event.get(name="event-zero").prefetch_related("tournament")
+        self.assertEqual(event_0.tournament, tournament_0)
+        event_1 = await Event.get(name="event-one").prefetch_related("tournament")
+        self.assertEqual(event_1.tournament, tournament_1)
+
     async def test_reset_queryset_on_query(self):
         tournament = await Tournament.create(name="New Tournament")
         event = await Event.create(name="Test", tournament_id=tournament.id)

--- a/tortoise/backends/base/executor.py
+++ b/tortoise/backends/base/executor.py
@@ -512,7 +512,7 @@ class BaseExecutor:
         related_objects_for_fetch: Dict[str, list] = {}
         relation_key_field = f"{field}_id"
         for instance in instance_list:
-            if getattr(instance, relation_key_field):
+            if getattr(instance, relation_key_field) is not None:
                 key = cast(RelationalField, instance._meta.fields_map[field]).to_field
                 if key not in related_objects_for_fetch:
                     related_objects_for_fetch[key] = []


### PR DESCRIPTION
Currently, when trying to fetch a related object that has an integer primary key that equals to 0, the foreign key is set to `None` instead and the related object is not fetched.

## Description
Although it's uncommon, it's possible to have a row with integer primary key equal to 0 or even negative.
An application I am working at has a table with such a row, and another table relates to it, `prefetch_related` and `fetch_related` doesn't work correctly. Instead of fetching the related object, the foreign key field is set to `None`.
This pull request tries to fix that.

## Motivation and Context
This pull request attempts to fix the issue described above.

## How Has This Been Tested?
I've added a test in test_relations.py called `test_fetch_fk_zero`. It creates two Tournament objects with hard-coded IDs of 0 and 1, and then creates an Event for both of them. The test fails before my change, because the Tournament with ID=0 is not fetched when trying to use both `fetch_related` and `prefetch_related` on an Event.
The change doesn't seem to affect other tests, but because this is my first attempt to contribute to this project, it would be good for someone else to verify.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

