### PR TITLE
Update fastapi example to avoid httpx warning: `The "app" shortcut is now deprecated.`

### DIFF
--- a/examples/fastapi/_tests.py
+++ b/examples/fastapi/_tests.py
@@ -2,7 +2,7 @@
 # pylint: disable=E0611,E0401
 import pytest
 from asgi_lifespan import LifespanManager
-from httpx import AsyncClient
+from httpx import ASGITransport, AsyncClient
 from main import app
 from models import Users
 
@@ -15,7 +15,8 @@ def anyio_backend():
 @pytest.fixture(scope="module")
 async def client():
     async with LifespanManager(app):
-        async with AsyncClient(app=app, base_url="http://test") as c:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as c:
             yield c
 
 

--- a/examples/fastapi/main.py
+++ b/examples/fastapi/main.py
@@ -2,10 +2,9 @@
 from contextlib import asynccontextmanager
 from typing import List
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from models import User_Pydantic, UserIn_Pydantic, Users
 from pydantic import BaseModel
-from starlette.exceptions import HTTPException
 
 from tortoise.contrib.fastapi import RegisterTortoise
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Unittest of fastapi example print warning message with newer version httpx:
```
examples/fastapi/_tests.py::test_create_user
  /Users/mac10.12/Library/Caches/pypoetry/virtualenvs/tortoise-orm-iT379CwK-py3.10/lib/python3.10/site-packages/httpx/_client.py:1426: DeprecationWarning: The 'app' shortcut is now deprecated. Use the explicit style 'transport=ASGITransport(app=...)' instead.
    warnings.warn(message, DeprecationWarning)
```

## Description
<!--- Describe your changes in detail -->
How to reproduce:
```bash
cd examples/fastapi
pytest _tests.py
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
make ci && cd examples/fastapi && pytest _tests.py

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.