### PR TITLE
Remove duplicate version info

### DIFF
--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,8 @@
+import subprocess
+
+from tortoise import __version__
+
+
+def test_version():
+    r = subprocess.run(["poetry", "version", "-s"], capture_output=True)
+    r.stdout.decode() == __version__

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,8 +1,19 @@
-import subprocess
+import sys
+from pathlib import Path
 
 from tortoise import __version__
 
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomlkit as tomllib
+
+
+def _read_version() -> str:
+    text = Path("pyproject.toml").read_text()
+    data = tomllib.loads(text)
+    return data["tool"]["poetry"]["version"]
+
 
 def test_version():
-    r = subprocess.run(["poetry", "version", "-s"], capture_output=True)
-    assert r.stdout.decode().strip() == __version__
+    assert _read_version() == __version__

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -5,4 +5,4 @@ from tortoise import __version__
 
 def test_version():
     r = subprocess.run(["poetry", "version", "-s"], capture_output=True)
-    r.stdout.decode() == __version__
+    assert r.stdout.decode().strip() == __version__

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -9,7 +9,7 @@ else:
     import tomlkit as tomllib
 
 
-def _read_version() -> str:
+def _read_version():
     text = Path("pyproject.toml").read_text()
     data = tomllib.loads(text)
     return data["tool"]["poetry"]["version"]

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -6,7 +6,6 @@ import os
 import warnings
 from copy import deepcopy
 from inspect import isclass
-from pathlib import Path
 from types import ModuleType
 from typing import Coroutine, Dict, Iterable, List, Optional, Tuple, Type, Union, cast
 
@@ -692,7 +691,7 @@ def run_async(coro: Coroutine) -> None:
         loop.run_until_complete(connections.close_all(discard=True))
 
 
-__version__ = importlib_metadata.version(Path(__file__).parent.parent.name)
+__version__ = importlib_metadata.version("tortoise-orm")
 
 __all__ = [
     "Model",

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -1,10 +1,12 @@
 import asyncio
 import importlib
+import importlib.metadata as importlib_metadata
 import json
 import os
 import warnings
 from copy import deepcopy
 from inspect import isclass
+from pathlib import Path
 from types import ModuleType
 from typing import Coroutine, Dict, Iterable, List, Optional, Tuple, Type, Union, cast
 
@@ -690,7 +692,7 @@ def run_async(coro: Coroutine) -> None:
         loop.run_until_complete(connections.close_all(discard=True))
 
 
-__version__ = "0.20.1"
+__version__ = importlib_metadata.version(Path(__file__).parent.parent.name)
 
 __all__ = [
     "Model",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Both `pyproject.toml` and `tortoise/__init__.py` have version info (current is 0.20.1)

There are two ways to make it only one: 
- The current [official way of doing it without duplicating the value](https://github.com/python-poetry/poetry/pull/2366#issuecomment-652418094) is with `importlib.metadata`
- Another way is use a poetry plugin [poetry-version-plugin](https://github.com/tiangolo/poetry-version-plugin)

As we do not need to support python3.7 and `importlib.metadata` is much more simple, so I use it in `tortoise/__init__.py`, and introduce new testcase `tests/test_version.py`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Note: At local development environment, when version in pyproject.toml was changed, `python -c 'from tortoise import __version__;print(__version__)'` will not print the new one, unless you run `make deps` again.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
make ci

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

