### PR TITLE
fix: nvarchar field filtering bug for non-ascii characters 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,12 @@ Changelog
 0.20
 ====
 
+0.20.1
+------
+Added
+^^^^^
+- NVARCHAR non-ascii char support on mssql
+
 0.20.0
 ------
 Added

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -53,6 +53,7 @@ Contributors
 * Paul Serov ``@thakryptex``
 * Stanislav Zmiev ``@Ovsyanka83``
 * Waket Zheng ``@waketzheng``
+* Mohammad Norouzi ``@mm74noroozi``
 
 Special Thanks
 ==============

--- a/tests/fields/test_nvarchar.py
+++ b/tests/fields/test_nvarchar.py
@@ -39,6 +39,12 @@ class TestNVARCHARFields(test.IsolatedTestCase):
         obj2 = await testmodels.NVARCHAR.get(id=obj.id)
         self.assertEqual(obj, obj2)
 
+    async def test_filterUTF8Chars(self):
+        await testmodels.NVARCHAR.create(nvarchar="سلام")
+        obj = await testmodels.NVARCHAR.get(nvarchar="سلام")
+        self.assertIsNotNone(obj)
+        self.assertEqual(obj.nvarchar, "سلام")
+
     async def test_update(self):
         obj0 = await testmodels.NVARCHAR.create(nvarchar="سلام")
         await testmodels.NVARCHAR.filter(id=obj0.id).update(nvarchar="non-utf8")

--- a/tests/fields/test_nvarchar.py
+++ b/tests/fields/test_nvarchar.py
@@ -4,16 +4,16 @@ from tortoise.exceptions import IntegrityError, OperationalError
 from tortoise.exceptions import ConfigurationError
 
 @test.requireCapability(dialect="mssql")
-class TestArrayFields(test.IsolatedTestCase):
+class TestNVARCHARFields(test.IsolatedTestCase):
     tortoise_test_modules = ["tests.testmodels_mssql"]
 
-    def test_max_length_missing(self):
+    async def test_max_length_missing(self):
         with self.assertRaisesRegex(
             TypeError, "missing 1 required positional argument: 'max_length'"
         ):
             testmodels.NVARCHAR()  # pylint: disable=E1120
 
-    def test_max_length_bad(self):
+    async def test_max_length_bad(self):
         with self.assertRaisesRegex(ConfigurationError, "'max_length' must be >= 1"):
             testmodels.NVARCHAR(max_length=0)
 
@@ -34,7 +34,7 @@ class TestArrayFields(test.IsolatedTestCase):
         obj0 = await testmodels.NVARCHAR.create(nvarchar="سلام")
         obj = await testmodels.NVARCHAR.get(id=obj0.id)
         self.assertEqual(obj.nvarchar, "سلام")
-        self.assertIs(obj.array_null, None)
+        self.assertIs(obj.nvarchar_null, None)
         await obj.save()
         obj2 = await testmodels.NVARCHAR.get(id=obj.id)
         self.assertEqual(obj, obj2)
@@ -43,8 +43,8 @@ class TestArrayFields(test.IsolatedTestCase):
         obj0 = await testmodels.NVARCHAR.create(nvarchar="سلام")
         await testmodels.NVARCHAR.filter(id=obj0.id).update(nvarchar="non-utf8")
         obj = await testmodels.NVARCHAR.get(id=obj0.id)
-        self.assertEqual(obj.array, "non-utf8")
-        self.assertIs(obj.array_null, None)
+        self.assertEqual(obj.nvarchar, "non-utf8")
+        self.assertIs(obj.nvarchar_null, None)
 
     async def test_cast(self):
         obj0 = await testmodels.NVARCHAR.create(nvarchar=33)
@@ -54,7 +54,7 @@ class TestArrayFields(test.IsolatedTestCase):
     async def test_values(self):
         obj0 = await testmodels.NVARCHAR.create(nvarchar="سلام")
         values = await testmodels.NVARCHAR.get(id=obj0.id).values("nvarchar")
-        self.assertEqual(values["array"], "سلام")
+        self.assertEqual(values["nvarchar"], "سلام")
 
     async def test_values_list(self):
         obj0 = await testmodels.NVARCHAR.create(nvarchar="سلام")

