### PR TITLE
More efficient `utils.chunk`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,7 +25,6 @@ Fixed
 - Fix `bulk_update` when using custom fields. (#1564)
 - Fix `optional` parameter in `pydantic_model_creator` does not work for pydantic v2. (#1551)
 - Fix `get_annotations` now evaluates annotations in the default scope instead of the app namespace. (#1552)
-- Fix `BulkCreateQuery` now does not convert `objects` to list.
 
 Changed
 ^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,11 @@ Fixed
 - Fix `bulk_update` when using custom fields. (#1564)
 - Fix `optional` parameter in `pydantic_model_creator` does not work for pydantic v2. (#1551)
 - Fix `get_annotations` now evaluates annotations in the default scope instead of the app namespace. (#1552)
+- Fix `BulkCreateQuery` now does not convert `objects` to list.
+
+Changed
+^^^^^^^
+- Change `utils.chunk` from function to return iterables lazily.
 
 0.20.1
 ------

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -56,6 +56,7 @@ Contributors
 * Yuval Ben-Arie ``@yuvalbenarie``
 * Stephan Klein ``@privatwolke``
 * ``@WizzyGeek``
+* Abdeldjalil Hezouat ``@Abdeldjalil-H``
 
 Special Thanks
 ==============

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -1861,7 +1861,7 @@ class BulkCreateQuery(AwaitableQuery, Generic[MODEL]):
         on_conflict: Optional[Iterable[str]] = None,
     ):
         super().__init__(model)
-        self.objects = list(objects)
+        self.objects = objects
         self.ignore_conflicts = ignore_conflicts
         self.batch_size = batch_size
         self._db = db

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -1861,7 +1861,7 @@ class BulkCreateQuery(AwaitableQuery, Generic[MODEL]):
         on_conflict: Optional[Iterable[str]] = None,
     ):
         super().__init__(model)
-        self.objects = objects
+        self.objects = list(objects)
         self.ignore_conflicts = ignore_conflicts
         self.batch_size = batch_size
         self._db = db

--- a/tortoise/utils.py
+++ b/tortoise/utils.py
@@ -1,6 +1,18 @@
+import sys
 from typing import TYPE_CHECKING, Any, Iterable, Optional
 
 from tortoise.log import logger
+
+if sys.version_info >= (3, 12):
+    from itertools import batched
+else:
+    from itertools import islice
+
+    def batched(iterable, n):
+        it = iter(iterable)
+        while batch := tuple(islice(it, n)):
+            yield batch
+
 
 if TYPE_CHECKING:  # pragma: nocoverage
     from tortoise.backends.base.client import BaseDBAsyncClient
@@ -39,6 +51,4 @@ def chunk(instances: Iterable[Any], batch_size: Optional[int] = None) -> Iterabl
     if not batch_size:
         yield instances
     else:
-        instances = list(instances)
-        for i in range(0, len(instances), batch_size):
-            yield instances[i : i + batch_size]  # noqa:E203
+        yield from batched(instances, batch_size)

--- a/tortoise/utils.py
+++ b/tortoise/utils.py
@@ -1,5 +1,5 @@
 import sys
-from typing import TYPE_CHECKING, Any, Iterable, Optional
+from typing import TYPE_CHECKING, Any, Iterable, Optional, Tuple
 
 from tortoise.log import logger
 
@@ -8,7 +8,7 @@ if sys.version_info >= (3, 12):
 else:
     from itertools import islice
 
-    def batched(iterable, n):
+    def batched(iterable: Iterable[Any], n: int) -> Iterable[Tuple[Any]]:
         it = iter(iterable)
         while batch := tuple(islice(it, n)):
             yield batch


### PR DESCRIPTION
The `utils.chunk` function from `tortoise.utils` is converting `instances` into list. I think it is better to not load all the list at one time but rather in chunks as the name suggested. This is useful in cases when the user passes a generator instead of list especially for large datasets.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

