### PR TITLE
Enhancement for FastAPI lifespan support (#1371)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Changelog
 ------
 Added
 ^^^^^
+- Enhancement for FastAPI lifespan support (#1371)
 - Add binary compression support for `UUIDField` in `MySQL`. (#1458)
 - Only `Model`, `Tortoise`, `BaseDBAsyncClient`, `__version__`, and `connections` are now exported from `tortoise`
 - Add parameter `validators` to `pydantic_model_creator`. (#1471)

--- a/docs/contrib/fastapi.rst
+++ b/docs/contrib/fastapi.rst
@@ -4,7 +4,7 @@
 Tortoise-ORM FastAPI integration
 ================================
 
-We have a lightweight integration util ``tortoise.contrib.fastapi`` which has a single function ``register_tortoise`` which sets up Tortoise-ORM on startup and cleans up on teardown.
+We have a lightweight integration util ``tortoise.contrib.fastapi`` which has a class ``RegisterTortoise`` that can be used to set up/clean up Tortoise-ORM in lifespan context.
 
 FastAPI is basically Starlette & Pydantic, but in a very specific way.
 

--- a/examples/fastapi/README.rst
+++ b/examples/fastapi/README.rst
@@ -1,7 +1,7 @@
 Tortoise-ORM FastAPI example
 ============================
 
-We have a lightweight integration util ``tortoise.contrib.fastapi`` which has a single function ``register_tortoise`` which sets up Tortoise-ORM on startup and cleans up on teardown.
+We have a lightweight integration util ``tortoise.contrib.fastapi`` which has a class ``RegisterTortoise`` that can be used to sets up and cleans up Tortoise-ORM in lifespan context.
 
 Usage
 -----

--- a/examples/fastapi/main.py
+++ b/examples/fastapi/main.py
@@ -1,4 +1,5 @@
 # pylint: disable=E0611,E0401
+from contextlib import asynccontextmanager
 from typing import List
 
 from fastapi import FastAPI
@@ -6,9 +7,26 @@ from models import User_Pydantic, UserIn_Pydantic, Users
 from pydantic import BaseModel
 from starlette.exceptions import HTTPException
 
-from tortoise.contrib.fastapi import register_tortoise
+from tortoise.contrib.fastapi import RegisterTortoise
 
-app = FastAPI(title="Tortoise ORM FastAPI example")
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # app startup
+    async with RegisterTortoise(
+        app,
+        db_url="sqlite://:memory:",
+        modules={"models": ["models"]},
+        generate_schemas=True,
+        add_exception_handlers=True,
+    ):
+        # db connected
+        yield
+        # app teardown
+    # db connections closed
+
+
+app = FastAPI(title="Tortoise ORM FastAPI example", lifespan=lifespan)
 
 
 class Status(BaseModel):
@@ -43,12 +61,3 @@ async def delete_user(user_id: int):
     if not deleted_count:
         raise HTTPException(status_code=404, detail=f"User {user_id} not found")
     return Status(message=f"Deleted user {user_id}")
-
-
-register_tortoise(
-    app,
-    db_url="sqlite://:memory:",
-    modules={"models": ["models"]},
-    generate_schemas=True,
-    add_exception_handlers=True,
-)

--- a/tortoise/contrib/fastapi/__init__.py
+++ b/tortoise/contrib/fastapi/__init__.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+import warnings
+from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from types import ModuleType
 from typing import Dict, Iterable, Optional, Union
 
@@ -5,6 +9,7 @@ from fastapi import FastAPI
 from pydantic import BaseModel  # pylint: disable=E0611
 from starlette.requests import Request
 from starlette.responses import JSONResponse
+from starlette.routing import _DefaultLifespan
 
 from tortoise import Tortoise, connections
 from tortoise.exceptions import DoesNotExist, IntegrityError
@@ -13,6 +18,126 @@ from tortoise.log import logger
 
 class HTTPNotFoundError(BaseModel):
     detail: str
+
+
+class RegisterTortoise(AbstractAsyncContextManager):
+    """
+    Registers Tortoise-ORM with set-up and tear-down
+    inside a FastAPI application's lifespan.
+
+    You can configure using only one of ``config``, ``config_file``
+    and ``(db_url, modules)``.
+
+    Parameters
+    ----------
+    app:
+        FastAPI app.
+    config:
+        Dict containing config:
+
+        Example
+        -------
+
+        .. code-block:: python3
+
+            {
+                'connections': {
+                    # Dict format for connection
+                    'default': {
+                        'engine': 'tortoise.backends.asyncpg',
+                        'credentials': {
+                            'host': 'localhost',
+                            'port': '5432',
+                            'user': 'tortoise',
+                            'password': 'qwerty123',
+                            'database': 'test',
+                        }
+                    },
+                    # Using a DB_URL string
+                    'default': 'postgres://postgres:qwerty123@localhost:5432/events'
+                },
+                'apps': {
+                    'models': {
+                        'models': ['__main__'],
+                        # If no default_connection specified, defaults to 'default'
+                        'default_connection': 'default',
+                    }
+                }
+            }
+
+    config_file:
+        Path to .json or .yml (if PyYAML installed) file containing config with
+        same format as above.
+    db_url:
+        Use a DB_URL string. See :ref:`db_url`
+    modules:
+        Dictionary of ``key``: [``list_of_modules``] that defined "apps" and modules that
+        should be discovered for models.
+    generate_schemas:
+        True to generate schema immediately. Only useful for dev environments
+        or SQLite ``:memory:`` databases
+    add_exception_handlers:
+        True to add some automatic exception handlers for ``DoesNotExist`` & ``IntegrityError``.
+        This is not recommended for production systems as it may leak data.
+
+    Raises
+    ------
+    ConfigurationError
+        For any configuration error
+    """
+
+    def __init__(
+        self,
+        app: FastAPI,
+        config: Optional[dict] = None,
+        config_file: Optional[str] = None,
+        db_url: Optional[str] = None,
+        modules: Optional[Dict[str, Iterable[Union[str, ModuleType]]]] = None,
+        generate_schemas: bool = False,
+        add_exception_handlers: bool = False,
+    ) -> None:
+        self.app = app
+        self.config = config
+        self.config_file = config_file
+        self.db_url = db_url
+        self.modules = modules
+        self.generate_schemas = generate_schemas
+        if add_exception_handlers:
+
+            @app.exception_handler(DoesNotExist)
+            async def doesnotexist_exception_handler(request: Request, exc: DoesNotExist):
+                return JSONResponse(status_code=404, content={"detail": str(exc)})
+
+            @app.exception_handler(IntegrityError)
+            async def integrityerror_exception_handler(request: Request, exc: IntegrityError):
+                return JSONResponse(
+                    status_code=422,
+                    content={"detail": [{"loc": [], "msg": str(exc), "type": "IntegrityError"}]},
+                )
+
+    async def init_orm(self) -> None:  # pylint: disable=W0612
+        config, config_file = self.config, self.config_file
+        db_url, modules = self.db_url, self.modules
+        await Tortoise.init(config=config, config_file=config_file, db_url=db_url, modules=modules)
+        logger.info("Tortoise-ORM started, %s, %s", connections._get_storage(), Tortoise.apps)
+        if self.generate_schemas:
+            logger.info("Tortoise-ORM generating schema")
+            await Tortoise.generate_schemas()
+
+    @staticmethod
+    async def close_orm() -> None:  # pylint: disable=W0612
+        await connections.close_all()
+        logger.info("Tortoise-ORM shutdown")
+
+    def __call__(self, *args, **kwargs) -> "RegisterTortoise":
+        return self
+
+    async def __aenter__(self):
+        await self.init_orm()
+        return self
+
+    async def __aexit__(self, *args, **kw):
+        await self.close_orm()
 
 
 def register_tortoise(
@@ -88,29 +213,41 @@ def register_tortoise(
     ConfigurationError
         For any configuration error
     """
+    orm = RegisterTortoise(
+        app,
+        config,
+        config_file,
+        db_url,
+        modules,
+        generate_schemas,
+        add_exception_handlers,
+    )
+    lifespan = app.router.lifespan_context
+    if isinstance(lifespan, _DefaultLifespan):
+        # Leave on_event here to compare with old versions
+        # So people can upgrade tortoise-orm in running project without changing any code
 
-    @app.on_event("startup")
-    async def init_orm() -> None:  # pylint: disable=W0612
-        await Tortoise.init(config=config, config_file=config_file, db_url=db_url, modules=modules)
-        logger.info("Tortoise-ORM started, %s, %s", connections._get_storage(), Tortoise.apps)
-        if generate_schemas:
-            logger.info("Tortoise-ORM generating schema")
-            await Tortoise.generate_schemas()
+        @app.on_event("startup")  # type: ignore[unreachable]
+        async def init_orm() -> None:  # pylint: disable=W0612
+            await orm.init_orm()
 
-    @app.on_event("shutdown")
-    async def close_orm() -> None:  # pylint: disable=W0612
-        await connections.close_all()
-        logger.info("Tortoise-ORM shutdown")
+        @app.on_event("shutdown")
+        async def close_orm() -> None:  # pylint: disable=W0612
+            await orm.close_orm()
 
-    if add_exception_handlers:
+    else:
+        # If custom lifespan was passed to app, register tortoise in it
+        warnings.warn(
+            "`register_tortoise` function is deprecated, "
+            "use the `RegisterTortoise` class instead."
+            "See more about it on https://tortoise.github.io/examples/fastapi.",
+            DeprecationWarning,
+        )
 
-        @app.exception_handler(DoesNotExist)
-        async def doesnotexist_exception_handler(request: Request, exc: DoesNotExist):
-            return JSONResponse(status_code=404, content={"detail": str(exc)})
+        @asynccontextmanager
+        async def orm_lifespan(_app: FastAPI):
+            async with orm:
+                async with lifespan(_app):
+                    yield
 
-        @app.exception_handler(IntegrityError)
-        async def integrityerror_exception_handler(request: Request, exc: IntegrityError):
-            return JSONResponse(
-                status_code=422,
-                content={"detail": [{"loc": [], "msg": str(exc), "type": "IntegrityError"}]},
-            )
+        app.router.lifespan_context = orm_lifespan


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
- Add a new class `RegisterTortoise` which can be used in lifespan context
- Enhancement `register_tortoise` to auto run in lifespan context, but echo deprecated warning

## Description
<!--- Describe your changes in detail -->
Support register in fastapi's lifespan and leave `register_tortoise` there to compare old version

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For some running projects, people may want to only upgrade dependencies without changing any code.

While for new project, it is more flexibility to use `async with` format to register db.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```bash
make test
cd examples/fastapi && PYTHONPATH=. pytest _tests.py
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