--- a/tests/fields/test_nvarchar.py
+++ b/tests/fields/test_nvarchar.py
@@ -1,0 +1,64 @@
+from tests import testmodels_mssql as testmodels
+from tortoise.contrib import test
+from tortoise.exceptions import IntegrityError, OperationalError
+from tortoise.exceptions import ConfigurationError
+
+@test.requireCapability(dialect="mssql")
+class TestArrayFields(test.IsolatedTestCase):
+    tortoise_test_modules = ["tests.testmodels_mssql"]
+
+    def test_max_length_missing(self):
+        with self.assertRaisesRegex(
+            TypeError, "missing 1 required positional argument: 'max_length'"
+        ):
+            testmodels.NVARCHAR()  # pylint: disable=E1120
+
+    def test_max_length_bad(self):
+        with self.assertRaisesRegex(ConfigurationError, "'max_length' must be >= 1"):
+            testmodels.NVARCHAR(max_length=0)
+
+    async def _setUpDB(self) -> None:
+        try:
+            await super()._setUpDB()
+        except OperationalError:
+            raise test.SkipTest("Works only with MSSQLServer")
+
+    async def test_empty(self):
+        with self.assertRaises(IntegrityError):
+            await testmodels.NVARCHAR.create()
+
+    async def test_filtering(self):
+        testmodels.NVARCHAR.create(nvarchar="سلام").sql()
+
+    async def test_create(self):
+        obj0 = await testmodels.NVARCHAR.create(nvarchar="سلام")
+        obj = await testmodels.NVARCHAR.get(id=obj0.id)
+        self.assertEqual(obj.nvarchar, "سلام")
+        self.assertIs(obj.array_null, None)
+        await obj.save()
+        obj2 = await testmodels.NVARCHAR.get(id=obj.id)
+        self.assertEqual(obj, obj2)
+
+    async def test_update(self):
+        obj0 = await testmodels.NVARCHAR.create(nvarchar="سلام")
+        await testmodels.NVARCHAR.filter(id=obj0.id).update(nvarchar="non-utf8")
+        obj = await testmodels.NVARCHAR.get(id=obj0.id)
+        self.assertEqual(obj.array, "non-utf8")
+        self.assertIs(obj.array_null, None)
+
+    async def test_cast(self):
+        obj0 = await testmodels.NVARCHAR.create(nvarchar=33)
+        obj = await testmodels.NVARCHAR.get(id=obj0.id)
+        self.assertEqual(obj.nvarchar, "33")
+
+    async def test_values(self):
+        obj0 = await testmodels.NVARCHAR.create(nvarchar="سلام")
+        values = await testmodels.NVARCHAR.get(id=obj0.id).values("nvarchar")
+        self.assertEqual(values["array"], "سلام")
+
+    async def test_values_list(self):
+        obj0 = await testmodels.NVARCHAR.create(nvarchar="سلام")
+        values = await testmodels.NVARCHAR.get(id=obj0.id).values_list("nvarchar", flat=True)
+        self.assertEqual(values, "سلام")
+
+    

--- a/tests/testmodels_mssql.py
+++ b/tests/testmodels_mssql.py
@@ -1,0 +1,7 @@
+from tortoise import Model, fields
+from tortoise.contrib.mssql.fields import NVARCHAR
+
+class NVARCHARFields(Model):
+    id = fields.IntField(pk=True)
+    nvarchar = NVARCHAR(max_length=255)
+    nvarchar_null = NVARCHAR(max_length=255,null=True)

--- a/tortoise/contrib/mssql/field_types.py
+++ b/tortoise/contrib/mssql/field_types.py
@@ -1,0 +1,5 @@
+class NVARCHAR:
+    def __init__(self,value):
+        self._value = value
+    def __str__(self):
+        return f"N'{self._value}'"

--- a/tortoise/contrib/mssql/fields.py
+++ b/tortoise/contrib/mssql/fields.py
@@ -1,0 +1,11 @@
+from tortoise.fields.data import CharField
+from tortoise.contrib.mssql.field_types import NVARCHAR
+
+
+class NVARCHAR(CharField):
+
+    field_type = NVARCHAR
+    
+    @property
+    def SQL_TYPE(self) -> str:
+        return f"NVARCHAR({self.field.max_length})"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
in mssql when we want to filter non-ascii character we should use it in the format like:
```sql
select * from MyTable where name=N'سلام'
```
and if we use it like other ascii variables we get empty response
```sql
select * from MyTable where name='سلام'
```

## Motivation and Context
in mssql it is impossible to query on non-ascii words

## How Has This Been Tested?
I have added all test for charfield to this field also I have tested create and filter non-ascii chars

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

