### PR TITLE
Fix `bulk_update` when using a pk other than `id`

### DIFF
--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -57,6 +57,19 @@ class TestUpdate(test.TestCase):
         self.assertEqual((await DatetimeFields.get(pk=objs[0].pk)).datetime, t0)
         self.assertEqual((await DatetimeFields.get(pk=objs[1].pk)).datetime, t1)
 
+    async def test_bulk_update_pk_non_id(self):
+        tournament = await Tournament.create(name="")
+        events = [
+            await Event.create(name="1", tournament=tournament),
+            await Event.create(name="2", tournament=tournament),
+        ]
+        events[0].name = "3"
+        events[1].name = "4"
+        rows_affected = await Event.bulk_update(events, fields=["name"])
+        self.assertEqual(rows_affected, 2)
+        self.assertEqual((await Event.get(pk=events[0].pk)).name, events[0].name)
+        self.assertEqual((await Event.get(pk=events[1].pk)).name, events[1].name)
+
     async def test_bulk_update_pk_uuid(self):
         objs = [
             await UUIDFields.create(data=uuid.uuid4()),

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -1800,7 +1800,7 @@ class BulkUpdateQuery(UpdateQuery, Generic[MODEL]):
         )
         executor = self._db.executor_class(model=self.model, db=self._db)
         pk_attr = self.model._meta.pk_attr
-        source_pk_attr = self.model._meta.fields_map["id"].source_field or pk_attr
+        source_pk_attr = self.model._meta.fields_map[pk_attr].source_field or pk_attr
         pk = Field(source_pk_attr)
         for objects_item in chunk(self.objects, self.batch_size):
             query = copy(self.query)


### PR DESCRIPTION
In method `bulk_update`, the primary key name is hard-coded as `"id"`; therefore, it throws an error when using a primary key with a name other than `id`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

