### PR TITLE
fix index name

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,7 @@ Fixed
 - Fix `optional` parameter in `pydantic_model_creator` does not work for pydantic v2. (#1551)
 - Fix `get_annotations` now evaluates annotations in the default scope instead of the app namespace. (#1552)
 - Fix `get_or_create` method. (#1404)
+- Use `index_name` instead of `BaseSchemaGenerator._generate_index_name` to generate index name.
 
 Changed
 ^^^^^^^

--- a/tortoise/indexes.py
+++ b/tortoise/indexes.py
@@ -40,24 +40,17 @@ class Index:
 
     def get_sql(self, schema_generator: "BaseSchemaGenerator", model: "Type[Model]", safe: bool):
         if self.fields:
-            return self.INDEX_CREATE_TEMPLATE.format(
-                exists="IF NOT EXISTS " if safe else "",
-                index_name=schema_generator.quote(
-                    self.name or schema_generator._generate_index_name("idx", model, self.fields)
-                ),
-                index_type=f" {self.INDEX_TYPE} ",
-                table_name=schema_generator.quote(model._meta.db_table),
-                fields=", ".join(schema_generator.quote(f) for f in self.fields),
-                extra=self.extra,
-            )
+            fields = ", ".join(schema_generator.quote(f) for f in self.fields)
+        else:
+            expressions = [f"({expression.get_sql()})" for expression in self.expressions]
+            fields = ", ".join(expressions)
 
-        expressions = [f"({expression.get_sql()})" for expression in self.expressions]
         return self.INDEX_CREATE_TEMPLATE.format(
             exists="IF NOT EXISTS " if safe else "",
-            index_name=self.index_name(schema_generator, model),
+            index_name=schema_generator.quote(self.index_name(schema_generator, model)),
             index_type=f" {self.INDEX_TYPE} ",
             table_name=schema_generator.quote(model._meta.db_table),
-            fields=", ".join(expressions),
+            fields=fields,
             extra=self.extra,
         )
 


### PR DESCRIPTION
Use `index_name` from class `Index` to get index name instead of `BaseSchemaGenerator._generate_index_name`.

## Motivation and Context
This allows you to create your custom index class that inherits from `Index` and override `index_name` method to set index name. 

## How Has This Been Tested?
On existing tests.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

