### PR TITLE
Add POSIX Regex support for PostgreSQL and MySQL

### DIFF
--- a/docs/query.rst
+++ b/docs/query.rst
@@ -278,7 +278,7 @@ In PostgreSQL and MYSQL, you can use the ``contains``, ``contained_by`` and ``fi
     obj5 = await JSONModel.filter(data__filter={"owner__name__isnull": True}).first()
     obj6 = await JSONModel.filter(data__filter={"owner__last__not_isnull": False}).first()
 
-In PostgreSQL and MySQL, you can use ``posix_regex`` to make comparisons using POSIX regular expressions:
+In PostgreSQL and MySQL, you can use ``postgres_posix_regex`` to make comparisons using POSIX regular expressions:
 On PostgreSQL, this uses the ``~`` operator, on MySQL it uses the ``REGEXP`` operator.
 
 .. code-block:: python3

--- a/docs/query.rst
+++ b/docs/query.rst
@@ -278,6 +278,17 @@ In PostgreSQL and MYSQL, you can use the ``contains``, ``contained_by`` and ``fi
     obj5 = await JSONModel.filter(data__filter={"owner__name__isnull": True}).first()
     obj6 = await JSONModel.filter(data__filter={"owner__last__not_isnull": False}).first()
 
+In PostgreSQL and MySQL, you can use ``posix_regex`` to make comparisons using POSIX regular expressions:
+On PostgreSQL, this uses the ``~`` operator, on MySQL it uses the ``REGEXP`` operator.
+
+.. code-block:: python3
+    class DemoModel:
+      demo_text = fields.TextField()
+
+    await DemoModel.create(demo_text="Hello World")
+    obj = await DemoModel.filter(demo_text__posix_regex="^Hello World$").first()
+
+
 Complex prefetch
 ================
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -219,7 +219,6 @@ class TestBooleanFieldFilters(test.TestCase):
         )
 
 
-
 class TestDecimalFieldFilters(test.TestCase):
     async def asyncSetUp(self):
         await super().asyncSetUp()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -219,6 +219,7 @@ class TestBooleanFieldFilters(test.TestCase):
         )
 
 
+
 class TestDecimalFieldFilters(test.TestCase):
     async def asyncSetUp(self):
         await super().asyncSetUp()

--- a/tests/test_posix_regex_filter.py
+++ b/tests/test_posix_regex_filter.py
@@ -1,0 +1,25 @@
+from tortoise.contrib import test
+from tests import testmodels
+
+@test.requireCapability(dialect="postgres")
+class TestPosixRegexFilterPostgres(test.IsolatedTestCase):
+    tortoise_test_modules = ["tests.testmodels"]
+
+    async def test_regex_filter(self):
+        author = await testmodels.Author.create(name="Johann Wolfgang von Goethe")
+        self.assertEqual(
+            set(await testmodels.Author.filter(name__posix_regex="^Johann [a-zA-Z]+ von Goethe$").values_list("name", flat=True)),
+            {"Johann Wolfgang von Goethe"},
+        )
+
+
+@test.requireCapability(dialect="mysql")
+class TestPosixRegexFilterPostgres(test.IsolatedTestCase):
+    tortoise_test_modules = ["tests.testmodels"]
+
+    async def test_regex_filter(self):
+        author = await testmodels.Author.create(name="Johann Wolfgang von Goethe")
+        self.assertEqual(
+            set(await testmodels.Author.filter(name__posix_regex="^Johann [a-zA-Z]+ von Goethe$").values_list("name", flat=True)),
+            {"Johann Wolfgang von Goethe"},
+        )

--- a/tests/test_posix_regex_filter.py
+++ b/tests/test_posix_regex_filter.py
@@ -1,5 +1,5 @@
-from tortoise.contrib import test
 from tests import testmodels
+from tortoise.contrib import test
 
 
 class TestPosixRegexFilter(test.TestCase):
@@ -9,6 +9,10 @@ class TestPosixRegexFilter(test.TestCase):
     async def test_regex_filter(self):
         author = await testmodels.Author.create(name="Johann Wolfgang von Goethe")
         self.assertEqual(
-            set(await testmodels.Author.filter(name__posix_regex="^Johann [a-zA-Z]+ von Goethe$").values_list("name", flat=True)),
+            set(
+                await testmodels.Author.filter(
+                    name__posix_regex="^Johann [a-zA-Z]+ von Goethe$"
+                ).values_list("name", flat=True)
+            ),
             {author.name},
         )

--- a/tests/test_posix_regex_filter.py
+++ b/tests/test_posix_regex_filter.py
@@ -1,25 +1,14 @@
 from tortoise.contrib import test
 from tests import testmodels
 
-@test.requireCapability(dialect="postgres")
-class TestPosixRegexFilterPostgres(test.IsolatedTestCase):
-    tortoise_test_modules = ["tests.testmodels"]
 
