### PR TITLE
Fix bug in `tortoise.models.Model` When a QuerySet uses the only function and then uses the print function to print the returned result, an AttributeError is generated

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Fixed
 - Fix mysql uuid compression bug (#1687)
 - Fix comment for fk fields without constraint for mysql (#1679)
 - Removed no_delay option for postgres, as it wasn't doing anything (#1677)
+- Fix bug in `tortoise.models.Model` When a QuerySet uses the only function and then uses the print function to print the returned result, an AttributeError is generated. (#1723)
 
 0.21.5 <../0.21.5>`_ - 2024-07-18
 ------

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -781,7 +781,7 @@ class Model(metaclass=ModelMeta):
         return type(other) is type(self) and self.pk == other.pk  # type: ignore
 
     def _get_pk_val(self) -> Any:
-        return getattr(self, self._meta.pk_attr)
+        return getattr(self, self._meta.pk_attr, None)
 
     def _set_pk_val(self, value: Any) -> None:
         setattr(self, self._meta.pk_attr, value)


### PR DESCRIPTION
…tion and then uses the print function to print the returned result, an AttributeError is generated

<!--- Provide a general summary of your changes in the Title above -->

## Description
old:
```
def _get_pk_val(self) -> Any:
        return getattr(self, self._meta.pk_attr)
```
new:
```
def _get_pk_val(self) -> Any:
        return getattr(self, self._meta.pk_attr, None)
```

## Motivation and Context
When a QuerySet uses the only function and then uses the print function to print the returned result, an AttributeError is generated
[https://github.com/tortoise/tortoise-orm/issues/1723]()

## How Has This Been Tested?
make ci

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

