### PR TITLE
fix: bulk_update when using models with custom fields

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Added
 Fixed
 ^^^^^
 - Fix `DatetimeField` use '__year' report `'int' object has no attribute 'utcoffset'`. (#1575)
+- Fix `bulk_update` when using custom fields. (#1564)
 
 0.20.1
 ------

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -54,6 +54,7 @@ Contributors
 * Stanislav Zmiev ``@Ovsyanka83``
 * Waket Zheng ``@waketzheng``
 * Yuval Ben-Arie ``@yuvalbenarie``
+* Stephan Klein ``@privatwolke``
 
 Special Thanks
 ==============

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -6,11 +6,14 @@ import pytz
 from pypika.terms import Function
 
 from tests.testmodels import (
+    Currency,
     DatetimeFields,
     DefaultUpdate,
+    EnumFields,
     Event,
     IntFields,
     JSONFields,
+    Service,
     SmallIntFields,
     Tournament,
     UUIDFields,
@@ -89,6 +92,20 @@ class TestUpdate(test.TestCase):
         self.assertEqual(rows_affected, 2)
         self.assertEqual((await SmallIntFields.get(pk=objs[0].pk)).smallintnum_null, None)
         self.assertEqual((await SmallIntFields.get(pk=objs[1].pk)).smallintnum_null, None)
+
+    async def test_bulk_update_custom_field(self):
+        objs = [
+            await EnumFields.create(service=Service.python_programming, currency=Currency.EUR),
+            await EnumFields.create(service=Service.database_design, currency=Currency.USD),
+        ]
+        objs[0].currency = Currency.USD
+        objs[1].service = Service.system_administration
+        rows_affected = await EnumFields.bulk_update(objs, fields=["service", "currency"])
+        self.assertEqual(rows_affected, 2)
+        self.assertEqual((await EnumFields.get(pk=objs[0].pk)).currency, Currency.USD)
+        self.assertEqual(
+            (await EnumFields.get(pk=objs[1].pk)).service, Service.system_administration
+        )
 
     async def test_update_auto_now(self):
         obj = await DefaultUpdate.create()

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -1807,7 +1807,7 @@ class BulkUpdateQuery(UpdateQuery, Generic[MODEL]):
                 pk_list = []
                 for obj in objects_item:
                     value = executor.column_map[pk_attr](obj.pk, None)
-                    field_value = getattr(obj, field)
+                    field_value = obj._meta.fields_map[field].to_db_value(getattr(obj, field), obj)
                     case.when(
                         pk == value,
                         (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* The `bulk_update` feature doesn't properly serialize values from custom fields.
* This PR modifies the way values are retrieved when composing the `BulkUpdateQuery`.


## Motivation and Context
This change allows `bulk_update` usage also with models that use custom fields.


## How Has This Been Tested?
A test has been added which fails on the latest state of the develop branch.
After applying the changes from this PR, the test passes as expected.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

