### PR TITLE
fix #1462, add field_type for TimeDeltaField

### DIFF
--- a/tortoise/fields/data.py
+++ b/tortoise/fields/data.py
@@ -495,6 +495,7 @@ class TimeDeltaField(Field[datetime.timedelta]):
     A field for storing time differences.
     """
 
+    field_type = datetime.timedelta
     SQL_TYPE = "BIGINT"
 
     class _db_oracle:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
fix https://github.com/tortoise/tortoise-orm/issues/1462

## Motivation and Context
use pydantic_model_creator with fields.TimeDeltaField in 0.19.3  will get error 

```
pydantic.error_wrappers.ValidationError: 1 validation error for DemoSchema
usage_time
  value is not None (type=type_error.not_none)
```
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
https://github.com/tortoise/tortoise-orm/assets/8170059/fa70fa98-0ebe-4c97-80da-2537ce0ac724

<!--- Include details of your testing environment, and the tests you ran to -->
python3.9 
pydantic          1.10.12
tortoise-orm      0.19.3
<!--- see how your change affects other areas of the code, etc. -->
tortoise/fields/data.py:501

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [yes ] My code follows the code style of this project.
- [no] My change requires a change to the documentation.
- [no] I have updated the documentation accordingly.
- [no] I have added the changelog accordingly.
- [yes ] I have read the **CONTRIBUTING** document.
- [no ] I have added tests to cover my changes.
- [no ] All new and existing tests passed.

