### PR TITLE
Made it possible to pass the "index_type" argument in the Index and PartialIndex constructors

### DIFF
--- a/tortoise/indexes.py
+++ b/tortoise/indexes.py
@@ -75,7 +75,7 @@ class PartialIndex(Index):
         fields: Optional[Tuple[str, ...]] = None,
         name: Optional[str] = None,
         condition: Optional[dict] = None,
-        index_type: Optional[str] = ""
+        index_type: Optional[str] = None
     ):
         super().__init__(*expressions, fields=fields, name=name, index_type=index_type)
         if condition:

--- a/tortoise/indexes.py
+++ b/tortoise/indexes.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:
 
 
 class Index:
+    INDEX_TYPE = ""
     INDEX_CREATE_TEMPLATE = (
         "CREATE{index_type}INDEX {index_name} ON {table_name} ({fields}){extra};"
     )
@@ -17,7 +18,7 @@ class Index:
         *expressions: Term,
         fields: Optional[Tuple[str, ...]] = None,
         name: Optional[str] = None,
-        index_type: Optional[str] = ""
+        index_type: Optional[str] = None
     ):
         """
         All kinds of index parent class, default is BTreeIndex.
@@ -37,7 +38,7 @@ class Index:
         self.name = name
         self.expressions = expressions
         self.extra = ""
-        self.index_type = index_type
+        self.index_type = index_type or self.INDEX_TYPE
         
 
     def get_sql(self, schema_generator: "BaseSchemaGenerator", model: "Type[Model]", safe: bool):

--- a/tortoise/indexes.py
+++ b/tortoise/indexes.py
@@ -8,7 +8,6 @@ if TYPE_CHECKING:
 
 
 class Index:
-    INDEX_TYPE = ""
     INDEX_CREATE_TEMPLATE = (
         "CREATE{index_type}INDEX {index_name} ON {table_name} ({fields}){extra};"
     )
@@ -18,6 +17,7 @@ class Index:
         *expressions: Term,
         fields: Optional[Tuple[str, ...]] = None,
         name: Optional[str] = None,
+        index_type: Optional[str] = ""
     ):
         """
         All kinds of index parent class, default is BTreeIndex.
@@ -37,6 +37,8 @@ class Index:
         self.name = name
         self.expressions = expressions
         self.extra = ""
+        self.index_type = index_type
+        
 
     def get_sql(self, schema_generator: "BaseSchemaGenerator", model: "Type[Model]", safe: bool):
         if self.fields:
@@ -45,7 +47,7 @@ class Index:
                 index_name=schema_generator.quote(
                     self.name or schema_generator._generate_index_name("idx", model, self.fields)
                 ),
-                index_type=f" {self.INDEX_TYPE} ",
+                index_type=f" {self.index_type} ",
                 table_name=schema_generator.quote(model._meta.db_table),
                 fields=", ".join(schema_generator.quote(f) for f in self.fields),
                 extra=self.extra,
@@ -55,7 +57,7 @@ class Index:
         return self.INDEX_CREATE_TEMPLATE.format(
             exists="IF NOT EXISTS " if safe else "",
             index_name=self.index_name(schema_generator, model),
-            index_type=f" {self.INDEX_TYPE} ",
+            index_type=f" {self.index_type} ",
             table_name=schema_generator.quote(model._meta.db_table),
             fields=", ".join(expressions),
             extra=self.extra,
@@ -72,8 +74,9 @@ class PartialIndex(Index):
         fields: Optional[Tuple[str, ...]] = None,
         name: Optional[str] = None,
         condition: Optional[dict] = None,
+        index_type: Optional[str] = ""
     ):
-        super().__init__(*expressions, fields=fields, name=name)
+        super().__init__(*expressions, fields=fields, name=name, index_type=index_type)
         if condition:
             cond = " WHERE "
             items = []


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Title pretty much explains it all. This is so we can set the index as unique without the need of super seeding the class

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It just feels more natural to have it passed in the constructor as it is part of the index behavior to be unique or not, the type should not need to be overridden in another class

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has not been tested, but I'm fairly confident in this small change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

