### PR TITLE
fix values_list fields order

### DIFF
--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -1507,7 +1507,7 @@ class ValuesListQuery(FieldSelectQuery, Generic[SINGLE]):
         _, result = await self._db.execute_query(str(self.query))
         columns = [
             (key, self.resolve_to_python_value(self.model, name))
-            for key, name in sorted(self.fields.items())
+            for key, name in self.fields.items()
         ]
         if self.flat:
             func = columns[0][1]


### PR DESCRIPTION
Fix fields order for `ValuesListQuery`

<!--- Provide a general summary of your changes in the Title above -->
ValuesListQuery return wrong order list when the number of fields is greater than 10.

## Description
<!--- Describe your changes in detail -->
Starting from python 3.6, the dicts preserve the order of insertion. So there is no need for `sorted` method. Moreover, this gives wrong results if you use more than 10 fields, because `10_field` will come before `2_field`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

