### PR TITLE
Support await `tortoise.contrib.fastapi.RegisterTortoise`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,12 +15,15 @@ Added
 ^^^^^
 - Add ObjectDoesNotExistError to show better 404 message. (#759)
 - DoesNotExist and MultipleObjectsReturned support 'Type[Model]' argument. (#742)(#1650)
+- Add argument use_tz and timezone to RegisterTortoise. (#1649)
+- Support await tortoise.contrib.fastapi.RegisterTortoise. (#1661)
 
 Fixed
 ^^^^^
 - Fix `update_or_create` errors when field value changed. (#1584)
 - Fix bandit check error (#1643)
 - Fix potential race condition in ConnectionWrapper (#1656)
+- Fix py312 warning for datetime.utcnow (#1661)
 
 Changed
 ^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ Added
 - Add ObjectDoesNotExistError to show better 404 message. (#759)
 - DoesNotExist and MultipleObjectsReturned support 'Type[Model]' argument. (#742)(#1650)
 - Add argument use_tz and timezone to RegisterTortoise. (#1649)
-- Support await tortoise.contrib.fastapi.RegisterTortoise. (#1661)
+- Support await `tortoise.contrib.fastapi.RegisterTortoise`. (#1662)
 
 Fixed
 ^^^^^

--- a/tests/contrib/test_fastapi.py
+++ b/tests/contrib/test_fastapi.py
@@ -1,0 +1,34 @@
+from unittest.mock import AsyncMock, patch
+
+from fastapi import FastAPI
+
+from tortoise.contrib import test
+from tortoise.contrib.fastapi import RegisterTortoise
+
+
+class TestRegisterTortoise(test.TestCase):
+    @test.requireCapability(dialect="sqlite")  # type:ignore[misc]
+    @patch("tortoise.Tortoise.init")
+    @patch("tortoise.connections.close_all")
+    async def test_await(
+        self,
+        mocked_close: AsyncMock,
+        mocked_init: AsyncMock,
+    ) -> None:
+        app = FastAPI()
+        orm = await RegisterTortoise(
+            app,
+            db_url="sqlite://:memory:",
+            modules={"models": ["__main__"]},
+        )
+        mocked_init.assert_awaited_once()
+        mocked_init.assert_called_once_with(
+            config=None,
+            config_file=None,
+            db_url="sqlite://:memory:",
+            modules={"models": ["__main__"]},
+            use_tz=False,
+            timezone="UTC",
+        )
+        await orm.close_orm()
+        mocked_close.assert_awaited_once()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
1. Run `make style`
2. Update changelog
3. Update RegisterTortoise class document
4. Use typing.Self to improve type hint
5. Support await for RegisterTortoise and add testcase for this feature

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Sometimes, I want to use `await RegiterTortoise(...)` instead of `async with RegiterTortoise(...)`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
make ci

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

