### PR TITLE
create unqiue index in indexes and related children in contrib.postgres/sqlite.indexes

### DIFF
--- a/tortoise/contrib/sqlite/indexes.py
+++ b/tortoise/contrib/sqlite/indexes.py
@@ -1,0 +1,46 @@
+from typing import Dict, Optional, Tuple
+
+from pypika.terms import Term, ValueWrapper
+
+from tortoise.indexes import PartialIndex
+
+
+class SqliteIndex(PartialIndex):
+    INDEX_CREATE_TEMPLATE = PartialIndex.INDEX_CREATE_TEMPLATE.replace("INDEX", "INDEX {exists} ")
+
+
+class SqliteUniqueIndex(SqliteIndex):
+    INDEX_TYPE = "unique".upper()
+
+    def __init__(
+        self,
+        *expressions: Term,
+        fields: Optional[Tuple[str, ...]] = None,
+        name: Optional[str] = None,
+        condition: Optional[Dict[str, str]] = None,
+        where_expre: Optional[str] = None,
+    ):
+        _condition = condition
+        if condition:
+            condition = None
+        super().__init__(*expressions, fields=fields, name=name, condition=condition)
+        if _condition:
+            # TODO: what is the best practice to inject where expression?
+            self.extra = where_expre or self._gen_condition(_condition)
+
+    @classmethod
+    def _gen_field_cond(cls, kv: tuple):
+        key, cond = kv
+        op = (
+            ""
+            if isinstance(cond, str)
+            and cond.strip().lower().startswith(("is ", "isnot ", "<", ">", "=", "!="))
+            else "="
+        )
+        if op == "=":
+            cond = ValueWrapper(cond)
+        return str(f"{key} {op} {cond}")
+
+    def _gen_condition(self, conditions: Dict[str, str]):
+        conditions = " AND ".join(tuple(map(self._gen_field_cond, conditions.items())))
+        return f" where {conditions}"


### PR DESCRIPTION
create a postgresql unique index and consider the `nulls not distinct`

## Description
enhancement was started from this [issue](https://github.com/tortoise/tortoise-orm/issues/1641) 

this PR provide a manual solution for postgres driver. but i think the orm has to provide a base/shared solution.
the solution is a way to consider nulls equal in unique indexes on that drivers that consider nulls not equal.

postgres can done that by : `nulls not distinct`
sqlite and sqlserver too by : index expressions
on mysql i don't know yet.

