### PR TITLE
Enhancement for FastAPI lifespan support (#1371)

### DIFF
--- a/tortoise/contrib/fastapi/__init__.py
+++ b/tortoise/contrib/fastapi/__init__.py
@@ -14,6 +14,129 @@ class HTTPNotFoundError(BaseModel):
     detail: str
 
 
+class RegisterTortoise:
+    def __init__(
+        self,
+        app: FastAPI,
+        config: Optional[dict] = None,
+        config_file: Optional[str] = None,
+        db_url: Optional[str] = None,
+        modules: Optional[Dict[str, Iterable[Union[str, ModuleType]]]] = None,
+        generate_schemas: bool = False,
+        add_exception_handlers: bool = False,
+    ):
+        """
+        Offer functions to set-up or tear-down Tortoise-ORM for the FastAPI app's lifespan.
+
+        Usage::
+            >>> @asyncontextmanager
+            ... async def lifespan(app):
+            ...     await RegisterTortoise(app, ...).init()
+            ...     yield
+            ...     await RegisterTortoise.close()
+            >>> app = FastAPI(lifespan=lifespan)
+
+        You can configure using only one of ``config``, ``config_file``
+        and ``(db_url, modules)``.
+
+        Parameters
+        ----------
+        app:
+            FastAPI app.
+        config:
+            Dict containing config:
+
+            Example
+            -------
+
+            .. code-block:: python3
+
+                {
+                    'connections': {
+                        # Dict format for connection
+                        'default': {
+                            'engine': 'tortoise.backends.asyncpg',
+                            'credentials': {
+                                'host': 'localhost',
+                                'port': '5432',
+                                'user': 'tortoise',
+                                'password': 'qwerty123',
+                                'database': 'test',
+                            }
+                        },
+                        # Using a DB_URL string
+                        'default': 'postgres://postgres:qwerty123@localhost:5432/events'
+                    },
+                    'apps': {
+                        'models': {
+                            'models': ['__main__'],
+                            # If no default_connection specified, defaults to 'default'
+                            'default_connection': 'default',
+                        }
+                    }
+                }
+
+        config_file:
+            Path to .json or .yml (if PyYAML installed) file containing config with
+            same format as above.
+        db_url:
+            Use a DB_URL string. See :ref:`db_url`
+        modules:
+            Dictionary of ``key``: [``list_of_modules``] that defined "apps" and modules that
+            should be discovered for models.
+        generate_schemas:
+            True to generate schema immediately. Only useful for dev environments
+            or SQLite ``:memory:`` databases
+        add_exception_handlers:
+            True to add some automatic exception handlers for ``DoesNotExist`` & ``IntegrityError``.
+            This is not recommended for production systems as it may leak data.
+
+        Raises
+        ------
+        ConfigurationError
+            For any configuration error
+        """
+        self.app = app
+        self.config = config
+        self.config_file = config_file
+        self.db_url = db_url
+        self.modules = modules
+        self.generate_schemas = generate_schemas
+        self.add_exception_handlers = add_exception_handlers
+
+    async def init(self, init_exception_handlers=True) -> None:
+        await Tortoise.init(
+            config=self.config,
+            config_file=self.config_file,
+            db_url=self.db_url,
+            modules=self.modules,
+        )
+        logger.info("Tortoise-ORM started, %s, %s", connections._get_storage(), Tortoise.apps)
+        if self.generate_schemas:
+            logger.info("Tortoise-ORM generating schema")
+            await Tortoise.generate_schemas()
+        if init_exception_handlers and self.add_exception_handlers:
+            self.config_exception_handlers(self.app)
+
+    @staticmethod
+    async def close() -> None:
+        await connections.close_all()
+        logger.info("Tortoise-ORM shutdown")
+
+    @staticmethod
+    def config_exception_handlers(app) -> None:
+        @app.exception_handler(DoesNotExist)
+        async def doesnotexist_exception_handler(request: Request, exc: DoesNotExist):
+            return JSONResponse(status_code=404, content={"detail": str(exc)})
+
+        @app.exception_handler(IntegrityError)
+        async def integrityerror_exception_handler(request: Request, exc: IntegrityError):
+            return JSONResponse(
+                status_code=422,
+                content={"detail": [{"loc": [], "msg": str(exc), "type": "IntegrityError"}]},
+            )
+
+
 def register_tortoise(
     app: FastAPI,
     config: Optional[dict] = None,
@@ -87,29 +210,15 @@ def register_tortoise(
     ConfigurationError
         For any configuration error
     """
+    orm = RegisterTortoise(app, config, config_file, db_url, modules, generate_schemas)
 
     @app.on_event("startup")
     async def init_orm() -> None:  # pylint: disable=W0612
-        await Tortoise.init(config=config, config_file=config_file, db_url=db_url, modules=modules)
-        logger.info("Tortoise-ORM started, %s, %s", connections._get_storage(), Tortoise.apps)
-        if generate_schemas:
-            logger.info("Tortoise-ORM generating schema")
-            await Tortoise.generate_schemas()
+        await orm.init(False)
 
     @app.on_event("shutdown")
     async def close_orm() -> None:  # pylint: disable=W0612
-        await connections.close_all()
-        logger.info("Tortoise-ORM shutdown")
+        await orm.close()
 
     if add_exception_handlers:
-
-        @app.exception_handler(DoesNotExist)
-        async def doesnotexist_exception_handler(request: Request, exc: DoesNotExist):
-            return JSONResponse(status_code=404, content={"detail": str(exc)})
-
-        @app.exception_handler(IntegrityError)
-        async def integrityerror_exception_handler(request: Request, exc: IntegrityError):
-            return JSONResponse(
-                status_code=422,
-                content={"detail": [{"loc": [], "msg": str(exc), "type": "IntegrityError"}]},
-            )
+        orm.config_exception_handlers(app)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Compare with fastapi lifespan and startup

## Description
<!--- Describe your changes in detail -->
Use a new class to separate init_orm and close_orm

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/tortoise/tortoise-orm/issues/1371

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- `make test` worked at Ubuntu20.04
- `pytest _tests.py` worked in examples/fastapi 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.