### PR TITLE
docs: update pydantic `.json` and `.dict` methods in docs

### DIFF
--- a/docs/contrib/pydantic.rst
+++ b/docs/contrib/pydantic.rst
@@ -25,7 +25,7 @@ Here we introduce:
 * Creating a Pydantic model from a Tortoise model
 * Docstrings & doc-comments are used
 * Evaluating the generated schema
-* Simple serialisation with both ``.dict()`` and ``.json()``
+* Simple serialisation with both ``.model_dump()`` and ``.model_dump_json()``
 
 Source to example: :ref:`example_pydantic_tut1`
 
@@ -92,17 +92,17 @@ To serialise an object it is simply *(in an async context)*:
     tournament = await Tournament.create(name="New Tournament")
     tourpy = await Tournament_Pydantic.from_tortoise_orm(tournament)
 
-And one could get the contents by using `regular Pydantic-object methods <https://pydantic-docs.helpmanual.io/usage/exporting_models/>`_, such as ``.dict()`` or ``.json()``
+And one could get the contents by using `regular Pydantic-object methods <https://pydantic-docs.helpmanual.io/usage/exporting_models/>`_, such as ``.model_dump()`` or ``.model_dump_json()``
 
 .. code-block:: py3
 
-    >>> print(tourpy.dict())
+    >>> print(tourpy.model_dump())
     {
         'id': 1,
         'name': 'New Tournament',
         'created_at': datetime.datetime(2020, 3, 1, 20, 28, 9, 346808)
     }
-    >>> print(tourpy.json())
+    >>> print(tourpy.model_dump_json())
     {
         "id": 1,
         "name": "New Tournament",
@@ -202,11 +202,11 @@ To serialise an object it is simply *(in an async context)*:
 
     tourpy = await Tournament_Pydantic_List.from_queryset(Tournament.all())
 
-And one could get the contents by using `regular Pydantic-object methods <https://pydantic-docs.helpmanual.io/usage/exporting_models/>`_, such as ``.dict()`` or ``.json()``
+And one could get the contents by using `regular Pydantic-object methods <https://pydantic-docs.helpmanual.io/usage/exporting_models/>`_, such as ``.model_dump()`` or ``.model_dump_json()``
 
 .. code-block:: py3
 
-    >>> print(tourpy.dict())
+    >>> print(tourpy.model_dump())
     {
         '__root__': [
             {
@@ -226,7 +226,7 @@ And one could get the contents by using `regular Pydantic-object methods <https:
             }
         ]
     }
-    >>> print(tourpy.json())
+    >>> print(tourpy.model_dump_json())
     [
         {
             "id": 2,
@@ -245,7 +245,7 @@ And one could get the contents by using `regular Pydantic-object methods <https:
         }
     ]
 
-Note how ``.dict()`` has a ``_root__`` element with the list, but the ``.json()`` has the list as root.
+Note how ``.model_dump()`` has a ``_root__`` element with the list, but the ``.model_dump_json()`` has the list as root.
 Also note how the results are sorted alphabetically by ``name``.
 
 
@@ -479,7 +479,7 @@ Lets create and serialise the objects and see what they look like *(in an async 
     # Serialise Tournament
     tourpy = await Tournament_Pydantic.from_tortoise_orm(tournament)
 
-    >>> print(tourpy.json())
+    >>> print(tourpy.model_dump_json())
     {
         "id": 1,
         "name": "New Tournament",
@@ -499,7 +499,7 @@ And serialising the event *(in an async context)*:
 
     eventpy = await Event_Pydantic.from_tortoise_orm(event)
 
-    >>> print(eventpy.json())
+    >>> print(eventpy.model_dump_json())
     {
         "id": 1,
         "name": "The Event",
@@ -675,7 +675,7 @@ Lets create and serialise the objects and see what they look like *(in an async 
     # Serialise Tournament
     tourpy = await Tournament_Pydantic.from_tortoise_orm(tournament)
 
-    >>> print(tourpy.json())
+    >>> print(tourpy.model_dump_json())
     {
         "id": 1,
         "name": "New Tournament",


### PR DESCRIPTION
Updated the [Pydantic Serialization Tutorial](https://tortoise.github.io/contrib/pydantic.html?h=pydantic+serialization#tutorial) documentation accordingly to the new API by replacing the `.dict()` and `.json()` by the new ones.

## Description
Methods `.json()` and `.dict` were deprecated in the new Pydantic V2 API, this changes aims to change the related pydantic documentation regarding [Pydantic Serialization Tutorial](https://tortoise.github.io/contrib/pydantic.html?h=pydantic+serialization#tutorial) to the new methods. 

New methods replacements are:
* `.dict()` → `.model_dump()`
* `.json()` → `.model_dump_json()`

See [migration guide](https://docs.pydantic.dev/latest/migration/#changes-to-pydanticbasemodel).

## Motivation and Context
[Pydantic Migration Guide](https://docs.pydantic.dev/latest/migration/)

## How Has This Been Tested?
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ]  I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

