### PR TITLE
Feature: async default value

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Added
 - Enhancement for FastAPI lifespan support (#1371)
 - Add __eq__ method to Q to more easily test dynamically-built queries (#1506)
 - Added PlainToTsQuery function for postgres (#1347)
+- Allow field's default keyword to be async function (#1498)
 
 Fixed
 ^^^^^

--- a/tests/test_callable_default.py
+++ b/tests/test_callable_default.py
@@ -1,0 +1,21 @@
+from tests import testmodels
+from tortoise.contrib import test
+
+
+class TestCallableDefault(test.TestCase):
+    async def test_default_create(self):
+        model = await testmodels.CallableDefault.create()
+        self.assertEqual(model.callable_default, "callable_default")
+        self.assertEqual(model.async_default, "async_callable_default")
+
+    async def test_default_by_save(self):
+        saved_model = testmodels.CallableDefault()
+        await saved_model.save()
+        self.assertEqual(saved_model.callable_default, "callable_default")
+        self.assertEqual(saved_model.async_default, "async_callable_default")
+
+    async def test_async_default_change(self):
+        default_change = testmodels.CallableDefault()
+        default_change.async_default = "changed"
+        await default_change.save()
+        self.assertEqual(default_change.async_default, "changed")

--- a/tests/testmodels.py
+++ b/tests/testmodels.py
@@ -892,3 +892,17 @@ class CamelCaseAliasPerson(Model):
             alias_generator=camelize_var,
             populate_by_name=True,
         )
+
+
+def callable_default() -> str:
+    return "callable_default"
+
+
+async def async_callable_default() -> str:
+    return "async_callable_default"
+
+
+class CallableDefault(Model):
+    id = fields.IntField(pk=True)
+    callable_default = fields.CharField(max_length=32, default=callable_default)
+    async_default = fields.CharField(max_length=32, default=async_callable_default)

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -667,14 +667,24 @@ class Model(metaclass=ModelMeta):
         self._partial = False
         self._saved_in_db = False
         self._custom_generated_pk = False
+        self._await_when_save: Dict[str, Callable[[], Awaitable[Any]]] = {}
 
         # Assign defaults for missing fields
         for key in meta.fields.difference(self._set_kwargs(kwargs)):
             field_object = meta.fields_map[key]
-            if callable(field_object.default):
-                setattr(self, key, field_object.default())
+            field_default = field_object.default
+            if inspect.iscoroutinefunction(field_default):
+                self._await_when_save[key] = field_default
+            elif callable(field_default):
+                setattr(self, key, field_default())
             else:
                 setattr(self, key, deepcopy(field_object.default))
+
+    def __setattr__(self, key, value):
+        # set field value override async default function
+        if hasattr(self, "_await_when_save"):
+            self._await_when_save.pop(key, None)
+        super().__setattr__(key, value)
 
     def _set_kwargs(self, kwargs: dict) -> Set[str]:
         meta = self._meta
@@ -719,6 +729,7 @@ class Model(metaclass=ModelMeta):
         self._partial = False
         self._saved_in_db = True
         self._custom_generated_pk = self._meta.db_pk_column not in self._meta.generated_db_fields
+        self._await_when_save = {}
 
         meta = self._meta
 
@@ -845,6 +856,13 @@ class Model(metaclass=ModelMeta):
         if listener not in cls_listeners:
             cls_listeners.append(listener)
 
+    async def _set_async_default_field(self) -> None:
+        """retrieve value from field's async default value"""
+        if hasattr(self, "_await_when_save"):
+            for k, v in self._await_when_save.items():
+                setattr(self, k, await v())
+            self._await_when_save = {}
+
     async def _pre_delete(
         self,
         using_db: Optional[BaseDBAsyncClient] = None,
@@ -921,6 +939,7 @@ class Model(metaclass=ModelMeta):
         :raises IncompleteInstanceError: If the model is partial and the fields are not available for persistence.
         :raises IntegrityError: If the model can't be created or updated (specifically if force_create or force_update has been set)
         """
+        await self._set_async_default_field()
         db = using_db or self._choose_db(True)
         executor = db.executor_class(model=self.__class__, db=db)
         if self._partial:

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -859,7 +859,7 @@ class Model(metaclass=ModelMeta):
     async def _set_async_default_field(self) -> None:
         """retrieve value from field's async default value"""
         if hasattr(self, "_await_when_save"):
-            for k, v in self._await_when_save.items():
+            for k, v in self._await_when_save.copy().items():
                 setattr(self, k, await v())
             self._await_when_save = {}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
allow Field's default value not only be callable, literal value, but also async function

## Description
<!--- Describe your changes in detail -->
when set Field's default keyword option to async function, then while save and create model, if the field never set, the field will be set as the async function's result

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I write a model and I want a serial of unique, auto increasing serial names generate from redis (by aioredis), but the field's default do not support retrieve value from async function, I have to override create method, that's cumbersome.

and tortoise is an async orm, it should support async first.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I create a new model for new test case, test model's behavior when combine async default with `save`, `create`, and when default field value was covered by set attribute.

I run tests on linux, include sqlite's test cases.

Almost no effect.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

