### PR TITLE
Update postgres.rst

### DIFF
--- a/docs/contrib/postgres.rst
+++ b/docs/contrib/postgres.rst
@@ -21,7 +21,9 @@ Fields
 
 Postgres specific fields.
 
+.. autoclass:: tortoise.contrib.postgres.fields.ArrayField
 .. autoclass:: tortoise.contrib.postgres.fields.TSVectorField
+
 
 Functions
 =========


### PR DESCRIPTION
This adds the missing documentation entry for ArrayField (postgres specific).

See https://github.com/tortoise/tortoise-orm/issues/1187
