### PR TITLE
Fix pydantic v2 pydantic_model_creator nullable field not optional

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Added
 
 Fixed
 ^^^^^
+- Fix pydantic v2 pydantic_model_creator nullable field not optional. (#1454)
 - Fix foreign key constraint not generated on MSSQL Server. (#1400)
 - Fix testcase error with python3.11 (#1308)
 

--- a/examples/blacksheep/models.py
+++ b/examples/blacksheep/models.py
@@ -1,5 +1,9 @@
+import tortoise
 from tortoise import fields, models
 from tortoise.contrib.pydantic import pydantic_model_creator
+
+if tortoise.__version__ >= "0.20":
+    raise RuntimeError("blacksheep not support pydantic V2, use tortoise-orm<0.20 instead!")
 
 
 class Users(models.Model):

--- a/examples/fastapi/main.py
+++ b/examples/fastapi/main.py
@@ -22,7 +22,7 @@ async def get_users():
 
 @app.post("/users", response_model=User_Pydantic)
 async def create_user(user: UserIn_Pydantic):
-    user_obj = await Users.create(**user.dict(exclude_unset=True))
+    user_obj = await Users.create(**user.model_dump(exclude_unset=True))
     return await User_Pydantic.from_tortoise_orm(user_obj)
 
 
@@ -33,7 +33,7 @@ async def get_user(user_id: int):
 
 @app.put("/user/{user_id}", response_model=User_Pydantic)
 async def update_user(user_id: int, user: UserIn_Pydantic):
-    await Users.filter(id=user_id).update(**user.dict(exclude_unset=True))
+    await Users.filter(id=user_id).update(**user.model_dump(exclude_unset=True))
     return await User_Pydantic.from_queryset_single(Users.get(id=user_id))
 
 

--- a/examples/pydantic/tutorial_1.py
+++ b/examples/pydantic/tutorial_1.py
@@ -5,7 +5,7 @@ Here we introduce:
 * Creating a Pydantic model from a Tortoise model
 * Docstrings & doc-comments are used
 * Evaluating the generated schema
-* Simple serialisation with both .dict() and .json()
+* Simple serialisation with both .model_dump() and .json()
 """
 from tortoise import Tortoise, fields, run_async
 from tortoise.contrib.pydantic import pydantic_model_creator
@@ -38,7 +38,7 @@ async def run():
     tourpy = await Tournament_Pydantic.from_tortoise_orm(tournament)
 
     # As Python dict with Python objects (e.g. datetime)
-    print(tourpy.dict())
+    print(tourpy.model_dump())
     # As serialised JSON (e.g. datetime is ISO8601 string representation)
     print(tourpy.json(indent=4))
 

--- a/examples/pydantic/tutorial_2.py
+++ b/examples/pydantic/tutorial_2.py
@@ -46,7 +46,7 @@ async def run():
 
     # As Python dict with Python objects (e.g. datetime)
     # Note that the root element is '__root__' that contains the root element.
-    print(tourpy.dict())
+    print(tourpy.model_dump())
     # As serialised JSON (e.g. datetime is ISO8601 string representation)
     print(tourpy.json(indent=4))
 


### PR DESCRIPTION
Fix pydantic v2 pydantic_model_creator nullable field not optional(#1454)

## How Has This Been Tested?
1. Tests for examples/fastapi passed
2. Tests for examples/blacksheep not work, because it does not support pydantic V2

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

