### PR TITLE
Improve exception log messages

### DIFF
--- a/tortoise/backends/asyncpg/client.py
+++ b/tortoise/backends/asyncpg/client.py
@@ -58,8 +58,13 @@ class AsyncpgDBClient(BasePostgresClient):
         try:
             self._pool = await self.create_pool(password=self.password, **self._template)
             self.log.debug("Created connection pool %s with params: %s", self._pool, self._template)
-        except asyncpg.InvalidCatalogNameError:
-            raise DBConnectionError(f"Can't establish connection to database {self.database}")
+        except asyncpg.InvalidCatalogNameError as ex:
+            msg = "Can't establish connection to "
+            if with_db:
+                msg += f"database {self.database}"
+            else:
+                msg += f"default database. Verify environment PGDATABASE. Exception: {ex}"
+            raise DBConnectionError(msg)
 
     async def create_pool(self, **kwargs) -> asyncpg.Pool:
         return await asyncpg.create_pool(None, **kwargs)


### PR DESCRIPTION
This PR is to improve the exception message I faced when running Tortoise.init with the option _create_db=True. This creates a connection without database set. But asyncpg library internally try to set database as os.getenv('PGDATABASE') or as the db username otherwise. This issue happened to me when running with WSL + docker; the exception error message gave me no clue what was happening. So, after a lot of debugging, all I had to do was to set 'PGDATABASE' environment as 'postgres'.
