### PR TITLE
refactor: use db queryset to reduce duplicated code

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,7 +20,7 @@ Fixed
 ^^^^^
 - Fix `update_or_create` errors when field value changed. (#1584)
 - Fix bandit check error (#1643)
-- Fix `update_or_create` errors when field value changed. (#1584)
+- Fix potential race condition in ConnectionWrapper (#1656)
 
 Changed
 ^^^^^^^

--- a/tests/test_model_methods.py
+++ b/tests/test_model_methods.py
@@ -20,9 +20,9 @@ from tortoise.exceptions import (
     DoesNotExist,
     IntegrityError,
     MultipleObjectsReturned,
+    ObjectDoesNotExistError,
     OperationalError,
     ParamsError,
-    ObjectDoesNotExistError,
     ValidationError,
 )
 from tortoise.expressions import F, Q

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -17,8 +17,8 @@ from tortoise.exceptions import (
     FieldError,
     IntegrityError,
     MultipleObjectsReturned,
-    ParamsError,
     NotExistOrMultiple,
+    ParamsError,
 )
 from tortoise.expressions import F, RawSQL, Subquery
 

--- a/tortoise/exceptions.py
+++ b/tortoise/exceptions.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Union, Optional
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 if TYPE_CHECKING:
     from tortoise import Model, Type

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -30,9 +30,9 @@ from tortoise.exceptions import (
     DoesNotExist,
     IncompleteInstanceError,
     IntegrityError,
+    ObjectDoesNotExistError,
     OperationalError,
     ParamsError,
-    ObjectDoesNotExistError,
 )
 from tortoise.fields.base import Field
 from tortoise.fields.data import IntField
@@ -1064,7 +1064,7 @@ class Model(metaclass=ModelMeta):
         Returns a queryset that will lock rows until the end of the transaction,
         generating a SELECT ... FOR UPDATE SQL statement on supported databases.
         """
-        return cls._db_queryset(using_db, True).select_for_update(nowait, skip_locked, of)
+        return cls._db_queryset(using_db, for_write=True).select_for_update(nowait, skip_locked, of)
 
     @classmethod
     async def update_or_create(
@@ -1145,7 +1145,7 @@ class Model(metaclass=ModelMeta):
         :param batch_size: How many objects are created in a single query
         :param using_db: Specific DB connection to use instead of default bound
         """
-        return cls._db_queryset(using_db).bulk_update(objects, fields, batch_size)
+        return cls._db_queryset(using_db, for_write=True).bulk_update(objects, fields, batch_size)
 
     @classmethod
     async def in_bulk(
@@ -1201,7 +1201,7 @@ class Model(metaclass=ModelMeta):
         :param batch_size: How many objects are created in a single query
         :param using_db: Specific DB connection to use instead of default bound
         """
-        return cls._db_queryset(using_db).bulk_create(
+        return cls._db_queryset(using_db, for_write=True).bulk_create(
             objects, batch_size, ignore_conflicts, update_fields, on_conflict
         )
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
There are server repeat code segments in tortoise/models.py as follows:
```
db = using_db or cls._choose_db()
cls._meta.manager.get_queryset().using_db(db)
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Add a new classmethod `_db_queryset` to Model

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
make ci

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

