### PR TITLE
fix: Make get_annotations evaluate annotations in default scope

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ Fixed
 - Fix `DatetimeField` use '__year' report `'int' object has no attribute 'utcoffset'`. (#1575)
 - Fix `bulk_update` when using custom fields. (#1564)
 - Fix `optional` parameter in `pydantic_model_creator` does not work for pydantic v2. (#1551)
+- Fix `get_annotations` now evaluates annotations in the default scope instead of the app namespace. (#1552)
 
 0.20.1
 ------

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -55,6 +55,7 @@ Contributors
 * Waket Zheng ``@waketzheng``
 * Yuval Ben-Arie ``@yuvalbenarie``
 * Stephan Klein ``@privatwolke``
+* ``@WizzyGeek``
 
 Special Thanks
 ==============

--- a/tortoise/contrib/pydantic/utils.py
+++ b/tortoise/contrib/pydantic/utils.py
@@ -14,5 +14,4 @@ def get_annotations(cls: "Type[Model]", method: Optional[Callable] = None) -> Di
     :param method: If specified, we try to get the annotations for the callable
     :return: The list of annotations
     """
-    globalns = tortoise.Tortoise.apps.get(cls._meta.app, None) if cls._meta.app else None
-    return typing.get_type_hints(method or cls, globalns=globalns)
+    return typing.get_type_hints(method or cls)

--- a/tortoise/contrib/pydantic/utils.py
+++ b/tortoise/contrib/pydantic/utils.py
@@ -1,8 +1,6 @@
 import typing
 from typing import Any, Callable, Dict, Optional, Type
 
-import tortoise
-
 if typing.TYPE_CHECKING:  # pragma: nocoverage
     from tortoise.models import Model
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Might be a breaking change, evaluates the annotations in the default scope instead of app namespace.

## Motivation and Context
Fixes #1552

## How Has This Been Tested?
Tested by execution on an existing codebase.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