+class TestPosixRegexFilter(test.TestCase):
+
+    @test.requireCapability(dialect="mysql")
+    @test.requireCapability(dialect="postgres")
     async def test_regex_filter(self):
         author = await testmodels.Author.create(name="Johann Wolfgang von Goethe")
         self.assertEqual(
             set(await testmodels.Author.filter(name__posix_regex="^Johann [a-zA-Z]+ von Goethe$").values_list("name", flat=True)),
-            {"Johann Wolfgang von Goethe"},
-        )
-
-
-@test.requireCapability(dialect="mysql")
-class TestPosixRegexFilterPostgres(test.IsolatedTestCase):
-    tortoise_test_modules = ["tests.testmodels"]
-
-    async def test_regex_filter(self):
-        author = await testmodels.Author.create(name="Johann Wolfgang von Goethe")
-        self.assertEqual(
-            set(await testmodels.Author.filter(name__posix_regex="^Johann [a-zA-Z]+ von Goethe$").values_list("name", flat=True)),
-            {"Johann Wolfgang von Goethe"},
+            {author.name},
         )

--- a/tortoise/backends/base_postgres/executor.py
+++ b/tortoise/backends/base_postgres/executor.py
@@ -12,9 +12,15 @@ from tortoise.contrib.postgres.json_functions import (
     postgres_json_contains,
     postgres_json_filter,
 )
-from tortoise.contrib.postgres.search import SearchCriterion
-from tortoise.filters import json_contained_by, json_contains, json_filter, search, posix_regex
 from tortoise.contrib.postgres.regex import postgres_posix_regex
+from tortoise.contrib.postgres.search import SearchCriterion
+from tortoise.filters import (
+    json_contained_by,
+    json_contains,
+    json_filter,
+    posix_regex,
+    search,
+)
 
 
 def postgres_search(field: Term, value: Term):

--- a/tortoise/backends/base_postgres/executor.py
+++ b/tortoise/backends/base_postgres/executor.py
@@ -13,8 +13,8 @@ from tortoise.contrib.postgres.json_functions import (
     postgres_json_filter,
 )
 from tortoise.contrib.postgres.search import SearchCriterion
-from tortoise.filters import json_contained_by, json_contains, json_filter, search
-from tortoise.contrib.postgres.regex import posix_regex
+from tortoise.filters import json_contained_by, json_contains, json_filter, search, posix_regex
+from tortoise.contrib.postgres.regex import postgres_posix_regex
 
 
 def postgres_search(field: Term, value: Term):
@@ -29,7 +29,7 @@ class BasePostgresExecutor(BaseExecutor):
         json_contains: postgres_json_contains,
         json_contained_by: postgres_json_contained_by,
         json_filter: postgres_json_filter,
-        posix_regex: posix_regex,
+        posix_regex: postgres_posix_regex,
     }
 
     def parameter(self, pos: int) -> Parameter:

--- a/tortoise/backends/base_postgres/executor.py
+++ b/tortoise/backends/base_postgres/executor.py
@@ -14,6 +14,7 @@ from tortoise.contrib.postgres.json_functions import (
 )
 from tortoise.contrib.postgres.search import SearchCriterion
 from tortoise.filters import json_contained_by, json_contains, json_filter, search
+from tortoise.contrib.postgres.regex import posix_regex
 
 
 def postgres_search(field: Term, value: Term):
@@ -28,6 +29,7 @@ class BasePostgresExecutor(BaseExecutor):
         json_contains: postgres_json_contains,
         json_contained_by: postgres_json_contained_by,
         json_filter: postgres_json_filter,
+        posix_regex: posix_regex,
     }
 
     def parameter(self, pos: int) -> Parameter:

--- a/tortoise/backends/mysql/executor.py
+++ b/tortoise/backends/mysql/executor.py
@@ -1,6 +1,6 @@
 from pypika import Parameter, functions
 from pypika.enums import SqlTypes
-from pypika.terms import Criterion, BasicCriterion
+from pypika.terms import BasicCriterion, Criterion
 from pypika.utils import format_quotes
 
 from tortoise import Model
@@ -25,9 +25,9 @@ from tortoise.filters import (
     json_contained_by,
     json_contains,
     json_filter,
+    posix_regex,
     search,
     starts_with,
-    posix_regex,
 )
 
 
@@ -95,12 +95,9 @@ def mysql_insensitive_ends_with(field: Term, value: str) -> Criterion:
 def mysql_search(field: Term, value: str):
     return SearchCriterion(field, expr=StrWrapper(value))
 
+
 def mysql_posix_regex(field: Term, value: str):
-    return BasicCriterion(
-        " REGEXP ",
-        field,
-        StrWrapper(value)
-    )
+    return BasicCriterion(" REGEXP ", field, StrWrapper(value))
 
 
 class MySQLExecutor(BaseExecutor):

--- a/tortoise/backends/mysql/executor.py
+++ b/tortoise/backends/mysql/executor.py
@@ -1,6 +1,6 @@
 from pypika import Parameter, functions
 from pypika.enums import SqlTypes
-from pypika.terms import Criterion
+from pypika.terms import Criterion, BasicCriterion
 from pypika.utils import format_quotes
 
 from tortoise import Model
@@ -27,6 +27,7 @@ from tortoise.filters import (
     json_filter,
     search,
     starts_with,
+    posix_regex,
 )
 
 
