### PR TITLE
Minor type hint fixes

### DIFF
--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -244,7 +244,7 @@ class MetaInfo:
         self.basequery_all_fields: Query = Query()
         self.basetable: Table = Table("")
         self.pk_attr: str = getattr(meta, "pk_attr", "")
-        self.generated_db_fields: Tuple[str] = None  # type: ignore
+        self.generated_db_fields: Tuple[str, ...] = None  # type: ignore
         self._model: Type["Model"] = None  # type: ignore
         self.table_description: str = getattr(meta, "table_description", "")
         self.pk: Field = None  # type: ignore

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -253,7 +253,7 @@ class AwaitableQuery(Generic[MODEL]):
         """Return the actual SQL."""
         return self.as_query().get_sql(**kwargs)
 
-    def as_query(self) -> QUERY:
+    def as_query(self) -> QueryBuilder:
         """Return the actual query."""
         if self._db is None:
             self._db = self._choose_db()  # type: ignore
@@ -1700,7 +1700,7 @@ class BulkUpdateQuery(UpdateQuery, Generic[MODEL]):
         self.objects = objects
         self.fields = fields
         self.batch_size = batch_size
-        self.queries: List[QUERY] = []
+        self.queries: List[QueryBuilder] = []
 
     def _make_query(self) -> None:
         table = self.model._meta.basetable


### PR DESCRIPTION
There isn't much to say here: the old type hints were invalid and these are correct.