### PR TITLE
Fix deadlock for Sanic apps with `generate_schema=True` and > 1 workers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Changelog
 Fixed
 ^^^^^
 - Fix bug in `pydantic_model_creator` when a foreign key is not included in `include` param. (#1430)
+- Fix bug in `contrib.sanic.register_tortoise` causing a deadlock when using asyncpg and > 1 workers (#1696)
 
 0.21.5 <../0.21.5>`_ - 2024-07-18
 ------

--- a/examples/fastapi/main.py
+++ b/examples/fastapi/main.py
@@ -4,9 +4,9 @@ from contextlib import asynccontextmanager
 from typing import AsyncGenerator
 
 from fastapi import FastAPI
+from routers import router as users_router
 
 from examples.fastapi.config import register_orm
-from routers import router as users_router
 from tortoise import Tortoise, generate_config
 from tortoise.contrib.fastapi import RegisterTortoise
 

--- a/tortoise/contrib/sanic/__init__.py
+++ b/tortoise/contrib/sanic/__init__.py
@@ -1,5 +1,5 @@
 from types import ModuleType
-from typing import Dict, Iterable, Optional, Union
+from typing import Coroutine, Dict, Iterable, Optional, Union
 
 from sanic import Sanic  # pylint: disable=E0401
 
@@ -77,9 +77,9 @@ def register_tortoise(
         For any configuration error
     """
 
-    async def tortoise_init():
+    async def tortoise_init() -> None:
         await Tortoise.init(config=config, config_file=config_file, db_url=db_url, modules=modules)
-        logger.info("Tortoise-ORM started, %s, %s", connections._get_storage(), Tortoise.apps)
+        logger.info("Tortoise-ORM started, %s, %s", connections._get_storage(), Tortoise.apps) # pylint: disable=W0212
 
     if generate_schemas:
         @app.listener("main_process_start")

--- a/tortoise/contrib/sanic/__init__.py
+++ b/tortoise/contrib/sanic/__init__.py
@@ -79,11 +79,14 @@ def register_tortoise(
 
     async def tortoise_init() -> None:
         await Tortoise.init(config=config, config_file=config_file, db_url=db_url, modules=modules)
-        logger.info("Tortoise-ORM started, %s, %s", connections._get_storage(), Tortoise.apps) # pylint: disable=W0212
+        logger.info(
+            "Tortoise-ORM started, %s, %s", connections._get_storage(), Tortoise.apps
+        )  # pylint: disable=W0212
 
     if generate_schemas:
+
         @app.listener("main_process_start")
-        async def init_orm_main(app, loop): # pylint: disable=W0612
+        async def init_orm_main(app, loop):  # pylint: disable=W0612
             await tortoise_init()
             logger.info("Tortoise-ORM generating schema")
             await Tortoise.generate_schemas()

--- a/tortoise/contrib/sanic/__init__.py
+++ b/tortoise/contrib/sanic/__init__.py
@@ -77,13 +77,20 @@ def register_tortoise(
         For any configuration error
     """
 
-    @app.listener("before_server_start")
-    async def init_orm(app, loop):  # pylint: disable=W0612
+    async def tortoise_init():
         await Tortoise.init(config=config, config_file=config_file, db_url=db_url, modules=modules)
         logger.info("Tortoise-ORM started, %s, %s", connections._get_storage(), Tortoise.apps)
-        if generate_schemas:
+
+    if generate_schemas:
+        @app.listener("main_process_start")
+        async def init_orm_main(app, loop): # pylint: disable=W0612
+            await tortoise_init()
             logger.info("Tortoise-ORM generating schema")
             await Tortoise.generate_schemas()
+
+    @app.listener("before_server_start")
+    async def init_orm(app, loop):  # pylint: disable=W0612
+        await tortoise_init()
 
     @app.listener("after_server_stop")
     async def close_orm(app, loop):  # pylint: disable=W0612

--- a/tortoise/contrib/sanic/__init__.py
+++ b/tortoise/contrib/sanic/__init__.py
@@ -1,5 +1,5 @@
 from types import ModuleType
-from typing import Coroutine, Dict, Iterable, Optional, Union
+from typing import Dict, Iterable, Optional, Union
 
 from sanic import Sanic  # pylint: disable=E0401
 


### PR DESCRIPTION
## Description/Motivation and Context
Fixes deadlock caused by multiple workers trying to initialize the schema at the same time.
In my case this deadlock was caught by `asyncpg`.
I did try making a minimum repro sample, but failed, and honestly, don't have the time to fiddle with it.
I can't post my app, as it's private.

## How Has This Been Tested?
I ran it in my own app where the deadlock previously occurred, now it doesn't and the schema is created as expected.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

