### PR TITLE
fix `exclude_readonly` param not working in `pydantic_model_creator`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,7 +22,7 @@ Fixed
 - Fix order of fields in `ValuesListQuery` when it has more than 10 fields. (#1492)
 - Fix pydantic v2 pydantic_model_creator nullable field not optional. (#1454)
 - Fix pydantic v2.5 unittest error. (#1535)
-- Fix pydantic_model_creator `exclude` parameter not working.
+- Fix pydantic_model_creator `exclude_readonly` parameter not working.
 
 0.20.0
 ------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Fixed
 - Fix order of fields in `ValuesListQuery` when it has more than 10 fields. (#1492)
 - Fix pydantic v2 pydantic_model_creator nullable field not optional. (#1454)
 - Fix pydantic v2.5 unittest error. (#1535)
+- Fix pydantic_model_creator `exclude` parameter not working.
 
 0.20.0
 ------

--- a/tests/contrib/test_pydantic.py
+++ b/tests/contrib/test_pydantic.py
@@ -1278,6 +1278,11 @@ class TestPydantic(test.TestCase):
             PydanticModel.model_config["from_attributes"],
         )
 
+    def test_exclude_read_only(self):
+        ModelPydantic = pydantic_model_creator(User, exclude_readonly=True)
+
+        self.assertNotIn("id", ModelPydantic.model_json_schema()["properties"])
+
 
 class TestPydanticCycle(test.TestCase):
     async def asyncSetUp(self) -> None:

--- a/tests/contrib/test_pydantic.py
+++ b/tests/contrib/test_pydantic.py
@@ -1279,9 +1279,9 @@ class TestPydantic(test.TestCase):
         )
 
     def test_exclude_read_only(self):
-        ModelPydantic = pydantic_model_creator(User, exclude_readonly=True)
+        ModelPydantic = pydantic_model_creator(Event, exclude_readonly=True)
 
-        self.assertNotIn("id", ModelPydantic.model_json_schema()["properties"])
+        self.assertNotIn("modified", ModelPydantic.model_json_schema()["properties"])
 
 
 class TestPydanticCycle(test.TestCase):

--- a/tortoise/contrib/pydantic/creator.py
+++ b/tortoise/contrib/pydantic/creator.py
@@ -406,7 +406,7 @@ def pydantic_model_creator(
                 json_schema_extra["nullable"] = True
             if fdesc.get("nullable") or field_default is not None or fname in optional:
                 ptype = Optional[ptype]
-            if not (exclude_readonly and fdesc["constraints"].get("readOnly") is True):
+            if not (exclude_readonly and json_schema_extra.get("readOnly") is True):
                 properties[fname] = annotation or ptype
 
         if fname in properties and not isinstance(properties[fname], tuple):


### PR DESCRIPTION
The `exclude_readonly` paramter in `pydantic_model_creator` is not working, i.e it is ignored. `readOnly` is deleted from `fdesc["constraints"]` so instead we read it from `extra_json_schema`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

