### PR TITLE
feat: support `app=None` for `tortoise.contrib.fastapi.RegisterTortoise`

### DIFF
--- a/examples/fastapi/_tests.py
+++ b/examples/fastapi/_tests.py
@@ -1,5 +1,6 @@
 # mypy: no-disallow-untyped-decorators
 # pylint: disable=E0611,E0401
+import multiprocessing
 import os
 from concurrent.futures import ProcessPoolExecutor
 from contextlib import asynccontextmanager
@@ -131,6 +132,7 @@ def query_without_app(pk: int) -> int:
 
 
 def test_query_without_app():
-    with ProcessPoolExecutor(max_workers=1, max_tasks_per_child=1) as executor:
+    multiprocessing.set_start_method("spawn")
+    with ProcessPoolExecutor(max_workers=1) as executor:
         future = executor.submit(query_without_app, 0)
         assert future.result() >= 0

--- a/tortoise/contrib/fastapi/__init__.py
+++ b/tortoise/contrib/fastapi/__init__.py
@@ -99,7 +99,7 @@ class RegisterTortoise(AbstractAsyncContextManager):
 
     def __init__(
         self,
-        app: FastAPI,
+        app: Optional[FastAPI] = None,
         config: Optional[dict] = None,
         config_file: Optional[str] = None,
         db_url: Optional[str] = None,
@@ -120,7 +120,7 @@ class RegisterTortoise(AbstractAsyncContextManager):
         self.timezone = timezone
         self._create_db = _create_db
 
-        if add_exception_handlers:
+        if add_exception_handlers and app is not None:
 
             @app.exception_handler(DoesNotExist)
             async def doesnotexist_exception_handler(request: "Request", exc: DoesNotExist):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Make it easy for fastapi projects to init orm outside app.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Sometimes we want to query db in a interactive environment (for example in ipython)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
make ci

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

