### PR TITLE
feat: support primary_key/db_index and mark pk/index as deprecated

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,7 @@ Changed
 ^^^^^^^
 - Change `utils.chunk` from function to return iterables lazily.
 - Removed lower bound of id keys in generated pydantic models. (#1602)
+- Rename Field initial arguments `pk`/`index` to `primary_key`/`db_index`. (#1621)
 
 Breaking Changes
 ^^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -101,7 +101,7 @@ You can start writing models like this:
     from tortoise import fields
 
     class Tournament(Model):
-        id = fields.IntField(pk=True)
+        id = fields.IntField(primary_key=True)
         name = fields.TextField()
 
         def __str__(self):
@@ -109,7 +109,7 @@ You can start writing models like this:
 
 
     class Event(Model):
-        id = fields.IntField(pk=True)
+        id = fields.IntField(primary_key=True)
         name = fields.TextField()
         tournament = fields.ForeignKeyField('models.Tournament', related_name='events')
         participants = fields.ManyToManyField('models.Team', related_name='events', through='event_team')
@@ -119,7 +119,7 @@ You can start writing models like this:
 
 
     class Team(Model):
-        id = fields.IntField(pk=True)
+        id = fields.IntField(primary_key=True)
         name = fields.TextField()
 
         def __str__(self):

--- a/docs/contrib/pydantic.rst
+++ b/docs/contrib/pydantic.rst
@@ -40,7 +40,7 @@ Lets start with a basic Tortoise Model:
         """
         This references a Tournament
         """
-        id = fields.IntField(pk=True)
+        id = fields.IntField(primary_key=True)
         name = fields.CharField(max_length=100)
         #: The date-time the Tournament record was created at
         created_at = fields.DatetimeField(auto_now_add=True)
@@ -131,7 +131,7 @@ Source to example: :ref:`example_pydantic_tut2`
         """
         This references a Tournament
         """
-        id = fields.IntField(pk=True)
+        id = fields.IntField(primary_key=True)
         name = fields.CharField(max_length=100)
         #: The date-time the Tournament record was created at
         created_at = fields.DatetimeField(auto_now_add=True)
@@ -278,7 +278,7 @@ We define our models with a relationship:
         This references a Tournament
         """
 
-        id = fields.IntField(pk=True)
+        id = fields.IntField(primary_key=True)
         name = fields.CharField(max_length=100)
         #: The date-time the Tournament record was created at
         created_at = fields.DatetimeField(auto_now_add=True)
@@ -288,7 +288,7 @@ We define our models with a relationship:
         This references an Event in a Tournament
         """
 
-        id = fields.IntField(pk=True)
+        id = fields.IntField(primary_key=True)
         name = fields.CharField(max_length=100)
         created_at = fields.DatetimeField(auto_now_add=True)
 
@@ -533,7 +533,7 @@ Let's add some methods that calculate data, and tell the creators to use them:
         This references a Tournament
         """
 
-        id = fields.IntField(pk=True)
+        id = fields.IntField(primary_key=True)
         name = fields.CharField(max_length=100)
         created_at = fields.DatetimeField(auto_now_add=True)
 
@@ -568,7 +568,7 @@ Let's add some methods that calculate data, and tell the creators to use them:
         This references an Event in a Tournament
         """
 
-        id = fields.IntField(pk=True)
+        id = fields.IntField(primary_key=True)
         name = fields.CharField(max_length=100)
         created_at = fields.DatetimeField(auto_now_add=True)
 

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -16,7 +16,7 @@ Fields are defined as properties of a ``Model`` class object:
     from tortoise import fields
 
     class Tournament(Model):
-        id = fields.IntField(pk=True)
+        id = fields.IntField(primary_key=True)
         name = fields.CharField(max_length=255)
 
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -84,7 +84,7 @@ You can start writing models like this:
     class Tournament(Model):
         # Defining `id` field is optional, it will be defined automatically
         # if you haven't done it yourself
-        id = fields.IntField(pk=True)
+        id = fields.IntField(primary_key=True)
         name = fields.CharField(max_length=255)
 
         # Defining ``__str__`` is also optional, but gives you pretty
@@ -94,7 +94,7 @@ You can start writing models like this:
 
 
     class Event(Model):
-        id = fields.IntField(pk=True)
+        id = fields.IntField(primary_key=True)
         name = fields.CharField(max_length=255)
         # References to other models are defined in format
         # "{app_name}.{model_name}" - where {app_name} is defined in tortoise config
@@ -106,7 +106,7 @@ You can start writing models like this:
 
 
     class Team(Model):
-        id = fields.IntField(pk=True)
+        id = fields.IntField(primary_key=True)
         name = fields.CharField(max_length=255)
 
         def __str__(self):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -58,7 +58,7 @@ Define your models like so:
     from tortoise import fields
 
     class Tournament(Model):
-        id = fields.IntField(pk=True)
+        id = fields.IntField(primary_key=True)
         name = fields.TextField()
 
 Initialise your models and database like so:

--- a/docs/indexes.rst
+++ b/docs/indexes.rst
@@ -4,7 +4,7 @@
 Indexes
 =======
 
-Default tortoise use `BTree` index when define index use `index=True` in field, or define indexes use in `Meta` class, but if you want use other index types, like `FullTextIndex` in `MySQL`, or `GinIndex` in `Postgres`, you should use `tortoise.indexes.Index` and its subclasses.
+Default tortoise use `BTree` index when define index use `db_index=True` in field, or define indexes use in `Meta` class, but if you want use other index types, like `FullTextIndex` in `MySQL`, or `GinIndex` in `Postgres`, you should use `tortoise.indexes.Index` and its subclasses.
 
 Usage
 =====

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -20,7 +20,7 @@ With that you can start describing your own models like that
 .. code-block:: python3
 
     class Tournament(Model):
-        id = fields.IntField(pk=True)
+        id = fields.IntField(primary_key=True)
         name = fields.TextField()
         created = fields.DatetimeField(auto_now_add=True)
 
@@ -29,7 +29,7 @@ With that you can start describing your own models like that
 
 
     class Event(Model):
-        id = fields.IntField(pk=True)
+        id = fields.IntField(primary_key=True)
         name = fields.TextField()
         tournament = fields.ForeignKeyField('models.Tournament', related_name='events')
         participants = fields.ManyToManyField('models.Team', related_name='events', through='event_team')
@@ -41,7 +41,7 @@ With that you can start describing your own models like that
 
 
     class Team(Model):
-        id = fields.IntField(pk=True)
+        id = fields.IntField(primary_key=True)
         name = fields.TextField()
 
         def __str__(self):
@@ -58,7 +58,7 @@ Every model should be derived from base model. You also can derive from your own
 .. code-block:: python3
 
     class AbstractTournament(Model):
-        id = fields.IntField(pk=True)
+        id = fields.IntField(primary_key=True)
         name = fields.TextField()
         created = fields.DatetimeField(auto_now_add=True)
 
@@ -97,7 +97,7 @@ That alias field can be used as a field name when doing filtering e.g. ``.filter
     CharField
     UUIDField
 
-One must define a primary key by setting a ``pk`` parameter to ``True``. 
+One must define a primary key by setting a ``primary_key`` parameter to ``True``.
 If you don't define a primary key, we will create a primary key of type ``IntField`` with name of ``id`` for you.
 
 .. note::
@@ -107,11 +107,11 @@ Any of these are valid primary key definitions in a Model:
 
 .. code-block:: python3
 
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
 
-    checksum = fields.CharField(pk=True)
+    checksum = fields.CharField(primary_key=True)
 
-    guid = fields.UUIDField(pk=True)
+    guid = fields.UUIDField(primary_key=True)
 
 
 Inheritance
@@ -141,7 +141,7 @@ Let's have a look at some examples.
         name = fields.CharField(40, unique=True)
 
     class MyAbstractBaseModel(Model):
-        id = fields.IntField(pk=True)
+        id = fields.IntField(primary_key=True)
 
         class Meta:
             abstract = True
@@ -149,7 +149,7 @@ Let's have a look at some examples.
     class UserModel(TimestampMixin, MyAbstractBaseModel):
         # Overriding the id definition
         # from MyAbstractBaseModel
-        id = fields.UUIDField(pk=True)
+        id = fields.UUIDField(primary_key=True)
 
         # Adding additional fields
         first_name = fields.CharField(20, null=True)
@@ -413,7 +413,7 @@ all models including fields for the relations between models.
 
 
     class Tournament(Model):
-        id = fields.IntField(pk=True)
+        id = fields.IntField(primary_key=True)
         name = fields.CharField(max_length=255)
 
         events: fields.ReverseRelation["Event"]
@@ -423,7 +423,7 @@ all models including fields for the relations between models.
 
 
     class Event(Model):
-        id = fields.IntField(pk=True)
+        id = fields.IntField(primary_key=True)
         name = fields.CharField(max_length=255)
         tournament: fields.ForeignKeyRelation[Tournament] = fields.ForeignKeyField(
             "models.Tournament", related_name="events"
@@ -437,7 +437,7 @@ all models including fields for the relations between models.
 
 
     class Team(Model):
-        id = fields.IntField(pk=True)
+        id = fields.IntField(primary_key=True)
         name = fields.CharField(max_length=255)
 
         events: fields.ManyToManyRelation[Event]

--- a/examples/aiohttp/models.py
+++ b/examples/aiohttp/models.py
@@ -2,7 +2,7 @@ from tortoise import Model, fields
 
 
 class Users(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.CharField(50)
 
     def __str__(self):

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -7,7 +7,7 @@ from tortoise.models import Model
 
 
 class Event(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.TextField()
     datetime = fields.DatetimeField(null=True)
 

--- a/examples/basic_comments.py
+++ b/examples/basic_comments.py
@@ -8,7 +8,7 @@ from tortoise.models import Model
 
 
 class Event(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.TextField(description="Name of the event that corresponds to an action")
     datetime = fields.DatetimeField(
         null=True, description="Datetime of when the event was generated"

--- a/examples/blacksheep/models.py
+++ b/examples/blacksheep/models.py
@@ -3,7 +3,7 @@ from tortoise.contrib.pydantic import pydantic_model_creator
 
 
 class Users(models.Model):
-    id = fields.UUIDField(pk=True)
+    id = fields.UUIDField(primary_key=True)
     username = fields.CharField(max_length=63)
 
     def __str__(self) -> str:

--- a/examples/complex_filtering.py
+++ b/examples/complex_filtering.py
@@ -10,7 +10,7 @@ from tortoise.models import Model
 
 
 class Tournament(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.TextField()
 
     events: fields.ReverseRelation["Event"]
@@ -20,7 +20,7 @@ class Tournament(Model):
 
 
 class Event(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.TextField()
     tournament: fields.ForeignKeyRelation[Tournament] = fields.ForeignKeyField(
         "models.Tournament", related_name="events"
@@ -34,7 +34,7 @@ class Event(Model):
 
 
 class Team(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.TextField()
 
     events: fields.ManyToManyRelation[Event]

--- a/examples/complex_prefetching.py
+++ b/examples/complex_prefetching.py
@@ -4,7 +4,7 @@ from tortoise.query_utils import Prefetch
 
 
 class Tournament(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.TextField()
 
     events: fields.ReverseRelation["Event"]
@@ -14,7 +14,7 @@ class Tournament(Model):
 
 
 class Event(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.TextField()
     tournament: fields.ForeignKeyRelation[Tournament] = fields.ForeignKeyField(
         "models.Tournament", related_name="events"
@@ -28,7 +28,7 @@ class Event(Model):
 
 
 class Team(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.TextField()
 
     events: fields.ManyToManyRelation[Event]

--- a/examples/fastapi/models.py
+++ b/examples/fastapi/models.py
@@ -7,7 +7,7 @@ class Users(models.Model):
     The User model
     """
 
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     #: This is a username
     username = fields.CharField(max_length=20, unique=True)
     name = fields.CharField(max_length=50, null=True)

--- a/examples/functions.py
+++ b/examples/functions.py
@@ -5,7 +5,7 @@ from tortoise.models import Model
 
 
 class Tournament(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.TextField()
     desc = fields.TextField(null=True)
 
@@ -16,7 +16,7 @@ class Tournament(Model):
 
 
 class Event(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.TextField()
     tournament: fields.ForeignKeyRelation[Tournament] = fields.ForeignKeyField(
         "models.Tournament", related_name="events"
@@ -30,7 +30,7 @@ class Event(Model):
 
 
 class Team(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.TextField()
 
     events: fields.ManyToManyRelation[Event]

--- a/examples/manual_sql.py
+++ b/examples/manual_sql.py
@@ -8,7 +8,7 @@ from tortoise.transactions import in_transaction
 
 
 class Event(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.TextField()
     timestamp = fields.DatetimeField(auto_now_add=True)
 

--- a/examples/postgres.py
+++ b/examples/postgres.py
@@ -7,7 +7,7 @@ from tortoise.models import Model
 
 
 class Report(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     content = fields.JSONField()
 
     def __str__(self):

--- a/examples/pydantic/basic.py
+++ b/examples/pydantic/basic.py
@@ -8,7 +8,7 @@ from tortoise.models import Model
 
 
 class Tournament(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.TextField()
     created_at = fields.DatetimeField(auto_now_add=True)
 
@@ -19,7 +19,7 @@ class Tournament(Model):
 
 
 class Event(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.TextField()
     created_at = fields.DatetimeField(auto_now_add=True)
     tournament: fields.ForeignKeyNullableRelation[Tournament] = fields.ForeignKeyField(
@@ -40,7 +40,7 @@ class Address(Model):
     created_at = fields.DatetimeField(auto_now_add=True)
 
     event: fields.OneToOneRelation[Event] = fields.OneToOneField(
-        "models.Event", on_delete=fields.OnDelete.CASCADE, related_name="address", pk=True
+        "models.Event", on_delete=fields.OnDelete.CASCADE, related_name="address", primary_key=True
     )
 
     class Meta:
@@ -48,7 +48,7 @@ class Address(Model):
 
 
 class Team(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.TextField()
     created_at = fields.DatetimeField(auto_now_add=True)
 

--- a/examples/pydantic/early_init.py
+++ b/examples/pydantic/early_init.py
@@ -8,7 +8,7 @@ from tortoise.models import Model
 
 
 class Tournament(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.TextField()
     created_at = fields.DatetimeField(auto_now_add=True)
 
@@ -19,7 +19,7 @@ class Tournament(Model):
 
 
 class Event(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.TextField()
     created_at = fields.DatetimeField(auto_now_add=True)
     tournament: fields.ForeignKeyNullableRelation[Tournament] = fields.ForeignKeyField(

--- a/examples/pydantic/tutorial_1.py
+++ b/examples/pydantic/tutorial_1.py
@@ -18,7 +18,7 @@ class Tournament(Model):
     This references a Tournament
     """
 
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.CharField(max_length=100)
     #: The date-time the Tournament record was created at
     created_at = fields.DatetimeField(auto_now_add=True)

--- a/examples/pydantic/tutorial_2.py
+++ b/examples/pydantic/tutorial_2.py
@@ -16,7 +16,7 @@ class Tournament(Model):
     This references a Tournament
     """
 
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.CharField(max_length=100)
     #: The date-time the Tournament record was created at
     created_at = fields.DatetimeField(auto_now_add=True)

--- a/examples/pydantic/tutorial_3.py
+++ b/examples/pydantic/tutorial_3.py
@@ -16,7 +16,7 @@ class Tournament(Model):
     This references a Tournament
     """
 
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.CharField(max_length=100)
     #: The date-time the Tournament record was created at
     created_at = fields.DatetimeField(auto_now_add=True)
@@ -27,7 +27,7 @@ class Event(Model):
     This references an Event in a Tournament
     """
 
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.CharField(max_length=100)
     created_at = fields.DatetimeField(auto_now_add=True)
 

--- a/examples/pydantic/tutorial_4.py
+++ b/examples/pydantic/tutorial_4.py
@@ -17,7 +17,7 @@ class Tournament(Model):
     This references a Tournament
     """
 
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.CharField(max_length=100)
     created_at = fields.DatetimeField(auto_now_add=True)
 
@@ -62,7 +62,7 @@ class Event(Model):
     This references an Event in a Tournament
     """
 
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.CharField(max_length=100)
     created_at = fields.DatetimeField(auto_now_add=True)
 

--- a/examples/quart/models.py
+++ b/examples/quart/models.py
@@ -2,7 +2,7 @@ from tortoise import Model, fields
 
 
 class Users(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     status = fields.CharField(20)
 
     def __str__(self):
@@ -10,7 +10,7 @@ class Users(Model):
 
 
 class Workers(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     status = fields.CharField(20)
 
     def __str__(self):

--- a/examples/relations.py
+++ b/examples/relations.py
@@ -12,7 +12,7 @@ from tortoise.models import Model
 
 
 class Tournament(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.TextField()
 
     events: fields.ReverseRelation["Event"]
@@ -22,7 +22,7 @@ class Tournament(Model):
 
 
 class Event(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.TextField()
     tournament: fields.ForeignKeyRelation[Tournament] = fields.ForeignKeyField(
         "models.Tournament", related_name="events"
@@ -40,7 +40,7 @@ class Address(Model):
     street = fields.CharField(max_length=128)
 
     event: fields.OneToOneRelation[Event] = fields.OneToOneField(
-        "models.Event", on_delete=fields.OnDelete.CASCADE, related_name="address", pk=True
+        "models.Event", on_delete=fields.OnDelete.CASCADE, related_name="address", primary_key=True
     )
 
     def __str__(self):
@@ -48,7 +48,7 @@ class Address(Model):
 
 
 class Team(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.TextField()
 
     events: fields.ManyToManyRelation[Event]

--- a/examples/relations_with_unique.py
+++ b/examples/relations_with_unique.py
@@ -11,7 +11,7 @@ from tortoise.query_utils import Prefetch
 
 
 class School(Model):
-    uuid = fields.UUIDField(pk=True)
+    uuid = fields.UUIDField(primary_key=True)
     name = fields.TextField()
     id = fields.IntField(unique=True)
 
@@ -20,7 +20,7 @@ class School(Model):
 
 
 class Student(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.TextField()
     school: fields.ForeignKeyRelation[School] = fields.ForeignKeyField(
         "models.School", related_name="students", to_field="id"
@@ -28,7 +28,7 @@ class Student(Model):
 
 
 class Principal(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.TextField()
     school: fields.OneToOneRelation[School] = fields.OneToOneField(
         "models.School", on_delete=fields.OnDelete.CASCADE, related_name="principal", to_field="id"

--- a/examples/router.py
+++ b/examples/router.py
@@ -9,7 +9,7 @@ from tortoise.models import Model
 
 
 class Event(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.TextField()
     datetime = fields.DatetimeField(null=True)
 

--- a/examples/sanic/models.py
+++ b/examples/sanic/models.py
@@ -2,7 +2,7 @@ from tortoise import Model, fields
 
 
 class Users(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.CharField(50)
 
     def __str__(self):

--- a/examples/schema_create.py
+++ b/examples/schema_create.py
@@ -8,8 +8,8 @@ from tortoise.utils import get_schema_sql
 
 
 class Tournament(Model):
-    id = fields.IntField(pk=True)
-    name = fields.CharField(max_length=255, description="Tournament name", index=True)
+    id = fields.IntField(primary_key=True)
+    name = fields.CharField(max_length=255, description="Tournament name", db_index=True)
     created = fields.DatetimeField(auto_now_add=True, description="Created datetime")
 
     events: fields.ReverseRelation["Event"]
@@ -19,7 +19,7 @@ class Tournament(Model):
 
 
 class Event(Model):
-    id = fields.IntField(pk=True, description="Event ID")
+    id = fields.IntField(primary_key=True, description="Event ID")
     name = fields.CharField(max_length=255, unique=True)
     tournament: fields.ForeignKeyRelation[Tournament] = fields.ForeignKeyField(
         "models.Tournament", related_name="events", description="FK to tournament"
@@ -39,7 +39,7 @@ class Event(Model):
 
 
 class Team(Model):
-    name = fields.CharField(max_length=50, pk=True, description="The TEAM name (and PK)")
+    name = fields.CharField(max_length=50, primary_key=True, description="The TEAM name (and PK)")
 
     events: fields.ManyToManyRelation[Event]
 

--- a/examples/signals.py
+++ b/examples/signals.py
@@ -10,7 +10,7 @@ from tortoise.signals import post_delete, post_save, pre_delete, pre_save
 
 
 class Signal(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.TextField()
 
     class Meta:

--- a/examples/starlette/models.py
+++ b/examples/starlette/models.py
@@ -2,7 +2,7 @@ from tortoise import fields, models
 
 
 class Users(models.Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     username = fields.CharField(max_length=20)
 
     def __str__(self) -> str:

--- a/examples/transactions.py
+++ b/examples/transactions.py
@@ -9,7 +9,7 @@ from tortoise.transactions import atomic, in_transaction
 
 
 class Event(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.TextField()
 
     class Meta:

--- a/examples/two_databases.py
+++ b/examples/two_databases.py
@@ -15,7 +15,7 @@ from tortoise.models import Model
 
 
 class Tournament(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.TextField()
 
     def __str__(self):
@@ -26,7 +26,7 @@ class Tournament(Model):
 
 
 class Event(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.TextField()
     tournament_id = fields.IntField()
     # Here we make link to events.Team, not models.Team
@@ -42,7 +42,7 @@ class Event(Model):
 
 
 class Team(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.TextField()
 
     event_team: fields.ManyToManyRelation[Event]

--- a/tests/fields/subclass_models.py
+++ b/tests/fields/subclass_models.py
@@ -14,7 +14,7 @@ class RacePlacingEnum(Enum):
 
 
 class RaceParticipant(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     first_name = fields.CharField(max_length=64)
     place = EnumField(RacePlacingEnum, default=RacePlacingEnum.DNF)
     predicted_place = EnumField(RacePlacingEnum, null=True)
@@ -27,5 +27,5 @@ class ContactTypeEnum(IntEnum):
 
 
 class Contact(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     type = IntEnumField(ContactTypeEnum, default=ContactTypeEnum.other)

--- a/tests/fields/test_binary.py
+++ b/tests/fields/test_binary.py
@@ -37,4 +37,9 @@ class TestBinaryFields(test.TestCase):
 
     def test_index_fail(self):
         with self.assertRaisesRegex(ConfigurationError, "can't be indexed"):
-            BinaryField(index=True)
+            with self.assertWarnsRegex(
+                DeprecationWarning, "`index` is deprecated, please use `db_index` instead"
+            ):
+                BinaryField(index=True)
+        with self.assertRaisesRegex(ConfigurationError, "can't be indexed"):
+            BinaryField(db_index=True)

--- a/tests/fields/test_db_index.py
+++ b/tests/fields/test_db_index.py
@@ -1,0 +1,51 @@
+from typing import Any
+
+from tortoise import fields
+from tortoise.contrib import test
+from tortoise.exceptions import ConfigurationError
+
+
+class TestIndexAlias(test.TestCase):
+    Field: Any = fields.IntField
+
+    def test_index_alias(self):
+        kwargs: dict = getattr(self, "init_kwargs", {})
+        with self.assertWarnsRegex(
+            DeprecationWarning, "`index` is deprecated, please use `db_index` instead"
+        ):
+            f = self.Field(index=True, **kwargs)
+        assert f.index is True
+        with self.assertWarnsRegex(
+            DeprecationWarning, "`index` is deprecated, please use `db_index` instead"
+        ):
+            f = self.Field(index=False, **kwargs)
+        assert f.index is False
+        f = self.Field(db_index=True, **kwargs)
+        assert f.index is True
+        f = self.Field(db_index=True, index=True, **kwargs)
+        assert f.index is True
+        f = self.Field(db_index=False, **kwargs)
+        assert f.index is False
+        f = self.Field(db_index=False, index=False, **kwargs)
+        assert f.index is False
+        with self.assertRaisesRegex(ConfigurationError, "can't set both db_index and index"):
+            self.Field(db_index=False, index=True, **kwargs)
+        with self.assertRaisesRegex(ConfigurationError, "can't set both db_index and index"):
+            self.Field(db_index=True, index=False, **kwargs)
+
+
+class TestIndexAliasSmallInt(TestIndexAlias):
+    Field = fields.SmallIntField
+
+
+class TestIndexAliasBigInt(TestIndexAlias):
+    Field = fields.BigIntField
+
+
+class TestIndexAliasUUID(TestIndexAlias):
+    Field = fields.UUIDField
+
+
+class TestIndexAliasChar(TestIndexAlias):
+    Field = fields.CharField
+    init_kwargs = {"max_length": 10}

--- a/tests/fields/test_json.py
+++ b/tests/fields/test_json.py
@@ -257,7 +257,12 @@ class TestJSONFields(test.TestCase):
 
     def test_index_fail(self):
         with self.assertRaisesRegex(ConfigurationError, "can't be indexed"):
-            JSONField(index=True)
+            with self.assertWarnsRegex(
+                DeprecationWarning, "`index` is deprecated, please use `db_index` instead"
+            ):
+                JSONField(index=True)
+        with self.assertRaisesRegex(ConfigurationError, "can't be indexed"):
+            JSONField(db_index=True)
 
     async def test_validate_str(self):
         obj0 = await testmodels.JSONFields.create(data=[], data_validate='["text", 5]')

--- a/tests/fields/test_text.py
+++ b/tests/fields/test_text.py
@@ -42,4 +42,4 @@ class TestTextFields(test.TestCase):
         with self.assertWarnsRegex(
             DeprecationWarning, "TextField as a PrimaryKey is Deprecated, use CharField"
         ):
-            TextField(pk=True)
+            TextField(primary_key=True)

--- a/tests/fields/test_text.py
+++ b/tests/fields/test_text.py
@@ -29,7 +29,7 @@ class TestTextFields(test.TestCase):
         self.assertEqual(values, "baa")
 
     def test_unique_fail(self):
-        msg = "TextField doesn't support unique indexes, consider CharField"
+        msg = "TextField can't be indexed, consider CharField"
         with self.assertRaisesRegex(ConfigurationError, msg):
             with self.assertWarnsRegex(
                 DeprecationWarning, "`index` is deprecated, please use `db_index` instead"

--- a/tests/fields/test_text.py
+++ b/tests/fields/test_text.py
@@ -29,10 +29,14 @@ class TestTextFields(test.TestCase):
         self.assertEqual(values, "baa")
 
     def test_unique_fail(self):
-        with self.assertRaisesRegex(
-            ConfigurationError, "TextField doesn't support unique indexes, consider CharField"
-        ):
-            TextField(unique=True)
+        msg = "TextField doesn't support unique indexes, consider CharField"
+        with self.assertRaisesRegex(ConfigurationError, msg):
+            with self.assertWarnsRegex(
+                DeprecationWarning, "`index` is deprecated, please use `db_index` instead"
+            ):
+                TextField(index=True)
+        with self.assertRaisesRegex(ConfigurationError, msg):
+            TextField(db_index=True)
 
     def test_index_fail(self):
         with self.assertRaisesRegex(ConfigurationError, "can't be indexed, consider CharField"):

--- a/tests/model_setup/model_bad_rel1.py
+++ b/tests/model_setup/model_bad_rel1.py
@@ -7,7 +7,7 @@ from tortoise.models import Model
 
 
 class Tournament(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
 
 
 class Event(Model):

--- a/tests/model_setup/model_bad_rel2.py
+++ b/tests/model_setup/model_bad_rel2.py
@@ -10,7 +10,7 @@ from tortoise.models import Model
 
 
 class Tournament(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
 
 
 class Event(Model):

--- a/tests/model_setup/model_bad_rel3.py
+++ b/tests/model_setup/model_bad_rel3.py
@@ -8,7 +8,7 @@ from tortoise.models import Model
 
 
 class Tournament(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
 
 
 class Event(Model):

--- a/tests/model_setup/model_bad_rel4.py
+++ b/tests/model_setup/model_bad_rel4.py
@@ -8,7 +8,7 @@ from tortoise.models import Model
 
 
 class Tournament(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
 
 
 class Event(Model):

--- a/tests/model_setup/model_bad_rel5.py
+++ b/tests/model_setup/model_bad_rel5.py
@@ -8,7 +8,7 @@ from tortoise.models import Model
 
 
 class Tournament(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
 
 
 class Event(Model):

--- a/tests/model_setup/model_generated_nonint.py
+++ b/tests/model_setup/model_generated_nonint.py
@@ -7,4 +7,4 @@ from tortoise.models import Model
 
 
 class Tournament(Model):
-    val = fields.CharField(max_length=50, pk=True, generated=True)
+    val = fields.CharField(max_length=50, primary_key=True, generated=True)

--- a/tests/model_setup/model_multiple_pk.py
+++ b/tests/model_setup/model_multiple_pk.py
@@ -7,5 +7,5 @@ from tortoise.models import Model
 
 
 class Tournament(Model):
-    id = fields.IntField(pk=True)
-    id2 = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
+    id2 = fields.IntField(primary_key=True)

--- a/tests/model_setup/models__models__bad.py
+++ b/tests/model_setup/models__models__bad.py
@@ -7,18 +7,18 @@ from tortoise.models import Model
 
 
 class BadTournament(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.TextField()
-    created = fields.DatetimeField(auto_now_add=True, index=True)
+    created = fields.DatetimeField(auto_now_add=True, db_index=True)
 
     def __str__(self):
         return self.name
 
 
 class GoodTournament(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.TextField()
-    created = fields.DatetimeField(auto_now_add=True, index=True)
+    created = fields.DatetimeField(auto_now_add=True, db_index=True)
 
     def __str__(self):
         return self.name
@@ -26,9 +26,9 @@ class GoodTournament(Model):
 
 class Tmp:
     class InAClassTournament(Model):
-        id = fields.IntField(pk=True)
+        id = fields.IntField(primary_key=True)
         name = fields.TextField()
-        created = fields.DatetimeField(auto_now_add=True, index=True)
+        created = fields.DatetimeField(auto_now_add=True, db_index=True)
 
         def __str__(self):
             return self.name

--- a/tests/model_setup/models__models__good.py
+++ b/tests/model_setup/models__models__good.py
@@ -7,18 +7,18 @@ from tortoise.models import Model
 
 
 class BadTournament(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.TextField()
-    created = fields.DatetimeField(auto_now_add=True, index=True)
+    created = fields.DatetimeField(auto_now_add=True, db_index=True)
 
     def __str__(self):
         return self.name
 
 
 class GoodTournament(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.TextField()
-    created = fields.DatetimeField(auto_now_add=True, index=True)
+    created = fields.DatetimeField(auto_now_add=True, db_index=True)
 
     def __str__(self):
         return self.name
@@ -26,9 +26,9 @@ class GoodTournament(Model):
 
 class Tmp:
     class InAClassTournament(Model):
-        id = fields.IntField(pk=True)
+        id = fields.IntField(primary_key=True)
         name = fields.TextField()
-        created = fields.DatetimeField(auto_now_add=True, index=True)
+        created = fields.DatetimeField(auto_now_add=True, db_index=True)
 
         def __str__(self):
             return self.name

--- a/tests/model_setup/models_dup1.py
+++ b/tests/model_setup/models_dup1.py
@@ -7,7 +7,7 @@ from tortoise.models import Model
 
 
 class Tournament(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
 
 
 class Event(Model):

--- a/tests/model_setup/models_dup2.py
+++ b/tests/model_setup/models_dup2.py
@@ -19,4 +19,4 @@ class Party(Model):
 
 
 class Team(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)

--- a/tests/model_setup/models_dup3.py
+++ b/tests/model_setup/models_dup3.py
@@ -7,7 +7,7 @@ from tortoise.models import Model
 
 
 class Tournament(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     event = fields.CharField(max_length=32)
 
 

--- a/tests/schema/models_no_auto_create_m2m.py
+++ b/tests/schema/models_no_auto_create_m2m.py
@@ -8,8 +8,8 @@ from tortoise.models import Model
 
 
 class Tournament(Model):
-    tid = fields.SmallIntField(pk=True)
-    name = fields.CharField(max_length=100, description="Tournament name", index=True)
+    tid = fields.SmallIntField(primary_key=True)
+    name = fields.CharField(max_length=100, description="Tournament name", db_index=True)
     created = fields.DatetimeField(auto_now_add=True, description="Created */'`/* datetime")
 
     class Meta:
@@ -17,7 +17,7 @@ class Tournament(Model):
 
 
 class Event(Model):
-    id = fields.BigIntField(pk=True, description="Event ID")
+    id = fields.BigIntField(primary_key=True, description="Event ID")
     name = fields.TextField()
     tournament: fields.ForeignKeyRelation[Tournament] = fields.ForeignKeyField(
         "models.Tournament", related_name="events", description="FK to tournament"
@@ -55,7 +55,7 @@ class TeamEvent(Model):
 
 
 class Team(Model):
-    name = fields.CharField(max_length=50, pk=True, description="The TEAM name (and PK)")
+    name = fields.CharField(max_length=50, primary_key=True, description="The TEAM name (and PK)")
     key = fields.IntField()
     manager: fields.ForeignKeyNullableRelation["Team"] = fields.ForeignKeyField(
         "models.Team", related_name="team_members", null=True

--- a/tests/schema/models_no_db_constraint.py
+++ b/tests/schema/models_no_db_constraint.py
@@ -7,8 +7,8 @@ from tortoise.models import Model
 
 
 class Tournament(Model):
-    tid = fields.SmallIntField(pk=True)
-    name = fields.CharField(max_length=100, description="Tournament name", index=True)
+    tid = fields.SmallIntField(primary_key=True)
+    name = fields.CharField(max_length=100, description="Tournament name", db_index=True)
     created = fields.DatetimeField(auto_now_add=True, description="Created */'`/* datetime")
 
     class Meta:
@@ -16,7 +16,7 @@ class Tournament(Model):
 
 
 class Event(Model):
-    id = fields.BigIntField(pk=True, description="Event ID")
+    id = fields.BigIntField(primary_key=True, description="Event ID")
     name = fields.TextField()
     tournament: fields.ForeignKeyRelation[Tournament] = fields.ForeignKeyField(
         "models.Tournament",
@@ -42,7 +42,7 @@ class Event(Model):
 
 
 class Team(Model):
-    name = fields.CharField(max_length=50, pk=True, description="The TEAM name (and PK)")
+    name = fields.CharField(max_length=50, primary_key=True, description="The TEAM name (and PK)")
     key = fields.IntField()
     manager: fields.ForeignKeyNullableRelation["Team"] = fields.ForeignKeyField(
         "models.Team", db_constraint=False, related_name="team_members", null=True

--- a/tests/schema/models_schema_create.py
+++ b/tests/schema/models_schema_create.py
@@ -10,8 +10,8 @@ from tortoise.models import Model
 
 
 class Tournament(Model):
-    tid = fields.SmallIntField(pk=True)
-    name = fields.CharField(max_length=100, description="Tournament name", index=True)
+    tid = fields.SmallIntField(primary_key=True)
+    name = fields.CharField(max_length=100, description="Tournament name", db_index=True)
     created = fields.DatetimeField(auto_now_add=True, description="Created */'`/* datetime")
 
     class Meta:
@@ -19,7 +19,7 @@ class Tournament(Model):
 
 
 class Event(Model):
-    id = fields.BigIntField(pk=True, description="Event ID")
+    id = fields.BigIntField(primary_key=True, description="Event ID")
     name = fields.TextField()
     tournament: fields.ForeignKeyRelation[Tournament] = fields.ForeignKeyField(
         "models.Tournament", related_name="events", description="FK to tournament"
@@ -42,7 +42,7 @@ class Event(Model):
 
 
 class Team(Model):
-    name = fields.CharField(max_length=50, pk=True, description="The TEAM name (and PK)")
+    name = fields.CharField(max_length=50, primary_key=True, description="The TEAM name (and PK)")
     key = fields.IntField()
     manager: fields.ForeignKeyNullableRelation["Team"] = fields.ForeignKeyField(
         "models.Team", related_name="team_members", null=True
@@ -67,7 +67,7 @@ class TeamAddress(Model):
     country = fields.CharField(max_length=50, description="Country")
     street = fields.CharField(max_length=128, description="Street Address")
     team: fields.OneToOneRelation[Team] = fields.OneToOneField(
-        "models.Team", related_name="address", on_delete=fields.CASCADE, pk=True
+        "models.Team", related_name="address", on_delete=fields.CASCADE, primary_key=True
     )
 
 
@@ -84,8 +84,8 @@ class VenueInformation(Model):
 
 
 class SourceFields(Model):
-    id = fields.IntField(pk=True, source_field="sometable_id")
-    chars = fields.CharField(max_length=255, source_field="some_chars_table", index=True)
+    id = fields.IntField(primary_key=True, source_field="sometable_id")
+    chars = fields.CharField(max_length=255, source_field="some_chars_table", db_index=True)
 
     fk: fields.ForeignKeyNullableRelation["SourceFields"] = fields.ForeignKeyField(
         "models.SourceFields", related_name="team_members", null=True, source_field="fk_sometable"
@@ -105,7 +105,7 @@ class SourceFields(Model):
 
 
 class Company(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.TextField()
     uuid = fields.UUIDField(unique=True, default=uuid4)
 
@@ -113,7 +113,7 @@ class Company(Model):
 
 
 class Employee(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.TextField()
     company: fields.ForeignKeyRelation[Company] = fields.ForeignKeyField(
         "models.Company",

--- a/tests/test_early_init.py
+++ b/tests/test_early_init.py
@@ -5,7 +5,7 @@ from tortoise.models import Model
 
 
 class Tournament(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.CharField(max_length=100)
     created_at = fields.DatetimeField(auto_now_add=True)
 
@@ -22,7 +22,7 @@ class Event(Model):
     This is multiline docs.
     """
 
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     #: The Event NAME
     #:  It's pretty important
     name = fields.CharField(max_length=255)

--- a/tests/testmodels.py
+++ b/tests/testmodels.py
@@ -56,10 +56,10 @@ class BookNoConstraint(Model):
 
 
 class Tournament(Model):
-    id = fields.SmallIntField(pk=True)
+    id = fields.SmallIntField(primary_key=True)
     name = fields.CharField(max_length=255)
     desc = fields.TextField(null=True)
-    created = fields.DatetimeField(auto_now_add=True, index=True)
+    created = fields.DatetimeField(auto_now_add=True, db_index=True)
 
     events: fields.ReverseRelation["Event"]
     minrelations: fields.ReverseRelation["MinRelation"]
@@ -75,7 +75,7 @@ class Tournament(Model):
 class Reporter(Model):
     """Whom is assigned as the reporter"""
 
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.TextField()
 
     events: fields.ReverseRelation["Event"]
@@ -90,7 +90,7 @@ class Reporter(Model):
 class Event(Model):
     """Events on the calendar"""
 
-    event_id = fields.BigIntField(pk=True)
+    event_id = fields.BigIntField(primary_key=True)
     #: The name
     name = fields.TextField()
     #: What tournaments is a happenin'
@@ -132,7 +132,7 @@ class Address(Model):
     street = fields.CharField(max_length=128)
 
     event: fields.OneToOneRelation[Event] = fields.OneToOneField(
-        "models.Event", on_delete=fields.CASCADE, related_name="address", pk=True
+        "models.Event", on_delete=fields.CASCADE, related_name="address", primary_key=True
     )
 
 
@@ -152,7 +152,7 @@ class Team(Model):
     Team that is a playing
     """
 
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.TextField()
 
     events: fields.ManyToManyRelation[Event]
@@ -170,7 +170,7 @@ class Team(Model):
 
 
 class EventTwo(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.TextField()
     tournament_id = fields.IntField()
     # Here we make link to events.Team, not models.Team
@@ -184,7 +184,7 @@ class EventTwo(Model):
 
 
 class TeamTwo(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.TextField()
 
     eventtwo_through: fields.ManyToManyRelation[EventTwo]
@@ -197,56 +197,56 @@ class TeamTwo(Model):
 
 
 class IntFields(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     intnum = fields.IntField()
     intnum_null = fields.IntField(null=True)
 
 
 class BigIntFields(Model):
-    id = fields.BigIntField(pk=True)
+    id = fields.BigIntField(primary_key=True)
     intnum = fields.BigIntField()
     intnum_null = fields.BigIntField(null=True)
 
 
 class SmallIntFields(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     smallintnum = fields.SmallIntField()
     smallintnum_null = fields.SmallIntField(null=True)
 
 
 class CharFields(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     char = fields.CharField(max_length=255)
     char_null = fields.CharField(max_length=255, null=True)
 
 
 class TextFields(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     text = fields.TextField()
     text_null = fields.TextField(null=True)
 
 
 class BooleanFields(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     boolean = fields.BooleanField()
     boolean_null = fields.BooleanField(null=True)
 
 
 class BinaryFields(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     binary = fields.BinaryField()
     binary_null = fields.BinaryField(null=True)
 
 
 class DecimalFields(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     decimal = fields.DecimalField(max_digits=18, decimal_places=4)
     decimal_nodec = fields.DecimalField(max_digits=18, decimal_places=0)
     decimal_null = fields.DecimalField(max_digits=18, decimal_places=4, null=True)
 
 
 class DatetimeFields(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     datetime = fields.DatetimeField()
     datetime_null = fields.DatetimeField(null=True)
     datetime_auto = fields.DatetimeField(auto_now=True)
@@ -254,25 +254,25 @@ class DatetimeFields(Model):
 
 
 class TimeDeltaFields(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     timedelta = fields.TimeDeltaField()
     timedelta_null = fields.TimeDeltaField(null=True)
 
 
 class DateFields(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     date = fields.DateField()
     date_null = fields.DateField(null=True)
 
 
 class TimeFields(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     time = fields.TimeField()
     time_null = fields.TimeField(null=True)
 
 
 class FloatFields(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     floatnum = fields.FloatField()
     floatnum_null = fields.FloatField(null=True)
 
@@ -287,7 +287,7 @@ class JSONFields(Model):
         if not isinstance(value, (dict, list)):
             raise ValidationError("Value must be a dict or list.")
 
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     data = fields.JSONField()
     data_null = fields.JSONField(null=True)
     data_default = fields.JSONField(default={"a": 1})
@@ -295,20 +295,20 @@ class JSONFields(Model):
 
 
 class UUIDFields(Model):
-    id = fields.UUIDField(pk=True, default=uuid.uuid1)
+    id = fields.UUIDField(primary_key=True, default=uuid.uuid1)
     data = fields.UUIDField()
     data_auto = fields.UUIDField(default=uuid.uuid4)
     data_null = fields.UUIDField(null=True)
 
 
 class MinRelation(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     tournament: fields.ForeignKeyRelation[Tournament] = fields.ForeignKeyField("models.Tournament")
     participants: fields.ManyToManyRelation[Team] = fields.ManyToManyField("models.Team")
 
 
 class M2MOne(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.CharField(max_length=255, null=True)
     two: fields.ManyToManyRelation["M2MTwo"] = fields.ManyToManyField(
         "models.M2MTwo", related_name="one"
@@ -316,7 +316,7 @@ class M2MOne(Model):
 
 
 class M2MTwo(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.CharField(max_length=255, null=True)
 
     one: fields.ManyToManyRelation[M2MOne]
@@ -328,14 +328,14 @@ class NoID(Model):
 
 
 class UniqueName(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.CharField(max_length=20, null=True, unique=True)
     optional = fields.CharField(max_length=20, null=True)
     other_optional = fields.CharField(max_length=20, null=True)
 
 
 class UniqueTogetherFields(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     first_name = fields.CharField(max_length=64)
     last_name = fields.CharField(max_length=64)
 
@@ -344,7 +344,7 @@ class UniqueTogetherFields(Model):
 
 
 class UniqueTogetherFieldsWithFK(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     text = fields.CharField(max_length=64)
     tournament: fields.ForeignKeyRelation[Tournament] = fields.ForeignKeyField("models.Tournament")
 
@@ -357,7 +357,7 @@ class ImplicitPkModel(Model):
 
 
 class UUIDPkModel(Model):
-    id = fields.UUIDField(pk=True)
+    id = fields.UUIDField(primary_key=True)
 
     children: fields.ReverseRelation["UUIDFkRelatedModel"]
     children_null: fields.ReverseRelation["UUIDFkRelatedNullModel"]
@@ -365,7 +365,7 @@ class UUIDPkModel(Model):
 
 
 class UUIDFkRelatedModel(Model):
-    id = fields.UUIDField(pk=True)
+    id = fields.UUIDField(primary_key=True)
     name = fields.CharField(max_length=50, null=True)
     model: fields.ForeignKeyRelation[UUIDPkModel] = fields.ForeignKeyField(
         "models.UUIDPkModel", related_name="children"
@@ -373,7 +373,7 @@ class UUIDFkRelatedModel(Model):
 
 
 class UUIDFkRelatedNullModel(Model):
-    id = fields.UUIDField(pk=True)
+    id = fields.UUIDField(primary_key=True)
     name = fields.CharField(max_length=50, null=True)
     model: fields.ForeignKeyNullableRelation[UUIDPkModel] = fields.ForeignKeyField(
         "models.UUIDPkModel", related_name=False, null=True
@@ -384,7 +384,7 @@ class UUIDFkRelatedNullModel(Model):
 
 
 class UUIDM2MRelatedModel(Model):
-    id = fields.UUIDField(pk=True)
+    id = fields.UUIDField(primary_key=True)
     value = fields.TextField(default="test")
     models: fields.ManyToManyRelation[UUIDPkModel] = fields.ManyToManyField(
         "models.UUIDPkModel", related_name="peers"
@@ -392,14 +392,14 @@ class UUIDM2MRelatedModel(Model):
 
 
 class UUIDPkSourceModel(Model):
-    id = fields.UUIDField(pk=True, source_field="a")
+    id = fields.UUIDField(primary_key=True, source_field="a")
 
     class Meta:
         table = "upsm"
 
 
 class UUIDFkRelatedSourceModel(Model):
-    id = fields.UUIDField(pk=True, source_field="b")
+    id = fields.UUIDField(primary_key=True, source_field="b")
     name = fields.CharField(max_length=50, null=True, source_field="c")
     model: fields.ForeignKeyRelation[UUIDPkSourceModel] = fields.ForeignKeyField(
         "models.UUIDPkSourceModel", related_name="children", source_field="d"
@@ -410,7 +410,7 @@ class UUIDFkRelatedSourceModel(Model):
 
 
 class UUIDFkRelatedNullSourceModel(Model):
-    id = fields.UUIDField(pk=True, source_field="i")
+    id = fields.UUIDField(primary_key=True, source_field="i")
     name = fields.CharField(max_length=50, null=True, source_field="j")
     model: fields.ForeignKeyNullableRelation[UUIDPkSourceModel] = fields.ForeignKeyField(
         "models.UUIDPkSourceModel", related_name="children_null", source_field="k", null=True
@@ -421,7 +421,7 @@ class UUIDFkRelatedNullSourceModel(Model):
 
 
 class UUIDM2MRelatedSourceModel(Model):
-    id = fields.UUIDField(pk=True, source_field="e")
+    id = fields.UUIDField(primary_key=True, source_field="e")
     value = fields.TextField(default="test", source_field="f")
     models: fields.ManyToManyRelation[UUIDPkSourceModel] = fields.ManyToManyField(
         "models.UUIDPkSourceModel", related_name="peers", forward_key="e", backward_key="h"
@@ -432,7 +432,7 @@ class UUIDM2MRelatedSourceModel(Model):
 
 
 class CharPkModel(Model):
-    id = fields.CharField(max_length=64, pk=True)
+    id = fields.CharField(max_length=64, primary_key=True)
 
 
 class CharFkRelatedModel(Model):
@@ -458,7 +458,7 @@ class NameMixin:
 
 
 class MyAbstractBaseModel(NameMixin, Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
 
     class Meta:
         abstract = True
@@ -473,7 +473,7 @@ class CommentModel(Model):
         table = "comments"
         table_description = "Test Table comment"
 
-    id = fields.IntField(pk=True, description="Primary key \r*/'`/*\n field for the comments")
+    id = fields.IntField(primary_key=True, description="Primary key \r*/'`/*\n field for the comments")
     message = fields.TextField(description="Comment messages entered in the blog post")
     rating = fields.IntField(description="Upvotes done on the comment")
     escaped_comment_field = fields.TextField(description="This column acts as it's own comment")
@@ -574,8 +574,8 @@ class Employee(Model):
 
 
 class StraightFields(Model):
-    eyedee = fields.IntField(pk=True, description="Da PK")
-    chars = fields.CharField(max_length=50, index=True, description="Some chars")
+    eyedee = fields.IntField(primary_key=True, description="Da PK")
+    chars = fields.CharField(max_length=50, db_index=True, description="Some chars")
     blip = fields.CharField(max_length=50, default="BLIP")
     nullable = fields.CharField(max_length=50, null=True)
 
@@ -615,10 +615,10 @@ class SourceFields(Model):
     A Docstring.
     """
 
-    eyedee = fields.IntField(pk=True, source_field="sometable_id", description="Da PK")
+    eyedee = fields.IntField(primary_key=True, source_field="sometable_id", description="Da PK")
     # A regular comment
     chars = fields.CharField(
-        max_length=50, source_field="some_chars_table", index=True, description="Some chars"
+        max_length=50, source_field="some_chars_table", db_index=True, description="Some chars"
     )
     #: A docstring comment
     blip = fields.CharField(max_length=50, default="BLIP", source_field="da_blip")
@@ -720,7 +720,7 @@ class DefaultOrderedInvalid(Model):
 
 
 class School(Model):
-    uuid = fields.UUIDField(pk=True)
+    uuid = fields.UUIDField(primary_key=True)
     name = fields.TextField()
     id = fields.IntField(unique=True)
 
@@ -729,7 +729,7 @@ class School(Model):
 
 
 class Student(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.TextField()
     school: fields.ForeignKeyRelation[School] = fields.ForeignKeyField(
         "models.School", related_name="students", to_field="id"
@@ -737,7 +737,7 @@ class Student(Model):
 
 
 class Principal(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     name = fields.TextField()
     school: fields.OneToOneRelation[School] = fields.OneToOneField(
         "models.School", on_delete=fields.CASCADE, related_name="principal", to_field="id"
@@ -766,7 +766,7 @@ class DefaultModel(Model):
 
 
 class RequiredPKModel(Model):
-    id = fields.CharField(pk=True, max_length=100)
+    id = fields.CharField(primary_key=True, max_length=100)
     name = fields.CharField(max_length=255)
 
 
@@ -816,7 +816,7 @@ class AbstractManagerModel(Model):
 
 
 class User(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     username = fields.CharField(max_length=32)
     mail = fields.CharField(max_length=64)
     bio = fields.TextField()
@@ -836,7 +836,7 @@ class Extra(Model):
     src: https://github.com/tortoise/tortoise-orm/pull/826#issuecomment-883341557
     """
 
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     # currently, tortoise don't save models with single pk field for some reason \_0_/
     some_name = fields.CharField(default=lambda: str(uuid.uuid4()), max_length=64)
 
@@ -846,7 +846,7 @@ class Single(Model):
     src: https://github.com/tortoise/tortoise-orm/pull/826#issuecomment-883341557
     """
 
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     extra: fields.ForeignKeyNullableRelation[Extra] = fields.ForeignKeyField(
         "models.Extra", related_name="singles", null=True
     )
@@ -857,7 +857,7 @@ class Pair(Model):
     src: https://github.com/tortoise/tortoise-orm/pull/826#issuecomment-883341557
     """
 
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     left: fields.ForeignKeyNullableRelation[Single] = fields.ForeignKeyField(
         "models.Single", related_name="lefts", null=True
     )
@@ -878,7 +878,7 @@ class CamelCaseAliasPerson(Model):
         configuring config_class.
     """
 
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     first_name = fields.CharField(max_length=255)
     last_name = fields.CharField(max_length=255)
     full_address = fields.TextField(null=True)
@@ -903,6 +903,6 @@ async def async_callable_default() -> str:
 
 
 class CallableDefault(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     callable_default = fields.CharField(max_length=32, default=callable_default)
     async_default = fields.CharField(max_length=32, default=async_callable_default)

--- a/tests/testmodels.py
+++ b/tests/testmodels.py
@@ -473,7 +473,9 @@ class CommentModel(Model):
         table = "comments"
         table_description = "Test Table comment"
 
-    id = fields.IntField(primary_key=True, description="Primary key \r*/'`/*\n field for the comments")
+    id = fields.IntField(
+        primary_key=True, description="Primary key \r*/'`/*\n field for the comments"
+    )
     message = fields.TextField(description="Comment messages entered in the blog post")
     rating = fields.IntField(description="Upvotes done on the comment")
     escaped_comment_field = fields.TextField(description="This column acts as it's own comment")

--- a/tests/testmodels_mysql.py
+++ b/tests/testmodels_mysql.py
@@ -4,7 +4,7 @@ from tortoise.models import Model
 
 
 class UUIDPkModel(Model):
-    id = mysql_fields.UUIDField(pk=True)
+    id = mysql_fields.UUIDField(primary_key=True)
 
     children: fields.ReverseRelation["UUIDFkRelatedModel"]
     children_null: fields.ReverseRelation["UUIDFkRelatedNullModel"]
@@ -12,7 +12,7 @@ class UUIDPkModel(Model):
 
 
 class UUIDFkRelatedModel(Model):
-    id = mysql_fields.UUIDField(pk=True)
+    id = mysql_fields.UUIDField(primary_key=True)
     name = fields.CharField(max_length=50, null=True)
     model: fields.ForeignKeyRelation[UUIDPkModel] = fields.ForeignKeyField(
         "models.UUIDPkModel", related_name="children"
@@ -20,7 +20,7 @@ class UUIDFkRelatedModel(Model):
 
 
 class UUIDFkRelatedNullModel(Model):
-    id = mysql_fields.UUIDField(pk=True)
+    id = mysql_fields.UUIDField(primary_key=True)
     name = fields.CharField(max_length=50, null=True)
     model: fields.ForeignKeyNullableRelation[UUIDPkModel] = fields.ForeignKeyField(
         "models.UUIDPkModel", related_name=False, null=True
@@ -31,7 +31,7 @@ class UUIDFkRelatedNullModel(Model):
 
 
 class UUIDM2MRelatedModel(Model):
-    id = mysql_fields.UUIDField(pk=True)
+    id = mysql_fields.UUIDField(primary_key=True)
     value = fields.TextField(default="test")
     models: fields.ManyToManyRelation[UUIDPkModel] = fields.ManyToManyField(
         "models.UUIDPkModel", related_name="peers"
@@ -39,14 +39,14 @@ class UUIDM2MRelatedModel(Model):
 
 
 class UUIDPkSourceModel(Model):
-    id = mysql_fields.UUIDField(pk=True, source_field="a")
+    id = mysql_fields.UUIDField(primary_key=True, source_field="a")
 
     class Meta:
         table = "upsm"
 
 
 class UUIDFkRelatedSourceModel(Model):
-    id = mysql_fields.UUIDField(pk=True, source_field="b")
+    id = mysql_fields.UUIDField(primary_key=True, source_field="b")
     name = fields.CharField(max_length=50, null=True, source_field="c")
     model: fields.ForeignKeyRelation[UUIDPkSourceModel] = fields.ForeignKeyField(
         "models.UUIDPkSourceModel", related_name="children", source_field="d"
@@ -57,7 +57,7 @@ class UUIDFkRelatedSourceModel(Model):
 
 
 class UUIDFkRelatedNullSourceModel(Model):
-    id = mysql_fields.UUIDField(pk=True, source_field="i")
+    id = mysql_fields.UUIDField(primary_key=True, source_field="i")
     name = fields.CharField(max_length=50, null=True, source_field="j")
     model: fields.ForeignKeyNullableRelation[UUIDPkSourceModel] = fields.ForeignKeyField(
         "models.UUIDPkSourceModel", related_name="children_null", source_field="k", null=True
@@ -68,7 +68,7 @@ class UUIDFkRelatedNullSourceModel(Model):
 
 
 class UUIDM2MRelatedSourceModel(Model):
-    id = mysql_fields.UUIDField(pk=True, source_field="e")
+    id = mysql_fields.UUIDField(primary_key=True, source_field="e")
     value = fields.TextField(default="test", source_field="f")
     models: fields.ManyToManyRelation[UUIDPkSourceModel] = fields.ManyToManyField(
         "models.UUIDPkSourceModel", related_name="peers", forward_key="e", backward_key="h"

--- a/tests/testmodels_postgres.py
+++ b/tests/testmodels_postgres.py
@@ -3,6 +3,6 @@ from tortoise.contrib.postgres.fields import ArrayField
 
 
 class ArrayFields(Model):
-    id = fields.IntField(pk=True)
+    id = fields.IntField(primary_key=True)
     array = ArrayField()
     array_null = ArrayField(null=True)

--- a/tests/utils/test_describe_model.py
+++ b/tests/utils/test_describe_model.py
@@ -44,7 +44,7 @@ class TestDescribeModel(test.SimpleTestCase):
     maxDiff = None
 
     def test_describe_field_noninit_ser(self):
-        field = fields.IntField(pk=True)
+        field = fields.IntField(primary_key=True)
         self.assertEqual(
             field.describe(serializable=True),
             {
@@ -65,7 +65,7 @@ class TestDescribeModel(test.SimpleTestCase):
         )
 
     def test_describe_field_noninit(self):
-        field = fields.IntField(pk=True)
+        field = fields.IntField(primary_key=True)
         self.assertEqual(
             field.describe(serializable=False),
             {

--- a/tortoise/contrib/mysql/fields.py
+++ b/tortoise/contrib/mysql/fields.py
@@ -36,7 +36,7 @@ class UUIDField(UUIDFieldBase):
     SQL_TYPE = "CHAR(36)"
 
     def __init__(self, binary_compression: bool = True, **kwargs: Any) -> None:
-        if kwargs.get("pk", False) and "default" not in kwargs:
+        if (kwargs.get("primary_key") or kwargs.get("pk", False)) and "default" not in kwargs:
             kwargs["default"] = uuid4
         super().__init__(**kwargs)
 

--- a/tortoise/fields/base.py
+++ b/tortoise/fields/base.py
@@ -1,3 +1,4 @@
+import warnings
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
@@ -63,14 +64,14 @@ class Field(Generic[VALUE], metaclass=_FieldMeta):
     :param source_field: Provide a source_field name if the DB column name needs to be
         something specific instead of generated off the field name.
     :param generated: Is this field DB-generated?
-    :param pk: Is this field a Primary Key? Can only have a single such field on the Model,
+    :param primary_key: Is this field a Primary Key? Can only have a single such field on the Model,
         and if none is specified it will autogenerate a default primary key called ``id``.
     :param null: Is this field nullable?
     :param default: A default value for the field if not specified on Model creation.
         This can also be a callable for dynamic defaults in which case we will call it.
         The default value will not be part of the schema.
     :param unique: Is this field unique?
-    :param index: Should this field be indexed by itself?
+    :param db_index: Should this field be indexed by itself?
     :param description: Field description. Will also appear in ``Tortoise.describe_model()``
         and as DB comments in the generated DDL.
     :param validators: Validators for this field.
@@ -174,34 +175,61 @@ class Field(Generic[VALUE], metaclass=_FieldMeta):
         self,
         source_field: Optional[str] = None,
         generated: bool = False,
-        pk: bool = False,
+        primary_key: Optional[bool] = None,
         null: bool = False,
         default: Any = None,
         unique: bool = False,
-        index: bool = False,
+        db_index: Optional[bool] = None,
         description: Optional[str] = None,
         model: "Optional[Model]" = None,
         validators: Optional[List[Union[Validator, Callable]]] = None,
         **kwargs: Any,
     ) -> None:
-        # TODO: Rename pk to primary_key, alias pk, deprecate
-        # TODO: Rename index to db_index, alias index, deprecate
-        if not self.indexable and (unique or index):
+        if (index := kwargs.pop("index", None)) is not None:
+            if db_index is None:
+                warnings.warn(
+                    "`index` is deprecated, please use `db_index` instead",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                db_index = index
+            elif db_index != index:
+                raise ConfigurationError(
+                    f"{self.__class__.__name__} can't set both db_index and index"
+                )
+        if not self.indexable and (unique or db_index):
             raise ConfigurationError(f"{self.__class__.__name__} can't be indexed")
-        if pk and null:
-            raise ConfigurationError(
-                f"{self.__class__.__name__} can't be both null=True and pk=True"
-            )
-        if pk:
-            index = True
+        if (pk := kwargs.pop("pk", None)) is not None:
+            if primary_key is None:
+                warnings.warn(
+                    "`pk` is deprecated, please use `primary_key` instead",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                primary_key = pk
+            elif primary_key != pk:
+                raise ConfigurationError(
+                    f"{self.__class__.__name__} can't set both primary_key and pk"
+                )
+        if null:
+            if pk:
+                raise ConfigurationError(
+                    f"{self.__class__.__name__} can't be both null=True and pk=True"
+                )
+            if primary_key:
+                raise ConfigurationError(
+                    f"{self.__class__.__name__} can't be both null=True and primary_key=True"
+                )
+        if primary_key:
+            db_index = True
             unique = True
         self.source_field = source_field
         self.generated = generated
-        self.pk = pk
+        self.pk = bool(primary_key)
         self.default = default
         self.null = null
         self.unique = unique
-        self.index = index
+        self.index = bool(db_index)
         self.model_field_name = ""
         self.description = description
         self.docstring: Optional[str] = None

--- a/tortoise/fields/data.py
+++ b/tortoise/fields/data.py
@@ -66,17 +66,17 @@ class IntField(Field[int], int):
     """
     Integer field. (32-bit signed)
 
-    ``pk`` (bool):
+    ``primary_key`` (bool):
         True if field is Primary Key.
     """
 
     SQL_TYPE = "INT"
     allows_generated = True
 
-    def __init__(self, pk: bool = False, **kwargs: Any) -> None:
-        if pk:
+    def __init__(self, primary_key: bool = False, **kwargs: Any) -> None:
+        if primary_key:
             kwargs["generated"] = bool(kwargs.get("generated", True))
-        super().__init__(pk=pk, **kwargs)
+        super().__init__(primary_key=primary_key, **kwargs)
 
     @property
     def constraints(self) -> dict:
@@ -105,17 +105,17 @@ class BigIntField(Field[int], int):
     """
     Big integer field. (64-bit signed)
 
-    ``pk`` (bool):
+    ``primary_key`` (bool):
         True if field is Primary Key.
     """
 
     SQL_TYPE = "BIGINT"
     allows_generated = True
 
-    def __init__(self, pk: bool = False, **kwargs: Any) -> None:
-        if pk:
+    def __init__(self, primary_key: bool = False, **kwargs: Any) -> None:
+        if primary_key:
             kwargs["generated"] = bool(kwargs.get("generated", True))
-        super().__init__(pk=pk, **kwargs)
+        super().__init__(primary_key=primary_key, **kwargs)
 
     @property
     def constraints(self) -> dict:
@@ -145,17 +145,17 @@ class SmallIntField(Field[int], int):
     """
     Small integer field. (16-bit signed)
 
-    ``pk`` (bool):
+    ``primary_key`` (bool):
         True if field is Primary Key.
     """
 
     SQL_TYPE = "SMALLINT"
     allows_generated = True
 
-    def __init__(self, pk: bool = False, **kwargs: Any) -> None:
-        if pk:
+    def __init__(self, primary_key: bool = False, **kwargs: Any) -> None:
+        if primary_key:
             kwargs["generated"] = bool(kwargs.get("generated", True))
-        super().__init__(pk=pk, **kwargs)
+        super().__init__(primary_key=primary_key, **kwargs)
 
     @property
     def constraints(self) -> dict:
@@ -227,9 +227,9 @@ class TextField(Field[str], str):  # type: ignore
     SQL_TYPE = "TEXT"
 
     def __init__(
-        self, pk: bool = False, unique: bool = False, index: bool = False, **kwargs: Any
+        self, primary_key: bool = False, unique: bool = False, db_index: bool = False, **kwargs: Any
     ) -> None:
-        if pk:
+        if primary_key or kwargs.get("pk"):
             warnings.warn(
                 "TextField as a PrimaryKey is Deprecated, use CharField instead",
                 DeprecationWarning,
@@ -239,10 +239,10 @@ class TextField(Field[str], str):  # type: ignore
             raise ConfigurationError(
                 "TextField doesn't support unique indexes, consider CharField or another strategy"
             )
-        if index:
+        if db_index or kwargs.get("index"):
             raise ConfigurationError("TextField can't be indexed, consider CharField")
 
-        super().__init__(pk=pk, **kwargs)
+        super().__init__(primary_key=primary_key, **kwargs)
 
     class _db_mysql:
         SQL_TYPE = "LONGTEXT"
@@ -618,7 +618,7 @@ class UUIDField(Field[UUID], UUID):
         SQL_TYPE = "UUID"
 
     def __init__(self, **kwargs: Any) -> None:
-        if kwargs.get("pk", False) and "default" not in kwargs:
+        if (kwargs.get("primary_key") or kwargs.get("pk", False)) and "default" not in kwargs:
             kwargs["default"] = uuid4
         super().__init__(**kwargs)
 

--- a/tortoise/fields/data.py
+++ b/tortoise/fields/data.py
@@ -73,7 +73,7 @@ class IntField(Field[int], int):
     SQL_TYPE = "INT"
     allows_generated = True
 
-    def __init__(self, primary_key: bool = False, **kwargs: Any) -> None:
+    def __init__(self, primary_key: Optional[bool] = None, **kwargs: Any) -> None:
         if primary_key:
             kwargs["generated"] = bool(kwargs.get("generated", True))
         super().__init__(primary_key=primary_key, **kwargs)
@@ -112,7 +112,7 @@ class BigIntField(Field[int], int):
     SQL_TYPE = "BIGINT"
     allows_generated = True
 
-    def __init__(self, primary_key: bool = False, **kwargs: Any) -> None:
+    def __init__(self, primary_key: Optional[bool] = None, **kwargs: Any) -> None:
         if primary_key:
             kwargs["generated"] = bool(kwargs.get("generated", True))
         super().__init__(primary_key=primary_key, **kwargs)
@@ -152,7 +152,7 @@ class SmallIntField(Field[int], int):
     SQL_TYPE = "SMALLINT"
     allows_generated = True
 
-    def __init__(self, primary_key: bool = False, **kwargs: Any) -> None:
+    def __init__(self, primary_key: Optional[bool] = None, **kwargs: Any) -> None:
         if primary_key:
             kwargs["generated"] = bool(kwargs.get("generated", True))
         super().__init__(primary_key=primary_key, **kwargs)
@@ -227,7 +227,11 @@ class TextField(Field[str], str):  # type: ignore
     SQL_TYPE = "TEXT"
 
     def __init__(
-        self, primary_key: bool = False, unique: bool = False, db_index: bool = False, **kwargs: Any
+        self,
+        primary_key: Optional[bool] = None,
+        unique: bool = False,
+        db_index: bool = False,
+        **kwargs: Any,
     ) -> None:
         if primary_key or kwargs.get("pk"):
             warnings.warn(

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -560,7 +560,7 @@ class ModelMeta(type):
 
             if not custom_pk_present and not getattr(meta_class, "abstract", None):
                 if "id" not in attrs:
-                    attrs = {"id": IntField(pk=True), **attrs}
+                    attrs = {"id": IntField(primary_key=True), **attrs}
 
                 if not isinstance(attrs["id"], Field) or not attrs["id"].pk:
                     raise ConfigurationError(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes TODOs in tortoise/fields/base.py

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Rename Field argument `pk/index` to `primary_key/db_index`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```bash
make ci && cd examples/fastapi && pytest _tests.py && cd ../blacksheep && pytest _tests.py
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

