### PR TITLE
Fix test filters todo

### DIFF
--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -303,17 +303,13 @@ class TestCharFkFieldFilters(test.TestCase):
         )
 
     async def test_isnull(self):
-        self.assertSetEqual(
-            set(await CharPkModel.filter(children__isnull=True).values_list("id", flat=True)),
-            {"2001"},
+        self.assertEqual(
+            await CharPkModel.filter(children__isnull=True).values_list("id", flat=True),
+            ["2001"],
         )
-        self.assertSetEqual(
-            set(await CharPkModel.filter(children__isnull=False).values_list("id", flat=True)),
-            {
-                "17",
-                "17",
-                "12",
-            },  # TODO: [4/7/2021 by Mykola] Not sure if this is an expected behavior
+        self.assertEqual(
+            await CharPkModel.filter(children__isnull=False).values_list("id", flat=True),
+            ["17", "17", "12"],
         )
 
     async def test_not_isnull(self):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -303,13 +303,15 @@ class TestCharFkFieldFilters(test.TestCase):
         )
 
     async def test_isnull(self):
-        self.assertEqual(
-            await CharPkModel.filter(children__isnull=True).values_list("id", flat=True),
-            ["2001"],
+        self.assertSetEqual(
+            set(await CharPkModel.filter(children__isnull=True).values_list("id", flat=True)),
+            {"2001"},
         )
         self.assertEqual(
-            await CharPkModel.filter(children__isnull=False).values_list("id", flat=True),
-            ["17", "17", "12"],
+            await CharPkModel.filter(children__isnull=False)
+            .order_by("id")
+            .values_list("id", flat=True),
+            ["12", "17", "17"],
         )
 
     async def test_not_isnull(self):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes TODO item in tests/test_filters.py

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Django get result of: `['17', '17', '12']`
But test_mysql_myisam get result of `['12', '17', '17']`
So I add `.order_by("id")`

To reproduce Django result:
```bash
python3 -m venv venv
source venv/*/activate
pip install django
python -m django startproject haha
cd haha
python manage.py startapp foo
echo 'from django.db import models

class CharPkModel(models.Model):
    id = models.CharField(max_length=64, primary_key=True)

class CharFkRelatedModel(models.Model):
    model = models.ForeignKey(CharPkModel, related_name="children", on_delete=models.CASCADE)
' > foo/models.py
echo 'INSTALLED_APPS.append("foo")' >> haha/settings.py
python manage.py makemigrations
python manage.py migrate
python manage.py shell
```
```py
from foo.models import *
objs=CharPkModel.objects.bulk_create([CharPkModel(id=i) for i in '17 12 2001'.split()])
CharFkRelatedModel.objects.bulk_create([CharFkRelatedModel(model=i) for i in (objs[0], objs[0], objs[1])])
CharPkModel.objects.filter(children__isnull=False).values_list('id', flat=True)
```

<img width="1396" alt="image" src="https://github.com/tortoise/tortoise-orm/assets/35413830/9d51782c-7d22-4755-bda3-9c01970e9c16">


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
make ci

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

