### PR TITLE
Annotated count fix index error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,9 @@ Changelog
 
 0.21
 ====
+0.21.7
+------
+- Fix bug when using annotate and count at the same time but the annotation does not match anything, leading to an IndexError
 
 0.21.6
 ------

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -236,3 +236,10 @@ class TestAggregation(test.TestCase):
 
         res = await query.count()
         assert res == 2
+
+    async def test_count_without_matching(self) -> None:
+        await Tournament.create(name="Test")
+
+        query = Tournament.annotate(events_count=Count("events")).filter(events_count__gt=0).count()
+        result = await query
+        assert result == 0

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -1335,6 +1335,8 @@ class CountQuery(AwaitableQuery):
 
     async def _execute(self) -> int:
         _, result = await self._db.execute_query(str(self.query))
+        if not result:
+            return 0
         count = list(dict(result[0]).values())[0] - self.offset
         if self.limit and count > self.limit:
             return self.limit


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It fixes a 4 year old bug, when creating an annotation that has no matches, the `result` is an empty list but the actual code tries to reach for result[0] causing an `IndexError`

<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/tortoise/tortoise-orm/issues/469

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

