### PR TITLE
Fixed get_or_create method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ Fixed
 - Fix `bulk_update` when using custom fields. (#1564)
 - Fix `optional` parameter in `pydantic_model_creator` does not work for pydantic v2. (#1551)
 - Fix `get_annotations` now evaluates annotations in the default scope instead of the app namespace. (#1552)
+- Fix `get_or_create` method. (#1404)
 
 0.20.1
 ------

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -56,6 +56,7 @@ Contributors
 * Yuval Ben-Arie ``@yuvalbenarie``
 * Stephan Klein ``@privatwolke``
 * ``@WizzyGeek``
+* Ivan Pakeev ``@ipakeev``
 
 Special Thanks
 ==============

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -77,11 +77,3 @@ class TestConcurrencyTransactioned(test.TestCase):
         self.assertEqual(len(una_created), 1)
         for una in unas:
             self.assertEqual(una[0], unas[0][0])
-
-    @test.skipIf(sys.version_info < (3, 7), "aiocontextvars backport not handling this well")
-    async def test_concurrent_get_or_create(self):
-        unas = await asyncio.gather(*[UniqueName.get_or_create(name="b") for _ in range(10)])
-        una_created = [una[1] for una in unas if una[1] is True]
-        self.assertEqual(len(una_created), 1)
-        for una in unas:
-            self.assertEqual(una[0], unas[0][0])

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -1075,7 +1075,8 @@ class Model(metaclass=ModelMeta):
             return await cls.filter(**kwargs).using_db(db).get(), False
         except DoesNotExist:
             try:
-                return await cls.create(using_db=db, **defaults, **kwargs), True
+                async with in_transaction(connection_name=db.connection_name) as connection:
+                    return await cls.create(using_db=connection, **defaults, **kwargs), True
             except IntegrityError as exc:
                 try:
                     return await cls.filter(**kwargs).using_db(db).get(), False

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -32,7 +32,6 @@ from tortoise.exceptions import (
     IntegrityError,
     OperationalError,
     ParamsError,
-    TransactionManagementError,
 )
 from tortoise.fields.base import Field
 from tortoise.fields.data import IntField
@@ -1068,22 +1067,21 @@ class Model(metaclass=ModelMeta):
         :param using_db: Specific DB connection to use instead of default bound
         :param kwargs: Query parameters.
         :raises IntegrityError: If create failed
-        :raises TransactionManagementError: If transaction error
         """
         if not defaults:
             defaults = {}
         db = using_db or cls._choose_db(True)
-        async with in_transaction(connection_name=db.connection_name) as connection:
+        try:
+            return await cls.filter(**kwargs).using_db(db).get(), False
+        except DoesNotExist:
             try:
-                return (
-                    await cls.select_for_update().filter(**kwargs).using_db(connection).get(),
-                    False,
-                )
-            except DoesNotExist:
+                return await cls.create(using_db=db, **defaults, **kwargs), True
+            except IntegrityError as exc:
                 try:
-                    return await cls.create(using_db=connection, **defaults, **kwargs), True
-                except (IntegrityError, TransactionManagementError):
-                    return await cls.filter(**kwargs).using_db(connection).get(), False
+                    return await cls.filter(**kwargs).using_db(db).get(), False
+                except DoesNotExist:
+                    pass
+                raise exc
 
     @classmethod
     def select_for_update(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I encountered an error: with simultaneous identical requests, the server responds with 500 error code.
tortoise-orm 0.19.3

```
INFO:     'POST /api/token HTTP/1.1' 500 Internal Server Error
ERROR:    Exception in ASGI application
Traceback (most recent call last):
  File "/home/ipakeev/.virtualenvs/push-service/lib/python3.11/site-packages/tortoise/models.py", line 1059, in get_or_create
    await cls.select_for_update().filter(**kwargs).using_db(connection).get(),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ipakeev/.virtualenvs/push-service/lib/python3.11/site-packages/tortoise/queryset.py", line 1020, in _execute
    raise DoesNotExist("Object does not exist")
tortoise.exceptions.DoesNotExist: Object does not exist

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/ipakeev/.virtualenvs/push-service/lib/python3.11/site-packages/tortoise/models.py", line 1064, in get_or_create
    return await cls.create(using_db=connection, **defaults, **kwargs), True
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ipakeev/.virtualenvs/push-service/lib/python3.11/site-packages/tortoise/backends/asyncpg/client.py", line 86, in _translate_exceptions
    raise IntegrityError(exc)
tortoise.exceptions.IntegrityError: duplicate key value violates unique constraint "user_phone_key"
DETAIL:  Key (phone)=(9998887764) already exists.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/ipakeev/.virtualenvs/push-service/lib/python3.11/site-packages/uvicorn/protocols/http/h11_impl.py", line 407, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ipakeev/.virtualenvs/push-service/lib/python3.11/site-packages/uvicorn/middleware/proxy_headers.py", line 78, in __call__
    return await self.app(scope, receive, send)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ipakeev/.virtualenvs/push-service/lib/python3.11/site-packages/fastapi/applications.py", line 270, in __call__
    await super().__call__(scope, receive, send)
  File "/home/ipakeev/.virtualenvs/push-service/lib/python3.11/site-packages/starlette/applications.py", line 124, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/home/ipakeev/.virtualenvs/push-service/lib/python3.11/site-packages/starlette/middleware/errors.py", line 184, in __call__
    raise exc
  File "/home/ipakeev/.virtualenvs/push-service/lib/python3.11/site-packages/starlette/middleware/errors.py", line 162, in __call__
    await self.app(scope, receive, _send)
  File "/home/ipakeev/.virtualenvs/push-service/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 79, in __call__
    raise exc
  File "/home/ipakeev/.virtualenvs/push-service/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 68, in __call__
    await self.app(scope, receive, sender)
  File "/home/ipakeev/.virtualenvs/push-service/lib/python3.11/site-packages/fastapi/middleware/asyncexitstack.py", line 21, in __call__
    raise e
  File "/home/ipakeev/.virtualenvs/push-service/lib/python3.11/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
    await self.app(scope, receive, send)
  File "/home/ipakeev/.virtualenvs/push-service/lib/python3.11/site-packages/starlette/routing.py", line 706, in __call__
    await route.handle(scope, receive, send)
  File "/home/ipakeev/.virtualenvs/push-service/lib/python3.11/site-packages/starlette/routing.py", line 276, in handle
    await self.app(scope, receive, send)
  File "/home/ipakeev/.virtualenvs/push-service/lib/python3.11/site-packages/starlette/routing.py", line 66, in app
    response = await func(request)
               ^^^^^^^^^^^^^^^^^^^
  File "/home/ipakeev/.virtualenvs/push-service/lib/python3.11/site-packages/fastapi/routing.py", line 235, in app
    raw_response = await run_endpoint_function(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ipakeev/.virtualenvs/push-service/lib/python3.11/site-packages/fastapi/routing.py", line 161, in run_endpoint_function
    return await dependant.call(**values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ipakeev/work/push-service/push_service/app/token/routes.py", line 13, in create_token
    user, _ = await User.get_or_create(phone=body.phone)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ipakeev/.virtualenvs/push-service/lib/python3.11/site-packages/tortoise/models.py", line 1066, in get_or_create
    return await cls.filter(**kwargs).using_db(connection).get(), False
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ipakeev/.virtualenvs/push-service/lib/python3.11/site-packages/tortoise/backends/asyncpg/client.py", line 88, in _translate_exceptions
    raise TransactionManagementError(exc)
```

## How Has This Been Tested?
After applying this PR, everything works as expected:
```
        try:
            return await cls.filter(**kwargs).using_db(db).get(), False
        except DoesNotExist:
            try:
                print("not found")
                async with in_transaction(connection_name=db.connection_name) as connection:
                    return await cls.create(using_db=connection, **defaults, **kwargs), True
            except (IntegrityError, TransactionManagementError) as exc:
                print("integrity error")
                try:
                    return await cls.filter(**kwargs).using_db(db).get(), False
                except Exception:
                    raise exc
```

```
not found
not found
not found
integrity error
integrity error
INFO:     'POST /api/token HTTP/1.1' 200 OK
INFO:     'POST /api/token HTTP/1.1' 200 OK
INFO:     'POST /api/token HTTP/1.1' 200 OK
INFO:     'POST /api/token HTTP/1.1' 200 OK
INFO:     'POST /api/token HTTP/1.1' 200 OK
```

I did't find a way to reproduce this error in autotests.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] ~~My change requires a change to the documentation.~~
- [ ] ~~I have updated the documentation accordingly.~~
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] ~~I have added tests to cover my changes.~~
- [x] All new and existing tests passed.

