### PR TITLE
chore: filter DeprecationWarning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,6 +182,12 @@ per-file-ignores = [
 ]
 docstring_style = "sphinx"
 
+[tool.pytest.ini_options]
+filterwarnings = [
+    'ignore:`pk` is deprecated:DeprecationWarning',
+    'ignore:`index` is deprecated:DeprecationWarning',
+]
+
 [tool.coverage.run]
 branch = true
 source = ["tortoise"]


### PR DESCRIPTION
When running `make test_postgres_asyncpg` in local machine, the following warnings raised:
```
============================================== warnings summary ==============================================
tortoise/fields/data.py:79
tortoise/fields/data.py:79
tortoise/fields/data.py:79
tortoise/fields/data.py:79
tortoise/fields/data.py:79
tortoise/fields/data.py:79
tortoise/fields/data.py:79
tortoise/fields/data.py:79
  /Users/mac10.12/github/tortoise-orm/tortoise/fields/data.py:79: DeprecationWarning: `pk` is deprecated, please use `primary_key` instead
    super().__init__(primary_key=primary_key, **kwargs)

tortoise/fields/data.py:79
tortoise/fields/data.py:79
tortoise/fields/data.py:79
tortoise/fields/data.py:79
tortoise/fields/data.py:79
tortoise/fields/data.py:79
tortoise/fields/data.py:79
tortoise/fields/data.py:79
  /Users/mac10.12/github/tortoise-orm/tortoise/fields/data.py:79: DeprecationWarning: `index` is deprecated, please use `db_index` instead
    super().__init__(primary_key=primary_key, **kwargs)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
1103 passed, 85 skipped, 3 xfailed, 16 warnings in 78.73s (0:01:18)
```
It is caused by this line `initializer(["tests.testmodels"], db_url=db_url)` in conftest.py as the there is a `OldStyleModel` in tests/testmodels.py

These warnings do not make any sense, it is better to ignore it.