### PR TITLE
fix: `DatetimeField` use __year report `'int' object has no attribute 'utcoffset'`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ Fixed
 - Fix pydantic v2.5 unittest error. (#1535)
 - Fix pydantic_model_creator `exclude_readonly` parameter not working.
 - Fix annotation propagation for non-filter queries. (#1590)
+- Fix `DatetimeField` use '__year' report `'int' object has no attribute 'utcoffset'`. (#1575)
 
 0.20.0
 ------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,5 +180,5 @@ source = ["tortoise"]
 [tool.coverage.report]
 show_missing = true
 
-[tool.ruff]
+[tool.ruff.lint]
 ignore = ["E501"]


### PR DESCRIPTION
Fix `DatetimeField` use '__year' report `'int' object has no attribute 'utcoffset'`. (#1575)
When config with `"use_tz": True`, the bug  can be reproduced.

