### PR TITLE
Fix Mysql `UUIDField` with `binary_compression=True`

### DIFF
--- a/tortoise/contrib/mysql/fields.py
+++ b/tortoise/contrib/mysql/fields.py
@@ -49,7 +49,7 @@ class UUIDField(UUIDFieldBase):
         # If not, raise an error
         # This is to prevent UUIDv1 or any other version from being stored in the database
         if self._binary_compression:
-            if value is None or not isinstance(value, UUID):
+            if not isinstance(value, UUID):
                 raise ValueError("UUIDField only accepts UUID values")
             return value.bytes
         return value and str(value)

--- a/tortoise/contrib/mysql/fields.py
+++ b/tortoise/contrib/mysql/fields.py
@@ -49,7 +49,7 @@ class UUIDField(UUIDFieldBase):
         # If not, raise an error
         # This is to prevent UUIDv1 or any other version from being stored in the database
         if self._binary_compression:
-            if value is not isinstance(value, UUID):
+            if value is None or not isinstance(value, UUID):
                 raise ValueError("UUIDField only accepts UUID values")
             return value.bytes
         return value and str(value)


### PR DESCRIPTION
Fix for binary_compression with mysql UUIDField
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed a bug that breaks UUIDField from mysql, probably a misstype
<!--- Describe your changes in detail -->

## Motivation and Context
Seems that this field doesnt work when binary_compression=True, to_db_value method is broken, so there is a fix
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

