### PR TITLE
Update the pylint plugin to latest astroid version

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -59,6 +59,7 @@ Contributors
 * Ivan Pakeev ``@ipakeev``
 * Abdeldjalil Hezouat ``@Abdeldjalil-H``
 * Andrea Magistà ``@vlakius``
+* Daniel Szucs ``@Quasar6X``
 
 Special Thanks
 ==============

--- a/tortoise/contrib/pylint/__init__.py
+++ b/tortoise/contrib/pylint/__init__.py
@@ -6,15 +6,14 @@ from typing import Any, Dict, Iterator, List
 
 from astroid import MANAGER, inference_tip, nodes
 from astroid.exceptions import AstroidError
-from astroid.node_classes import AnnAssign, Assign
-from astroid.nodes import ClassDef
+from astroid.nodes import AnnAssign, Assign, ClassDef
 from pylint.lint import PyLinter
 
 MODELS: Dict[str, ClassDef] = {}
 FUTURE_RELATIONS: Dict[str, list] = {}
 
 
-def register(linter: PyLinter) -> None:
+def register(linter: PyLinter) -> None:  # pylint: disable=unused-argument
     """
     Reset state every time this is called, since we now get new AST to transform.
     """
@@ -107,7 +106,9 @@ def transform_model(cls: ClassDef) -> None:
         MANAGER.ast_from_module_name("tortoise.models").lookup("MetaInfo")[1][0].instantiate_class()
     ]
     if "id" not in cls.locals:
-        cls.locals["id"] = [nodes.ClassDef("id", None)]
+        cls.locals["id"] = [
+            nodes.ClassDef("id", None, None, None, end_lineno=None, end_col_offset=None)
+        ]
 
 
 def is_model_field(cls: ClassDef) -> bool:


### PR DESCRIPTION
The pylint plugin is now working with the latest pylint version 3.2.7

## Motivation and Context
The current version of the pylint plugin does not work and `pylint` raises a warning that it was unable to load it.

## How Has This Been Tested?
I've run `pylint` on a local project of mine with `tortoise-orm` installed and it picks up the plugin without any warnings.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

