### PR TITLE
Fix bug in `pydantic_model_creator` when `include` does not contain foreing keys.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,12 @@ Changelog
 0.21
 ====
 
+0.21.6
+------
+Fixed
+^^^^^
+- Fix bug in `pydantic_model_creator` when a foreign key is not included in `include` param. (#1430)
+
 0.21.5 <../0.21.5>`_ - 2024-07-18
 ------
 Added

--- a/tortoise/contrib/pydantic/creator.py
+++ b/tortoise/contrib/pydantic/creator.py
@@ -265,7 +265,7 @@ def pydantic_model_creator(
                 # Remove raw fields
                 raw_field = fd.get("raw_field", None)
                 if raw_field is not None and exclude_raw_fields and raw_field != pk_raw_field:
-                    del field_map[raw_field]
+                    field_map.pop(raw_field, None)
                 field_map[n] = fd
 
     # Update field definitions from description


### PR DESCRIPTION
When the function `pydantic_model_creator` is used to create a model and the parameter `include` is passed #1430, this will raise an error if the relation is passed but not the foreign key value. Here is an example:

```python
class Tournament(Model):
    """
    This references a Tournament
    """

    id = fields.IntField(primary_key=True)
    name = fields.CharField(max_length=100)


class Event(Model):
    """
    This references an Event in a Tournament
    """

    id = fields.IntField(primary_key=True)
    name = fields.CharField(max_length=100)

    tournament: fields.ForeignKeyRelation[Tournament] = fields.ForeignKeyField(
        "models.Tournament", related_name="events", description="The Tournament this happens in"
    )

# Initialise model structure early.
Tortoise.init_models(["__main__"], "models")

Event_Pydantic = pydantic_model_creator(Event, include=["tournament"])
```

The above code will raise a `KeyError` exception because `tournament` is not included, thus it will not be found in `field_map` variable of the function `field_map_update`. To fix this we can replace the `del` with `pop` method.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

