### PR TITLE
Fix TestCase | only "models" works as app_label

### DIFF
--- a/tortoise/contrib/test/__init__.py
+++ b/tortoise/contrib/test/__init__.py
@@ -43,6 +43,7 @@ _SELECTOR = None
 _LOOP: AbstractEventLoop = None  # type: ignore
 _MODULES: Iterable[Union[str, ModuleType]] = []
 _CONN_CONFIG: dict = {}
+_APP_LABEL = None
 
 
 def getDBConfig(app_label: str, modules: Iterable[Union[str, ModuleType]]) -> dict:
@@ -103,7 +104,9 @@ def initializer(
     global _TORTOISE_TEST_DB
     global _MODULES
     global _CONN_CONFIG
+    global _APP_LABEL
     _MODULES = modules
+    _APP_LABEL = app_label
     if db_url is not None:  # pragma: nobranch
         _TORTOISE_TEST_DB = db_url
     _CONFIG = getDBConfig(app_label=app_label, modules=_MODULES)
@@ -247,7 +250,7 @@ class IsolatedTestCase(SimpleTestCase):
 
     async def _setUpDB(self) -> None:
         await super()._setUpDB()
-        config = getDBConfig(app_label="models", modules=self.tortoise_test_modules or _MODULES)
+        config = getDBConfig(app_label=_APP_LABEL, modules=self.tortoise_test_modules or _MODULES)
         await Tortoise.init(config, _create_db=True)
         await Tortoise.generate_schemas(safe=False)
 
@@ -327,7 +330,7 @@ class TestCase(TruncationTestCase):
 
     async def asyncSetUp(self) -> None:
         await super().asyncSetUp()
-        self._db = connections.get("models")
+        self._db = connections.get(_APP_LABEL)
         self._transaction = TransactionTestContext(self._db._in_transaction().connection)
         await self._transaction.__aenter__()  # type: ignore
 


### PR DESCRIPTION
    - in the current implementation only "models" works as app_label
    - there is no way to change that during run time as it's hard coded
    - the fix introduces another _APP_LABEL global variable that is set
       in the initializer

Enables testing of apps with other labels than "models" in test classes of tortoise/contrib/test
automagically from the TORTOISE_ORM config dict.

## Description
Following the design of the file, a new global variable is introduced that is defined during the
call of the initializer function. Later occurences of the app_label function  parameter in _setUpDB
member functions, that don't expose the app_label variable, are provided with _APP_LABEL as
default value.

## Motivation and Context
App labels other than 'models' were not correctly propagated to the test functions, as 'models'
was hardcoded as app_label in the _setUpDB member functions.

## How Has This Been Tested?
Existing tests of the package pass. 

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