@@ -94,6 +95,13 @@ def mysql_insensitive_ends_with(field: Term, value: str) -> Criterion:
 def mysql_search(field: Term, value: str):
     return SearchCriterion(field, expr=StrWrapper(value))
 
+def mysql_posix_regex(field: Term, value: str):
+    return BasicCriterion(
+        " REGEXP ",
+        field,
+        StrWrapper(value)
+    )
+
 
 class MySQLExecutor(BaseExecutor):
     FILTER_FUNC_OVERRIDE = {
@@ -108,6 +116,7 @@ class MySQLExecutor(BaseExecutor):
         json_contains: mysql_json_contains,
         json_contained_by: mysql_json_contained_by,
         json_filter: mysql_json_filter,
+        posix_regex: mysql_posix_regex,
     }
     EXPLAIN_PREFIX = "EXPLAIN FORMAT=JSON"
 

--- a/tortoise/contrib/postgres/regex.py
+++ b/tortoise/contrib/postgres/regex.py
@@ -1,0 +1,5 @@
+from pypika.terms import Term, BasicCriterion
+
+
+def posix_regex(field: Term, value: str):
+    return BasicCriterion(" ~ ", field, value)

--- a/tortoise/contrib/postgres/regex.py
+++ b/tortoise/contrib/postgres/regex.py
@@ -1,5 +1,8 @@
 from pypika.terms import Term, BasicCriterion
+from pypika.enums import Comparator
 
+class PostgresRegexMatching(Comparator):
+    posix_regex = " ~ "
 
-def posix_regex(field: Term, value: str):
-    return BasicCriterion(" ~ ", field, value)
+def postgres_posix_regex(field: Term, value: str):
+    return BasicCriterion(PostgresRegexMatching.posix_regex, field, field.wrap_constant(value))

--- a/tortoise/contrib/postgres/regex.py
+++ b/tortoise/contrib/postgres/regex.py
@@ -1,8 +1,10 @@
-from pypika.terms import Term, BasicCriterion
 from pypika.enums import Comparator
+from pypika.terms import BasicCriterion, Term
+
 
 class PostgresRegexMatching(Comparator):
     posix_regex = " ~ "
+
 
 def postgres_posix_regex(field: Term, value: str):
     return BasicCriterion(PostgresRegexMatching.posix_regex, field, field.wrap_constant(value))

--- a/tortoise/contrib/postgres/regex.py
+++ b/tortoise/contrib/postgres/regex.py
@@ -1,9 +1,10 @@
-from pypika.enums import Comparator
+import enum
+
 from pypika.terms import BasicCriterion, Term
 
 
-class PostgresRegexMatching(Comparator):
-    posix_regex = " ~ "
+class PostgresRegexMatching(enum.Enum):
+    posix_regex = "~"
 
 
 def postgres_posix_regex(field: Term, value: str):

--- a/tortoise/filters.py
+++ b/tortoise/filters.py
@@ -132,7 +132,9 @@ def search(field: Term, value: str):
 
 def posix_regex(field: Term, value: str):
     # Will be overridden in each executor
-    raise NotImplementedError("The postgres_posix_regex filter operator is not supported by your database backend")
+    raise NotImplementedError(
+        "The postgres_posix_regex filter operator is not supported by your database backend"
+    )
 
 
 def starts_with(field: Term, value: str) -> Criterion:

--- a/tortoise/filters.py
+++ b/tortoise/filters.py
@@ -132,7 +132,7 @@ def search(field: Term, value: str):
 
 def posix_regex(field: Term, value: str):
     # Will be overridden in each executor
-    pass
+    raise NotImplementedError("The postgres_posix_regex filter operator is not supported by your database backend")
 
 
 def starts_with(field: Term, value: str) -> Criterion:
@@ -476,6 +476,12 @@ def get_filters_for_field(
             "field": actual_field_name,
             "source_field": source_field,
             "operator": insensitive_ends_with,
+            "value_encoder": string_encoder,
+        },
+        f"{field_name}__posix_regex": {
+            "field": actual_field_name,
+            "source_field": source_field,
+            "operator": posix_regex,
             "value_encoder": string_encoder,
         },
         f"{field_name}__year": {

--- a/tortoise/filters.py
+++ b/tortoise/filters.py
@@ -130,6 +130,11 @@ def search(field: Term, value: str):
     pass
 
 
+def posix_regex(field: Term, value: str):
+    # Will be overridden in each executor
+    pass
+
+
 def starts_with(field: Term, value: str) -> Criterion:
     return Like(Cast(field, SqlTypes.VARCHAR), field.wrap_constant(f"{escape_like(value)}%"))
 


### PR DESCRIPTION
This PR adds support for the Postgres "~" posix regex operator and the MySQL "RLIKE" operator  as a filter operator for char fields ("__posix_regex").

## Description
I needed support for filtering with the "~" operator offered by postgres ([9.7.3. POSIX Regular Expressions](https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-POSIX-REGEXP))

## Motivation and Context
The POSIX regex operator is more powerful than the LIKE statement.

## How Has This Been Tested?
I added two tests for the postgres and mysql backends

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

