### PR TITLE
Improve type hints for fields

### DIFF
--- a/tests/schema/models_no_auto_create_m2m.py
+++ b/tests/schema/models_no_auto_create_m2m.py
@@ -57,7 +57,7 @@ class TeamEvent(Model):
 class Team(Model):
     name = fields.CharField(max_length=50, pk=True, description="The TEAM name (and PK)")
     key = fields.IntField()
-    manager: fields.ForeignKeyRelation["Team"] = fields.ForeignKeyField(
+    manager: fields.ForeignKeyNullableRelation["Team"] = fields.ForeignKeyField(
         "models.Team", related_name="team_members", null=True
     )
     talks_to: fields.ManyToManyRelation["Team"] = fields.ManyToManyField(

--- a/tests/schema/models_no_db_constraint.py
+++ b/tests/schema/models_no_db_constraint.py
@@ -44,7 +44,7 @@ class Event(Model):
 class Team(Model):
     name = fields.CharField(max_length=50, pk=True, description="The TEAM name (and PK)")
     key = fields.IntField()
-    manager: fields.ForeignKeyRelation["Team"] = fields.ForeignKeyField(
+    manager: fields.ForeignKeyNullableRelation["Team"] = fields.ForeignKeyField(
         "models.Team", db_constraint=False, related_name="team_members", null=True
     )
     talks_to: fields.ManyToManyRelation["Team"] = fields.ManyToManyField(

--- a/tests/schema/models_schema_create.py
+++ b/tests/schema/models_schema_create.py
@@ -43,7 +43,7 @@ class Event(Model):
 class Team(Model):
     name = fields.CharField(max_length=50, pk=True, description="The TEAM name (and PK)")
     key = fields.IntField()
-    manager: fields.ForeignKeyRelation["Team"] = fields.ForeignKeyField(
+    manager: fields.ForeignKeyNullableRelation["Team"] = fields.ForeignKeyField(
         "models.Team", related_name="team_members", null=True
     )
     talks_to: fields.ManyToManyRelation["Team"] = fields.ManyToManyField(
@@ -77,7 +77,7 @@ class VenueInformation(Model):
     #: All this should not be part of the field description either!
     capacity = fields.IntField()
     rent = fields.FloatField()
-    team: fields.OneToOneRelation[Team] = fields.OneToOneField(
+    team: fields.OneToOneNullableRelation[Team] = fields.OneToOneField(
         "models.Team", on_delete=fields.SET_NULL, null=True
     )
 
@@ -86,7 +86,7 @@ class SourceFields(Model):
     id = fields.IntField(pk=True, source_field="sometable_id")
     chars = fields.CharField(max_length=255, source_field="some_chars_table", index=True)
 
-    fk: fields.ForeignKeyRelation["SourceFields"] = fields.ForeignKeyField(
+    fk: fields.ForeignKeyNullableRelation["SourceFields"] = fields.ForeignKeyField(
         "models.SourceFields", related_name="team_members", null=True, source_field="fk_sometable"
     )
 

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -328,6 +328,7 @@ class TestRelations(test.TestCase):
             .get(id=getattr(root, "id"))  # noqa
         )
         self.assertIsNone(retrieved_root.right)
+        assert retrieved_root.left is not None
         self.assertEqual(retrieved_root.left, left_1st_lvl)
         self.assertEqual(retrieved_root.left.left, left_2nd_lvl)
 

--- a/tests/testmodels.py
+++ b/tests/testmodels.py
@@ -140,7 +140,7 @@ class Dest_null(Model):
 
 class O2O_null(Model):
     name = fields.CharField(max_length=64)
-    event: fields.OneToOneRelation[Event] = fields.OneToOneField(
+    event: fields.OneToOneNullableRelation[Event] = fields.OneToOneField(
         "models.Dest_null", on_delete=fields.CASCADE, related_name="address_null", null=True
     )
 
@@ -668,10 +668,10 @@ class EnumFields(Model):
 
 class DoubleFK(Model):
     name = fields.CharField(max_length=50)
-    left: fields.ForeignKeyRelation["DoubleFK"] = fields.ForeignKeyField(
+    left: fields.ForeignKeyNullableRelation["DoubleFK"] = fields.ForeignKeyField(
         "models.DoubleFK", null=True, related_name="left_rel"
     )
-    right: fields.ForeignKeyRelation["DoubleFK"] = fields.ForeignKeyField(
+    right: fields.ForeignKeyNullableRelation["DoubleFK"] = fields.ForeignKeyField(
         "models.DoubleFK", null=True, related_name="right_rel"
     )
 
@@ -835,7 +835,7 @@ class Single(Model):
     """
 
     id = fields.IntField(pk=True)
-    extra: fields.ForeignKeyRelation[Extra] = fields.ForeignKeyField(
+    extra: fields.ForeignKeyNullableRelation[Extra] = fields.ForeignKeyField(
         "models.Extra", related_name="singles", null=True
     )
 
@@ -846,10 +846,10 @@ class Pair(Model):
     """
 
     id = fields.IntField(pk=True)
-    left: fields.ForeignKeyRelation[Single] = fields.ForeignKeyField(
+    left: fields.ForeignKeyNullableRelation[Single] = fields.ForeignKeyField(
         "models.Single", related_name="lefts", null=True
     )
-    right: fields.ForeignKeyRelation[Single] = fields.ForeignKeyField(
+    right: fields.ForeignKeyNullableRelation[Single] = fields.ForeignKeyField(
         "models.Single", related_name="rights", null=True
     )
 

--- a/tortoise/fields/base.py
+++ b/tortoise/fields/base.py
@@ -153,7 +153,9 @@ class Field(Generic[VALUE], metaclass=_FieldMeta):
     def __get__(self, instance: "Model", owner: Type["Model"]) -> VALUE:
         ...
 
-    def __get__(self, instance: Optional["Model"], owner: Type["Model"]):
+    def __get__(  # type: ignore[empty-body]
+        self, instance: Optional["Model"], owner: Type["Model"]
+    ) -> "Field[VALUE] | VALUE":
         ...
 
     def __init__(

--- a/tortoise/fields/relational.py
+++ b/tortoise/fields/relational.py
@@ -294,7 +294,9 @@ class RelationalField(Field[MODEL]):
     def __get__(self, instance: "Model", owner: Type["Model"]) -> MODEL:
         ...
 
-    def __get__(self, instance: Optional["Model"], owner: Type["Model"]):
+    def __get__(  # type: ignore[empty-body]
+        self, instance: Optional["Model"], owner: Type["Model"]
+    ) -> "RelationalField[MODEL] | MODEL":
         ...
 
     def describe(self, serializable: bool) -> dict:
@@ -402,13 +404,39 @@ class ManyToManyFieldInstance(RelationalField[MODEL]):
         return desc
 
 
+@overload
 def OneToOneField(
     model_name: str,
     related_name: Union[Optional[str], Literal[False]] = None,
     on_delete: str = CASCADE,
     db_constraint: bool = True,
+    *,
+    null: Literal[True],
+    **kwargs: Any,
+) -> "OneToOneNullableRelation[MODEL]":
+    ...
+
+
+@overload
+def OneToOneField(
+    model_name: str,
+    related_name: Union[Optional[str], Literal[False]] = None,
+    on_delete: str = CASCADE,
+    db_constraint: bool = True,
+    null: Literal[False] = False,
     **kwargs: Any,
 ) -> "OneToOneRelation[MODEL]":
+    ...
+
+
+def OneToOneField(
+    model_name: str,
+    related_name: Union[Optional[str], Literal[False]] = None,
+    on_delete: str = CASCADE,
+    db_constraint: bool = True,
+    null: bool = False,
+    **kwargs: Any,
+) -> "OneToOneRelation[MODEL] | OneToOneNullableRelation[MODEL]":
     """
     OneToOne relation field.
 
@@ -447,8 +475,33 @@ def OneToOneField(
     """
 
     return OneToOneFieldInstance(
-        model_name, related_name, on_delete, db_constraint=db_constraint, **kwargs
+        model_name, related_name, on_delete, db_constraint=db_constraint, null=null, **kwargs
     )
+
+
+@overload
+def ForeignKeyField(
+    model_name: str,
+    related_name: Union[Optional[str], Literal[False]] = None,
+    on_delete: str = CASCADE,
+    db_constraint: bool = True,
+    *,
+    null: Literal[True],
+    **kwargs: Any,
+) -> "ForeignKeyNullableRelation[MODEL]":
+    ...
+
+
+@overload
+def ForeignKeyField(
+    model_name: str,
+    related_name: Union[Optional[str], Literal[False]] = None,
+    on_delete: str = CASCADE,
+    db_constraint: bool = True,
+    null: Literal[False] = False,
+    **kwargs: Any,
+) -> "ForeignKeyRelation[MODEL]":
+    ...
 
 
 def ForeignKeyField(
@@ -456,8 +509,9 @@ def ForeignKeyField(
     related_name: Union[Optional[str], Literal[False]] = None,
     on_delete: str = CASCADE,
     db_constraint: bool = True,
+    null: bool = False,
     **kwargs: Any,
-) -> "ForeignKeyRelation[MODEL]":
+) -> "ForeignKeyRelation[MODEL] | ForeignKeyNullableRelation[MODEL]":
     """
     ForeignKey relation field.
 
@@ -496,7 +550,7 @@ def ForeignKeyField(
     """
 
     return ForeignKeyFieldInstance(
-        model_name, related_name, on_delete, db_constraint=db_constraint, **kwargs
+        model_name, related_name, on_delete, db_constraint=db_constraint, null=null, **kwargs
     )
 
 
@@ -509,7 +563,7 @@ def ManyToManyField(
     on_delete: str = CASCADE,
     db_constraint: bool = True,
     **kwargs: Any,
-) -> "ManyToManyRelation[MODEL]":
+) -> "ManyToManyRelation[Any]":
     """
     ManyToMany relation field.
 


### PR DESCRIPTION
Minor improvements to field type hints to improve the user experience. 

## Description
ForeignKey and OneToOne fields now warn the user (via type hints) if null=True has been passed and the user used the non-nullable version of the type.

## Motivation and Context
It gives our users more security when using tortoise

## How Has This Been Tested?
I played around with the tests in Tortoise which are now showing the correct types.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

