### PR TITLE
Add support for case insensitive regexp + add support for REGEXP SQLite module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,9 @@ test: deps
 test_sqlite:
 	$(py_warn) TORTOISE_TEST_DB=sqlite://:memory: pytest --cov-report= $(pytest_opts)
 
+test_sqlite_regexp:
+	$(py_warn) TORTOISE_TEST_DB=sqlite://:memory:?install_regexp_functions=True pytest --cov-report= $(pytest_opts)
+
 test_postgres_asyncpg:
 	python -V | grep PyPy || $(py_warn) TORTOISE_TEST_DB="asyncpg://postgres:$(TORTOISE_POSTGRES_PASS)@127.0.0.1:5432/test_\{\}" pytest $(pytest_opts) --cov-append --cov-report=
 

--- a/docs/query.rst
+++ b/docs/query.rst
@@ -271,8 +271,9 @@ The ``filter`` option allows you to filter the JSON object by its keys and value
     obj5 = await JSONModel.filter(data__filter={"owner__name__isnull": True}).first()
     obj6 = await JSONModel.filter(data__filter={"owner__last__not_isnull": False}).first()
 
-In PostgreSQL and MySQL, you can use ``postgres_posix_regex`` to make comparisons using POSIX regular expressions:
-In PostgreSQL, this is done with the ``~`` operator, while in MySQL the ``REGEXP`` operator is used.
+In PostgreSQL and MySQL and SQLite, you can use ``posix_regex`` to make comparisons using POSIX regular expressions:
+On PostgreSQL, this uses the ``~`` operator, on MySQL and SQLite it uses the ``REGEXP`` operator.
+PostgreSQL and SQLite also support ``iposix_regex``, which makes case insensive comparisons.
 
 
 .. code-block:: python3
@@ -281,6 +282,7 @@ In PostgreSQL, this is done with the ``~`` operator, while in MySQL the ``REGEXP
 
     await DemoModel.create(demo_text="Hello World")
     obj = await DemoModel.filter(demo_text__posix_regex="^Hello World$").first()
+    obj = await DemoModel.filter(demo_text__iposix_regex="^hello world$").first()
 
 
 In PostgreSQL, ``filter`` supports additional lookup types:

--- a/tests/contrib/test_pydantic.py
+++ b/tests/contrib/test_pydantic.py
@@ -7,6 +7,7 @@ from tests.testmodels import (
     Address,
     CamelCaseAliasPerson,
     Employee,
+    EnumFields,
     Event,
     IntFields,
     JSONFields,

--- a/tests/contrib/test_pydantic.py
+++ b/tests/contrib/test_pydantic.py
@@ -7,7 +7,6 @@ from tests.testmodels import (
     Address,
     CamelCaseAliasPerson,
     Employee,
-    EnumFields,
     Event,
     IntFields,
     JSONFields,

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -71,18 +71,21 @@ class TestConnections(SimpleTestCase):
     @patch("tortoise.connection.importlib.import_module")
     def test_discover_client_class_proper_impl(self, mocked_import_module: Mock):
         mocked_import_module.return_value = Mock(client_class="some_class")
-        client_class = self.conn_handler._discover_client_class("blah")
+        del mocked_import_module.return_value.get_client_class
+        client_class = self.conn_handler._discover_client_class({"engine": "blah"})
+
         mocked_import_module.assert_called_once_with("blah")
         self.assertEqual(client_class, "some_class")
 
     @patch("tortoise.connection.importlib.import_module")
     def test_discover_client_class_improper_impl(self, mocked_import_module: Mock):
         del mocked_import_module.return_value.client_class
+        del mocked_import_module.return_value.get_client_class
         engine = "some_engine"
         with self.assertRaises(
             ConfigurationError, msg=f'Backend for engine "{engine}" does not implement db client'
         ):
-            _ = self.conn_handler._discover_client_class(engine)
+            _ = self.conn_handler._discover_client_class({"engine": engine})
 
     @patch("tortoise.connection.ConnectionHandler.db_config", new_callable=PropertyMock)
     def test_get_db_info_present(self, mocked_db_config: Mock):
@@ -156,7 +159,7 @@ class TestConnections(SimpleTestCase):
 
         mocked_get_db_info.assert_called_once_with(alias)
         mocked_expand_db_url.assert_called_once_with("some_db_url")
-        mocked_discover_client_class.assert_called_once_with("some_engine")
+        mocked_discover_client_class.assert_called_once_with({"engine": "some_engine", "credentials": {"cred_key": "some_val"}})
         expected_client_class.assert_called_once_with(**expected_db_params)
         self.assertEqual(ret_val, "some_connection")
 
@@ -182,7 +185,7 @@ class TestConnections(SimpleTestCase):
 
         mocked_get_db_info.assert_called_once_with(alias)
         mocked_expand_db_url.assert_not_called()
-        mocked_discover_client_class.assert_called_once_with("some_engine")
+        mocked_discover_client_class.assert_called_once_with({"engine": "some_engine", "credentials": {"cred_key": "some_val"}})
         expected_client_class.assert_called_once_with(**expected_db_params)
         self.assertEqual(ret_val, "some_connection")
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -159,7 +159,9 @@ class TestConnections(SimpleTestCase):
 
         mocked_get_db_info.assert_called_once_with(alias)
         mocked_expand_db_url.assert_called_once_with("some_db_url")
-        mocked_discover_client_class.assert_called_once_with({"engine": "some_engine", "credentials": {"cred_key": "some_val"}})
+        mocked_discover_client_class.assert_called_once_with(
+            {"engine": "some_engine", "credentials": {"cred_key": "some_val"}}
+        )
         expected_client_class.assert_called_once_with(**expected_db_params)
         self.assertEqual(ret_val, "some_connection")
 
@@ -185,7 +187,9 @@ class TestConnections(SimpleTestCase):
 
         mocked_get_db_info.assert_called_once_with(alias)
         mocked_expand_db_url.assert_not_called()
-        mocked_discover_client_class.assert_called_once_with({"engine": "some_engine", "credentials": {"cred_key": "some_val"}})
+        mocked_discover_client_class.assert_called_once_with(
+            {"engine": "some_engine", "credentials": {"cred_key": "some_val"}}
+        )
         expected_client_class.assert_called_once_with(**expected_db_params)
         self.assertEqual(ret_val, "some_connection")
 

--- a/tests/test_posix_regex_filter.py
+++ b/tests/test_posix_regex_filter.py
@@ -42,29 +42,30 @@ class TestPosixRegexFilter(test.TestCase):
 
     @test.requireCapability(dialect="postgres")
     async def test_regex_filter_works_with_null_field_postgres(self):
-        t = await testmodels.Tournament.create(name="Test")
+        await testmodels.Tournament.create(name="Test")
         print(testmodels.Tournament.filter(desc__posix_regex="^test$").sql())
         self.assertEqual(
             set(
-                await testmodels.Tournament.filter(
-                    desc__posix_regex="^test$"
-                ).values_list("name", flat=True)
+                await testmodels.Tournament.filter(desc__posix_regex="^test$").values_list(
+                    "name", flat=True
+                )
             ),
             set(),
         )
 
     @test.requireCapability(dialect="sqlite")
     async def test_regex_filter_works_with_null_field_sqlite(self):
-        t = await testmodels.Tournament.create(name="Test")
+        await testmodels.Tournament.create(name="Test")
         print(testmodels.Tournament.filter(desc__posix_regex="^test$").sql())
         self.assertEqual(
             set(
-                await testmodels.Tournament.filter(
-                    desc__posix_regex="^test$"
-                ).values_list("name", flat=True)
+                await testmodels.Tournament.filter(desc__posix_regex="^test$").values_list(
+                    "name", flat=True
+                )
             ),
             set(),
         )
+
 
 class TestCaseInsensitivePosixRegexFilter(test.TestCase):
     @test.requireCapability(dialect="postgres")

--- a/tests/test_posix_regex_filter.py
+++ b/tests/test_posix_regex_filter.py
@@ -40,6 +40,32 @@ class TestPosixRegexFilter(test.TestCase):
             {author.name},
         )
 
+    @test.requireCapability(dialect="postgres")
+    async def test_regex_filter_works_with_null_field_postgres(self):
+        t = await testmodels.Tournament.create(name="Test")
+        print(testmodels.Tournament.filter(desc__posix_regex="^test$").sql())
+        self.assertEqual(
+            set(
+                await testmodels.Tournament.filter(
+                    desc__posix_regex="^test$"
+                ).values_list("name", flat=True)
+            ),
+            set(),
+        )
+
+    @test.requireCapability(dialect="sqlite")
+    async def test_regex_filter_works_with_null_field_sqlite(self):
+        t = await testmodels.Tournament.create(name="Test")
+        print(testmodels.Tournament.filter(desc__posix_regex="^test$").sql())
+        self.assertEqual(
+            set(
+                await testmodels.Tournament.filter(
+                    desc__posix_regex="^test$"
+                ).values_list("name", flat=True)
+            ),
+            set(),
+        )
+
 class TestCaseInsensitivePosixRegexFilter(test.TestCase):
     @test.requireCapability(dialect="postgres")
     async def test_case_insensitive_regex_filter_postgres(self):

--- a/tests/test_posix_regex_filter.py
+++ b/tests/test_posix_regex_filter.py
@@ -1,10 +1,10 @@
 from tests import testmodels
 from tortoise.contrib import test
 
+
 class RegexTestCase(test.TestCase):
     async def asyncSetUp(self) -> None:
         await super().asyncSetUp()
-
 
 
 class TestPosixRegexFilter(test.TestCase):

--- a/tests/test_posix_regex_filter.py
+++ b/tests/test_posix_regex_filter.py
@@ -56,7 +56,6 @@ class TestCaseInsensitivePosixRegexFilter(test.TestCase):
     @test.requireCapability(dialect="sqlite")
     async def test_case_insensitive_regex_filter_sqlite(self):
         author = await testmodels.Author.create(name="Johann Wolfgang von Goethe")
-        print(testmodels.Author.filter(name__iposix_regex="^johann [a-zA-Z]+ Von goethe$").sql(params_inline=True))
         self.assertEqual(
             set(
                 await testmodels.Author.filter(

--- a/tests/test_posix_regex_filter.py
+++ b/tests/test_posix_regex_filter.py
@@ -1,11 +1,16 @@
 from tests import testmodels
 from tortoise.contrib import test
 
+class RegexTestCase(test.TestCase):
+    async def asyncSetUp(self) -> None:
+        await super().asyncSetUp()
+
+
 
 class TestPosixRegexFilter(test.TestCase):
 
-    @test.requireCapability(dialect="postgres")
-    async def test_regex_filter_postgres(self):
+    @test.requireCapability(support_for_posix_regex_queries=True)
+    async def test_regex_filter(self):
         author = await testmodels.Author.create(name="Johann Wolfgang von Goethe")
         self.assertEqual(
             set(
@@ -16,31 +21,7 @@ class TestPosixRegexFilter(test.TestCase):
             {author.name},
         )
 
-    @test.requireCapability(dialect="mysql")
-    async def test_regex_filter_mysql(self):
-        author = await testmodels.Author.create(name="Johann Wolfgang von Goethe")
-        self.assertEqual(
-            set(
-                await testmodels.Author.filter(
-                    name__posix_regex="^Johann [a-zA-Z]+ von Goethe$"
-                ).values_list("name", flat=True)
-            ),
-            {author.name},
-        )
-
-    @test.requireCapability(dialect="sqlite")
-    async def test_regex_filter_sqlite(self):
-        author = await testmodels.Author.create(name="Johann Wolfgang von Goethe")
-        self.assertEqual(
-            set(
-                await testmodels.Author.filter(
-                    name__posix_regex="^Johann [a-zA-Z]+ von Goethe$"
-                ).values_list("name", flat=True)
-            ),
-            {author.name},
-        )
-
-    @test.requireCapability(dialect="postgres")
+    @test.requireCapability(dialect="postgres", support_for_posix_regex_queries=True)
     async def test_regex_filter_works_with_null_field_postgres(self):
         await testmodels.Tournament.create(name="Test")
         print(testmodels.Tournament.filter(desc__posix_regex="^test$").sql())
@@ -53,7 +34,7 @@ class TestPosixRegexFilter(test.TestCase):
             set(),
         )
 
-    @test.requireCapability(dialect="sqlite")
+    @test.requireCapability(dialect="sqlite", support_for_posix_regex_queries=True)
     async def test_regex_filter_works_with_null_field_sqlite(self):
         await testmodels.Tournament.create(name="Test")
         print(testmodels.Tournament.filter(desc__posix_regex="^test$").sql())
@@ -68,7 +49,7 @@ class TestPosixRegexFilter(test.TestCase):
 
 
 class TestCaseInsensitivePosixRegexFilter(test.TestCase):
-    @test.requireCapability(dialect="postgres")
+    @test.requireCapability(dialect="postgres", support_for_posix_regex_queries=True)
     async def test_case_insensitive_regex_filter_postgres(self):
         author = await testmodels.Author.create(name="Johann Wolfgang von Goethe")
         self.assertEqual(
@@ -80,7 +61,7 @@ class TestCaseInsensitivePosixRegexFilter(test.TestCase):
             {author.name},
         )
 
-    @test.requireCapability(dialect="sqlite")
+    @test.requireCapability(dialect="sqlite", support_for_posix_regex_queries=True)
     async def test_case_insensitive_regex_filter_sqlite(self):
         author = await testmodels.Author.create(name="Johann Wolfgang von Goethe")
         self.assertEqual(

--- a/tests/test_posix_regex_filter.py
+++ b/tests/test_posix_regex_filter.py
@@ -56,6 +56,7 @@ class TestCaseInsensitivePosixRegexFilter(test.TestCase):
     @test.requireCapability(dialect="sqlite")
     async def test_case_insensitive_regex_filter_sqlite(self):
         author = await testmodels.Author.create(name="Johann Wolfgang von Goethe")
+        print(testmodels.Author.filter(name__iposix_regex="^johann [a-zA-Z]+ Von goethe$").sql(params_inline=True))
         self.assertEqual(
             set(
                 await testmodels.Author.filter(

--- a/tests/test_posix_regex_filter.py
+++ b/tests/test_posix_regex_filter.py
@@ -4,14 +4,62 @@ from tortoise.contrib import test
 
 class TestPosixRegexFilter(test.TestCase):
 
-    @test.requireCapability(dialect="mysql")
     @test.requireCapability(dialect="postgres")
-    async def test_regex_filter(self):
+    async def test_regex_filter_postgres(self):
         author = await testmodels.Author.create(name="Johann Wolfgang von Goethe")
         self.assertEqual(
             set(
                 await testmodels.Author.filter(
                     name__posix_regex="^Johann [a-zA-Z]+ von Goethe$"
+                ).values_list("name", flat=True)
+            ),
+            {author.name},
+        )
+
+    @test.requireCapability(dialect="mysql")
+    async def test_regex_filter_mysql(self):
+        author = await testmodels.Author.create(name="Johann Wolfgang von Goethe")
+        self.assertEqual(
+            set(
+                await testmodels.Author.filter(
+                    name__posix_regex="^Johann [a-zA-Z]+ von Goethe$"
+                ).values_list("name", flat=True)
+            ),
+            {author.name},
+        )
+
+    @test.requireCapability(dialect="sqlite")
+    async def test_regex_filter_sqlite(self):
+        author = await testmodels.Author.create(name="Johann Wolfgang von Goethe")
+        self.assertEqual(
+            set(
+                await testmodels.Author.filter(
+                    name__posix_regex="^Johann [a-zA-Z]+ von Goethe$"
+                ).values_list("name", flat=True)
+            ),
+            {author.name},
+        )
+
+class TestCaseInsensitivePosixRegexFilter(test.TestCase):
+    @test.requireCapability(dialect="postgres")
+    async def test_case_insensitive_regex_filter_postgres(self):
+        author = await testmodels.Author.create(name="Johann Wolfgang von Goethe")
+        self.assertEqual(
+            set(
+                await testmodels.Author.filter(
+                    name__iposix_regex="^johann [a-zA-Z]+ Von goethe$"
+                ).values_list("name", flat=True)
+            ),
+            {author.name},
+        )
+
+    @test.requireCapability(dialect="sqlite")
+    async def test_case_insensitive_regex_filter_sqlite(self):
+        author = await testmodels.Author.create(name="Johann Wolfgang von Goethe")
+        self.assertEqual(
+            set(
+                await testmodels.Author.filter(
+                    name__iposix_regex="^johann [a-zA-Z]+ Von goethe$"
                 ).values_list("name", flat=True)
             ),
             {author.name},

--- a/tortoise/backends/base/client.py
+++ b/tortoise/backends/base/client.py
@@ -46,6 +46,7 @@ class Capabilities:
     :param support_for_update: Indicates that this DB supports SELECT ... FOR UPDATE SQL statement.
     :param support_index_hint: Support force index or use index.
     :param support_update_limit_order_by: support update/delete with limit and order by.
+    :param: support_for_posix_regex_queries: indicated if the db supports posix regex queries
     """
 
     def __init__(
@@ -63,6 +64,7 @@ class Capabilities:
         support_index_hint: bool = False,
         # support update/delete with limit and order by
         support_update_limit_order_by: bool = True,
+        support_for_posix_regex_queries: bool = False,
     ) -> None:
         super().__setattr__("_mutable", True)
 
@@ -74,6 +76,7 @@ class Capabilities:
         self.support_for_update = support_for_update
         self.support_index_hint = support_index_hint
         self.support_update_limit_order_by = support_update_limit_order_by
+        self.support_for_posix_regex_queries = support_for_posix_regex_queries
         super().__setattr__("_mutable", False)
 
     def __setattr__(self, attr: str, value: Any) -> None:

--- a/tortoise/backends/base/config_generator.py
+++ b/tortoise/backends/base/config_generator.py
@@ -62,7 +62,10 @@ DB_LOOKUP: Dict[str, Dict[str, Any]] = {
         "skip_first_char": False,
         "vmap": {"path": "file_path"},
         "defaults": {"journal_mode": "WAL", "journal_size_limit": 16384},
-        "cast": {"journal_size_limit": int},
+        "cast": {
+            "journal_size_limit": int,
+            "install_regexp_functions": bool,
+        },
     },
     "mysql": {
         "engine": "tortoise.backends.mysql",

--- a/tortoise/backends/base_postgres/client.py
+++ b/tortoise/backends/base_postgres/client.py
@@ -53,7 +53,9 @@ class BasePostgresClient(BaseDBAsyncClient, abc.ABC):
     query_class: Type[PostgreSQLQuery] = PostgreSQLQuery
     executor_class: Type[BasePostgresExecutor] = BasePostgresExecutor
     schema_generator: Type[BasePostgresSchemaGenerator] = BasePostgresSchemaGenerator
-    capabilities = Capabilities("postgres", support_update_limit_order_by=False, support_for_posix_regex_queries=True)
+    capabilities = Capabilities(
+        "postgres", support_update_limit_order_by=False, support_for_posix_regex_queries=True
+    )
     connection_class: "Optional[Union[AsyncConnection, Connection]]" = None
     loop: Optional[AbstractEventLoop] = None
     _pool: Optional[Any] = None

--- a/tortoise/backends/base_postgres/client.py
+++ b/tortoise/backends/base_postgres/client.py
@@ -53,7 +53,7 @@ class BasePostgresClient(BaseDBAsyncClient, abc.ABC):
     query_class: Type[PostgreSQLQuery] = PostgreSQLQuery
     executor_class: Type[BasePostgresExecutor] = BasePostgresExecutor
     schema_generator: Type[BasePostgresSchemaGenerator] = BasePostgresSchemaGenerator
-    capabilities = Capabilities("postgres", support_update_limit_order_by=False)
+    capabilities = Capabilities("postgres", support_update_limit_order_by=False, support_for_posix_regex_queries=True)
     connection_class: "Optional[Union[AsyncConnection, Connection]]" = None
     loop: Optional[AbstractEventLoop] = None
     _pool: Optional[Any] = None

--- a/tortoise/backends/base_postgres/executor.py
+++ b/tortoise/backends/base_postgres/executor.py
@@ -11,9 +11,13 @@ from tortoise.contrib.postgres.json_functions import (
     postgres_json_contains,
     postgres_json_filter,
 )
-from tortoise.contrib.postgres.regex import postgres_posix_regex
+from tortoise.contrib.postgres.regex import (
+    postgres_insensitive_posix_regex,
+    postgres_posix_regex,
+)
 from tortoise.contrib.postgres.search import SearchCriterion
 from tortoise.filters import (
+    insensitive_posix_regex,
     json_contained_by,
     json_contains,
     json_filter,
@@ -35,6 +39,7 @@ class BasePostgresExecutor(BaseExecutor):
         json_contained_by: postgres_json_contained_by,
         json_filter: postgres_json_filter,
         posix_regex: postgres_posix_regex,
+        insensitive_posix_regex: postgres_insensitive_posix_regex,
     }
 
     def _prepare_insert_statement(

--- a/tortoise/backends/mysql/client.py
+++ b/tortoise/backends/mysql/client.py
@@ -74,7 +74,7 @@ class MySQLClient(BaseDBAsyncClient):
     executor_class = MySQLExecutor
     schema_generator = MySQLSchemaGenerator
     capabilities = Capabilities(
-        "mysql", requires_limit=True, inline_comment=True, support_index_hint=True
+        "mysql", requires_limit=True, inline_comment=True, support_index_hint=True, support_for_posix_regex_queries=True
     )
 
     def __init__(

--- a/tortoise/backends/mysql/client.py
+++ b/tortoise/backends/mysql/client.py
@@ -74,7 +74,11 @@ class MySQLClient(BaseDBAsyncClient):
     executor_class = MySQLExecutor
     schema_generator = MySQLSchemaGenerator
     capabilities = Capabilities(
-        "mysql", requires_limit=True, inline_comment=True, support_index_hint=True, support_for_posix_regex_queries=True
+        "mysql",
+        requires_limit=True,
+        inline_comment=True,
+        support_index_hint=True,
+        support_for_posix_regex_queries=True,
     )
 
     def __init__(

--- a/tortoise/backends/mysql/executor.py
+++ b/tortoise/backends/mysql/executor.py
@@ -105,7 +105,7 @@ def mysql_search(field: Term, value: str) -> SearchCriterion:
 
 def mysql_posix_regex(field: Term, value: str) -> BasicCriterion:
     return BasicCriterion(
-        MySQLRegexpComparators.REGEXP, Coalesce(Cast(field, SqlTypes.VARCHAR)), StrWrapper(value)
+        MySQLRegexpComparators.REGEXP, Coalesce(Cast(field, SqlTypes.CHAR)), StrWrapper(value)
     )
 
 

--- a/tortoise/backends/mysql/executor.py
+++ b/tortoise/backends/mysql/executor.py
@@ -1,7 +1,10 @@
+import enum
+
 from pypika_tortoise import functions
 from pypika_tortoise.enums import SqlTypes
 from pypika_tortoise.terms import BasicCriterion, Criterion
 from pypika_tortoise.utils import format_quotes
+from pypika_tortoise.functions import Cast
 
 from tortoise import Model
 from tortoise.backends.base.executor import BaseExecutor
@@ -30,6 +33,9 @@ from tortoise.filters import (
     starts_with,
 )
 
+
+class MySQLRegexpComparators(enum.Enum):
+    REGEXP = " REGEXP "
 
 class StrWrapper(ValueWrapper):
     """
@@ -97,7 +103,7 @@ def mysql_search(field: Term, value: str) -> SearchCriterion:
 
 
 def mysql_posix_regex(field: Term, value: str) -> BasicCriterion:
-    return BasicCriterion(" REGEXP ", field, StrWrapper(value))  # type:ignore[arg-type]
+    return BasicCriterion(MySQLRegexpComparators.REGEXP, Cast(field, SqlTypes.VARCHAR), StrWrapper(value))  # type:ignore[arg-type]
 
 
 class MySQLExecutor(BaseExecutor):

--- a/tortoise/backends/mysql/executor.py
+++ b/tortoise/backends/mysql/executor.py
@@ -4,7 +4,7 @@ from pypika_tortoise import functions
 from pypika_tortoise.enums import SqlTypes
 from pypika_tortoise.terms import BasicCriterion, Criterion
 from pypika_tortoise.utils import format_quotes
-from pypika_tortoise.functions import Cast
+from pypika_tortoise.functions import Cast, Coalesce
 
 from tortoise import Model
 from tortoise.backends.base.executor import BaseExecutor
@@ -103,7 +103,7 @@ def mysql_search(field: Term, value: str) -> SearchCriterion:
 
 
 def mysql_posix_regex(field: Term, value: str) -> BasicCriterion:
-    return BasicCriterion(MySQLRegexpComparators.REGEXP, Cast(field, SqlTypes.VARCHAR), StrWrapper(value))
+    return BasicCriterion(MySQLRegexpComparators.REGEXP, Coalesce(Cast(field, SqlTypes.VARCHAR)), StrWrapper(value))
 
 
 class MySQLExecutor(BaseExecutor):

--- a/tortoise/backends/mysql/executor.py
+++ b/tortoise/backends/mysql/executor.py
@@ -2,9 +2,9 @@ import enum
 
 from pypika_tortoise import functions
 from pypika_tortoise.enums import SqlTypes
+from pypika_tortoise.functions import Cast, Coalesce
 from pypika_tortoise.terms import BasicCriterion, Criterion
 from pypika_tortoise.utils import format_quotes
-from pypika_tortoise.functions import Cast, Coalesce
 
 from tortoise import Model
 from tortoise.backends.base.executor import BaseExecutor
@@ -36,6 +36,7 @@ from tortoise.filters import (
 
 class MySQLRegexpComparators(enum.Enum):
     REGEXP = " REGEXP "
+
 
 class StrWrapper(ValueWrapper):
     """
@@ -103,7 +104,9 @@ def mysql_search(field: Term, value: str) -> SearchCriterion:
 
 
 def mysql_posix_regex(field: Term, value: str) -> BasicCriterion:
-    return BasicCriterion(MySQLRegexpComparators.REGEXP, Coalesce(Cast(field, SqlTypes.VARCHAR)), StrWrapper(value))
+    return BasicCriterion(
+        MySQLRegexpComparators.REGEXP, Coalesce(Cast(field, SqlTypes.VARCHAR)), StrWrapper(value)
+    )
 
 
 class MySQLExecutor(BaseExecutor):

--- a/tortoise/backends/mysql/executor.py
+++ b/tortoise/backends/mysql/executor.py
@@ -103,7 +103,7 @@ def mysql_search(field: Term, value: str) -> SearchCriterion:
 
 
 def mysql_posix_regex(field: Term, value: str) -> BasicCriterion:
-    return BasicCriterion(MySQLRegexpComparators.REGEXP, Cast(field, SqlTypes.VARCHAR), StrWrapper(value))  # type:ignore[arg-type]
+    return BasicCriterion(MySQLRegexpComparators.REGEXP, Cast(field, SqlTypes.VARCHAR), StrWrapper(value))
 
 
 class MySQLExecutor(BaseExecutor):

--- a/tortoise/backends/sqlite/__init__.py
+++ b/tortoise/backends/sqlite/__init__.py
@@ -1,3 +1,9 @@
-from .client import SqliteClient
+from .client import SqliteClient, SqliteClientWithRegexpSupport
 
 client_class = SqliteClient
+
+def get_client_class(db_info: dict):
+    if db_info.get("credentials", {}).get("install_regexp_functions"):
+        return SqliteClientWithRegexpSupport
+    else:
+        return SqliteClient

--- a/tortoise/backends/sqlite/__init__.py
+++ b/tortoise/backends/sqlite/__init__.py
@@ -2,6 +2,7 @@ from .client import SqliteClient, SqliteClientWithRegexpSupport
 
 client_class = SqliteClient
 
+
 def get_client_class(db_info: dict):
     if db_info.get("credentials", {}).get("install_regexp_functions"):
         return SqliteClientWithRegexpSupport

--- a/tortoise/backends/sqlite/client.py
+++ b/tortoise/backends/sqlite/client.py
@@ -29,6 +29,7 @@ from tortoise.backends.base.client import (
 )
 from tortoise.backends.sqlite.executor import SqliteExecutor
 from tortoise.backends.sqlite.schema_generator import SqliteSchemaGenerator
+from tortoise.contrib.sqlite.regex import install_regexp_function
 from tortoise.connection import connections
 from tortoise.exceptions import (
     IntegrityError,
@@ -84,6 +85,7 @@ class SqliteClient(BaseDBAsyncClient):
             for pragma, val in self.pragmas.items():
                 cursor = await self._connection.execute(f"PRAGMA {pragma}={val}")
                 await cursor.close()
+            await install_regexp_function(self._connection)
             self.log.debug(
                 "Created connection %s with params: filename=%s %s",
                 self._connection,

--- a/tortoise/backends/sqlite/client.py
+++ b/tortoise/backends/sqlite/client.py
@@ -12,7 +12,7 @@ from typing import (
     Sequence,
     Tuple,
     TypeVar,
-    cast, override,
+    cast,
 )
 
 import aiosqlite
@@ -29,8 +29,10 @@ from tortoise.backends.base.client import (
 )
 from tortoise.backends.sqlite.executor import SqliteExecutor
 from tortoise.backends.sqlite.schema_generator import SqliteSchemaGenerator
-from tortoise.contrib.sqlite.regex import install_regexp_functions as install_regexp_functions_to_db
 from tortoise.connection import connections
+from tortoise.contrib.sqlite.regex import (
+    install_regexp_functions as install_regexp_functions_to_db,
+)
 from tortoise.exceptions import (
     IntegrityError,
     OperationalError,
@@ -278,14 +280,15 @@ def _gen_savepoint_name(_c=count()) -> str:
 
 class SqliteClientWithRegexpSupport(SqliteClient):
     capabilities = Capabilities(
-        "sqlite", daemon=False, requires_limit=True, inline_comment=True, support_for_update=False, support_for_posix_regex_queries=True
+        "sqlite",
+        daemon=False,
+        requires_limit=True,
+        inline_comment=True,
+        support_for_update=False,
+        support_for_posix_regex_queries=True,
     )
 
     async def create_connection(self, with_db: bool) -> None:
         await super().create_connection(with_db)
-        await install_regexp_functions_to_db(self._connection)
-
-
-# class TransactionWrapperWithRegexpSupport(TransactionWrapper):
-#     def __init__(self, connection: SqliteClientWithRegexpSupport) -> None:
-#         super().__init__(connection)
+        if self._connection:
+            await install_regexp_functions_to_db(self._connection)

--- a/tortoise/backends/sqlite/executor.py
+++ b/tortoise/backends/sqlite/executor.py
@@ -7,6 +7,10 @@ import pytz
 
 from tortoise import Model, fields, timezone
 from tortoise.backends.base.executor import BaseExecutor
+from tortoise.contrib.sqlite.regex import (
+    insensitive_posix_sqlite_regexp,
+    posix_sqlite_regexp,
+)
 from tortoise.fields import (
     BigIntField,
     BooleanField,
@@ -16,6 +20,7 @@ from tortoise.fields import (
     SmallIntField,
     TimeField,
 )
+from tortoise.filters import insensitive_posix_regex, posix_regex
 
 
 def to_db_bool(
@@ -91,6 +96,10 @@ class SqliteExecutor(BaseExecutor):
     }
     EXPLAIN_PREFIX = "EXPLAIN QUERY PLAN"
     DB_NATIVE = {bytes, str, int, float}
+    FILTER_FUNC_OVERRIDE = {
+        posix_regex: posix_sqlite_regexp,
+        insensitive_posix_regex: insensitive_posix_sqlite_regexp,
+    }
 
     async def _process_insert_result(self, instance: Model, results: int) -> None:
         pk_field_object = self.model._meta.pk

--- a/tortoise/connection.py
+++ b/tortoise/connection.py
@@ -75,7 +75,9 @@ class ConnectionHandler:
             else:
                 client_class = engine_module.client_class
         except AttributeError:
-            raise ConfigurationError(f'Backend for engine "{engine_str}" does not implement db client')
+            raise ConfigurationError(
+                f'Backend for engine "{engine_str}" does not implement db client'
+            )
         return client_class
 
     def _get_db_info(self, conn_alias: str) -> Union[str, Dict]:

--- a/tortoise/connection.py
+++ b/tortoise/connection.py
@@ -65,13 +65,17 @@ class ConnectionHandler:
     def _clear_storage(self) -> None:
         self._get_storage().clear()
 
-    def _discover_client_class(self, engine: str) -> Type["BaseDBAsyncClient"]:
+    def _discover_client_class(self, db_info: dict) -> Type["BaseDBAsyncClient"]:
         # Let exception bubble up for transparency
-        engine_module = importlib.import_module(engine)
+        engine_str = db_info.get("engine", "")
+        engine_module = importlib.import_module(engine_str)
         try:
-            client_class = engine_module.client_class
+            if hasattr(engine_module, "get_client_class"):
+                client_class = engine_module.get_client_class(db_info)
+            else:
+                client_class = engine_module.client_class
         except AttributeError:
-            raise ConfigurationError(f'Backend for engine "{engine}" does not implement db client')
+            raise ConfigurationError(f'Backend for engine "{engine_str}" does not implement db client')
         return client_class
 
     def _get_db_info(self, conn_alias: str) -> Union[str, Dict]:
@@ -93,7 +97,7 @@ class ConnectionHandler:
         db_info = self._get_db_info(conn_alias)
         if isinstance(db_info, str):
             db_info = expand_db_url(db_info)
-        client_class = self._discover_client_class(db_info.get("engine", ""))
+        client_class = self._discover_client_class(db_info)
         db_params = db_info["credentials"].copy()
         db_params.update({"connection_name": conn_alias})
         connection: "BaseDBAsyncClient" = client_class(**db_params)

--- a/tortoise/contrib/postgres/regex.py
+++ b/tortoise/contrib/postgres/regex.py
@@ -6,7 +6,7 @@ from pypika_tortoise.terms import BasicCriterion, Term
 
 class PostgresRegexMatching(enum.Enum):
     POSIX_REGEX = " ~ "
-    IPOSIX_REGEX = " *~ "
+    IPOSIX_REGEX = " ~* "
 
 
 def postgres_posix_regex(field: Term, value: str):

--- a/tortoise/contrib/postgres/regex.py
+++ b/tortoise/contrib/postgres/regex.py
@@ -1,9 +1,9 @@
 import enum
 from typing import cast
 
-from pypika_tortoise.terms import BasicCriterion, Term
-from pypika_tortoise.functions import Cast, Coalesce
 from pypika_tortoise.enums import SqlTypes
+from pypika_tortoise.functions import Cast, Coalesce
+from pypika_tortoise.terms import BasicCriterion, Term
 
 
 class PostgresRegexMatching(enum.Enum):
@@ -13,9 +13,13 @@ class PostgresRegexMatching(enum.Enum):
 
 def postgres_posix_regex(field: Term, value: str):
     term = cast(Term, field.wrap_constant(value))
-    return BasicCriterion(PostgresRegexMatching.POSIX_REGEX, Coalesce(Cast(field, SqlTypes.VARCHAR), ""), term)
+    return BasicCriterion(
+        PostgresRegexMatching.POSIX_REGEX, Coalesce(Cast(field, SqlTypes.VARCHAR), ""), term
+    )
 
 
 def postgres_insensitive_posix_regex(field: Term, value: str):
     term = cast(Term, field.wrap_constant(value))
-    return BasicCriterion(PostgresRegexMatching.IPOSIX_REGEX, Coalesce(Cast(field, SqlTypes.VARCHAR), ""), term)
+    return BasicCriterion(
+        PostgresRegexMatching.IPOSIX_REGEX, Coalesce(Cast(field, SqlTypes.VARCHAR), ""), term
+    )

--- a/tortoise/contrib/postgres/regex.py
+++ b/tortoise/contrib/postgres/regex.py
@@ -5,6 +5,8 @@ from pypika_tortoise.terms import BasicCriterion, Term
 from pypika_tortoise.functions import Cast
 from pypika_tortoise.enums import SqlTypes
 
+from tortoise.functions import Coalesce
+
 
 class PostgresRegexMatching(enum.Enum):
     POSIX_REGEX = " ~ "

--- a/tortoise/contrib/postgres/regex.py
+++ b/tortoise/contrib/postgres/regex.py
@@ -2,6 +2,8 @@ import enum
 from typing import cast
 
 from pypika_tortoise.terms import BasicCriterion, Term
+from pypika_tortoise.functions import Cast
+from pypika_tortoise.enums import SqlTypes
 
 
 class PostgresRegexMatching(enum.Enum):

--- a/tortoise/contrib/postgres/regex.py
+++ b/tortoise/contrib/postgres/regex.py
@@ -5,9 +5,15 @@ from pypika_tortoise.terms import BasicCriterion, Term
 
 
 class PostgresRegexMatching(enum.Enum):
-    posix_regex = "~"
+    POSIX_REGEX = " ~ "
+    IPOSIX_REGEX = " *~ "
 
 
-def postgres_posix_regex(field: Term, value: str) -> BasicCriterion:
+def postgres_posix_regex(field: Term, value: str):
     term = cast(Term, field.wrap_constant(value))
-    return BasicCriterion(PostgresRegexMatching.posix_regex, field, term)
+    return BasicCriterion(PostgresRegexMatching.POSIX_REGEX, field, term)
+
+
+def postgres_insensitive_posix_regex(field: Term, value: str):
+    term = cast(Term, field.wrap_constant(value))
+    return BasicCriterion(PostgresRegexMatching.IPOSIX_REGEX, field, term)

--- a/tortoise/contrib/postgres/regex.py
+++ b/tortoise/contrib/postgres/regex.py
@@ -2,10 +2,8 @@ import enum
 from typing import cast
 
 from pypika_tortoise.terms import BasicCriterion, Term
-from pypika_tortoise.functions import Cast
+from pypika_tortoise.functions import Cast, Coalesce
 from pypika_tortoise.enums import SqlTypes
-
-from tortoise.functions import Coalesce
 
 
 class PostgresRegexMatching(enum.Enum):
@@ -15,9 +13,9 @@ class PostgresRegexMatching(enum.Enum):
 
 def postgres_posix_regex(field: Term, value: str):
     term = cast(Term, field.wrap_constant(value))
-    return BasicCriterion(PostgresRegexMatching.POSIX_REGEX, field, term)
+    return BasicCriterion(PostgresRegexMatching.POSIX_REGEX, Coalesce(Cast(field, SqlTypes.VARCHAR), ""), term)
 
 
 def postgres_insensitive_posix_regex(field: Term, value: str):
     term = cast(Term, field.wrap_constant(value))
-    return BasicCriterion(PostgresRegexMatching.IPOSIX_REGEX, field, term)
+    return BasicCriterion(PostgresRegexMatching.IPOSIX_REGEX, Coalesce(Cast(field, SqlTypes.VARCHAR), ""), term)

--- a/tortoise/contrib/sqlite/regex.py
+++ b/tortoise/contrib/sqlite/regex.py
@@ -4,8 +4,9 @@ from typing import cast
 
 import aiosqlite
 from pypika.terms import BasicCriterion, Term
-from pypika.functions import Cast
+from pypika.functions import Cast, Coalesce
 from pypika.enums import SqlTypes
+
 
 class SQLiteRegexMatching(enum.Enum):
     POSIX_REGEX = " REGEXP "
@@ -14,12 +15,12 @@ class SQLiteRegexMatching(enum.Enum):
 
 def posix_sqlite_regexp(field: Term, value: str):
     term = cast(Term, field.wrap_constant(value))
-    return BasicCriterion(SQLiteRegexMatching.POSIX_REGEX, Cast(field, SqlTypes.VARCHAR), term)
+    return BasicCriterion(SQLiteRegexMatching.POSIX_REGEX, Coalesce(Cast(field, SqlTypes.VARCHAR), ""), term)
 
 
 def insensitive_posix_sqlite_regexp(field: Term, value: str):
     term = cast(Term, field.wrap_constant(value))
-    return BasicCriterion(SQLiteRegexMatching.IPOSIX_REGEX, Cast(field, SqlTypes.VARCHAR), term)
+    return BasicCriterion(SQLiteRegexMatching.IPOSIX_REGEX, Coalesce(Cast(field, SqlTypes.VARCHAR), ""), term)
 
 async def install_regexp_function(connection: aiosqlite.Connection):
     def regexp(expr, item):

--- a/tortoise/contrib/sqlite/regex.py
+++ b/tortoise/contrib/sqlite/regex.py
@@ -3,9 +3,9 @@ import re
 from typing import cast
 
 import aiosqlite
-from pypika.enums import SqlTypes
-from pypika.functions import Cast, Coalesce
-from pypika.terms import BasicCriterion, Term
+from pypika_tortoise.enums import SqlTypes
+from pypika_tortoise.functions import Cast, Coalesce
+from pypika_tortoise.terms import BasicCriterion, Term
 
 
 class SQLiteRegexMatching(enum.Enum):

--- a/tortoise/contrib/sqlite/regex.py
+++ b/tortoise/contrib/sqlite/regex.py
@@ -3,7 +3,7 @@ import re
 from typing import cast
 
 import aiosqlite
-from pypika.terms import BasicCriterion, Term, Function
+from pypika.terms import BasicCriterion, Term
 
 
 class SQLiteRegexMatching(enum.Enum):

--- a/tortoise/contrib/sqlite/regex.py
+++ b/tortoise/contrib/sqlite/regex.py
@@ -1,0 +1,17 @@
+import enum
+
+from pypika.terms import BasicCriterion, Term
+
+
+class SQLiteRegexMatching(enum.Enum):
+    POSIX_REGEX = " REGEXP "
+
+
+def posix_sqlite_regexp(field: Term, value: str):
+    return BasicCriterion(SQLiteRegexMatching.POSIX_REGEX, field, field.wrap_constant(value))
+
+
+def insensitive_posix_sqlite_regexp(field: Term, value: str):
+    return BasicCriterion(
+        SQLiteRegexMatching.POSIX_REGEX, field, field.wrap_constant(f"(?i) {value}")
+    )

--- a/tortoise/contrib/sqlite/regex.py
+++ b/tortoise/contrib/sqlite/regex.py
@@ -1,17 +1,33 @@
 import enum
+import re
+from typing import cast
 
-from pypika.terms import BasicCriterion, Term
+import aiosqlite
+from pypika.terms import BasicCriterion, Term, Function
 
 
 class SQLiteRegexMatching(enum.Enum):
     POSIX_REGEX = " REGEXP "
+    IPOSIX_REGEX = " MATCH "
 
 
 def posix_sqlite_regexp(field: Term, value: str):
-    return BasicCriterion(SQLiteRegexMatching.POSIX_REGEX, field, field.wrap_constant(value))
+    term = cast(Term, field.wrap_constant(value))
+    return BasicCriterion(SQLiteRegexMatching.POSIX_REGEX, field, term)
+    # return Function("regexp", field, term)
 
 
 def insensitive_posix_sqlite_regexp(field: Term, value: str):
-    return BasicCriterion(
-        SQLiteRegexMatching.POSIX_REGEX, field, field.wrap_constant(f"(?i) {value}")
-    )
+    term = cast(Term, field.wrap_constant(value))
+    return BasicCriterion(SQLiteRegexMatching.IPOSIX_REGEX, field, term)
+    # return Function("iregexp", field, term)
+
+async def install_regexp_function(connection: aiosqlite.Connection):
+    def regexp(expr, item):
+        return re.search(expr, item) is not None
+
+    def iregexp(expr, item):
+        return re.search(expr, item, re.IGNORECASE) is not None
+
+    await connection.create_function("regexp", 2, regexp)
+    await connection.create_function("match", 2, iregexp)

--- a/tortoise/contrib/sqlite/regex.py
+++ b/tortoise/contrib/sqlite/regex.py
@@ -23,6 +23,8 @@ def insensitive_posix_sqlite_regexp(field: Term, value: str):
 
 async def install_regexp_function(connection: aiosqlite.Connection):
     def regexp(expr, item):
+        if not expr or not item:
+            return False
         return re.search(expr, item) is not None
 
     def iregexp(expr, item):

--- a/tortoise/contrib/sqlite/regex.py
+++ b/tortoise/contrib/sqlite/regex.py
@@ -27,7 +27,7 @@ def insensitive_posix_sqlite_regexp(field: Term, value: str):
     )
 
 
-async def install_regexp_function(connection: aiosqlite.Connection):
+async def install_regexp_functions(connection: aiosqlite.Connection):
     def regexp(expr, item):
         if not expr or not item:
             return False

--- a/tortoise/contrib/sqlite/regex.py
+++ b/tortoise/contrib/sqlite/regex.py
@@ -3,9 +3,9 @@ import re
 from typing import cast
 
 import aiosqlite
-from pypika.terms import BasicCriterion, Term
-from pypika.functions import Cast, Coalesce
 from pypika.enums import SqlTypes
+from pypika.functions import Cast, Coalesce
+from pypika.terms import BasicCriterion, Term
 
 
 class SQLiteRegexMatching(enum.Enum):
@@ -15,12 +15,17 @@ class SQLiteRegexMatching(enum.Enum):
 
 def posix_sqlite_regexp(field: Term, value: str):
     term = cast(Term, field.wrap_constant(value))
-    return BasicCriterion(SQLiteRegexMatching.POSIX_REGEX, Coalesce(Cast(field, SqlTypes.VARCHAR), ""), term)
+    return BasicCriterion(
+        SQLiteRegexMatching.POSIX_REGEX, Coalesce(Cast(field, SqlTypes.VARCHAR), ""), term
+    )
 
 
 def insensitive_posix_sqlite_regexp(field: Term, value: str):
     term = cast(Term, field.wrap_constant(value))
-    return BasicCriterion(SQLiteRegexMatching.IPOSIX_REGEX, Coalesce(Cast(field, SqlTypes.VARCHAR), ""), term)
+    return BasicCriterion(
+        SQLiteRegexMatching.IPOSIX_REGEX, Coalesce(Cast(field, SqlTypes.VARCHAR), ""), term
+    )
+
 
 async def install_regexp_function(connection: aiosqlite.Connection):
     def regexp(expr, item):

--- a/tortoise/contrib/sqlite/regex.py
+++ b/tortoise/contrib/sqlite/regex.py
@@ -4,7 +4,8 @@ from typing import cast
 
 import aiosqlite
 from pypika.terms import BasicCriterion, Term
-
+from pypika.functions import Cast
+from pypika.enums import SqlTypes
 
 class SQLiteRegexMatching(enum.Enum):
     POSIX_REGEX = " REGEXP "
@@ -13,14 +14,12 @@ class SQLiteRegexMatching(enum.Enum):
 
 def posix_sqlite_regexp(field: Term, value: str):
     term = cast(Term, field.wrap_constant(value))
-    return BasicCriterion(SQLiteRegexMatching.POSIX_REGEX, field, term)
-    # return Function("regexp", field, term)
+    return BasicCriterion(SQLiteRegexMatching.POSIX_REGEX, Cast(field, SqlTypes.VARCHAR), term)
 
 
 def insensitive_posix_sqlite_regexp(field: Term, value: str):
     term = cast(Term, field.wrap_constant(value))
-    return BasicCriterion(SQLiteRegexMatching.IPOSIX_REGEX, field, term)
-    # return Function("iregexp", field, term)
+    return BasicCriterion(SQLiteRegexMatching.IPOSIX_REGEX, Cast(field, SqlTypes.VARCHAR), term)
 
 async def install_regexp_function(connection: aiosqlite.Connection):
     def regexp(expr, item):

--- a/tortoise/filters.py
+++ b/tortoise/filters.py
@@ -144,7 +144,14 @@ def search(field: Term, value: str) -> Any:
 def posix_regex(field: Term, value: str) -> Any:
     # Will be overridden in each executor
     raise NotImplementedError(
-        "The postgres_posix_regex filter operator is not supported by your database backend"
+        "The posix_regex filter operator is not supported by your database backend"
+    )
+
+
+def insensitive_posix_regex(field: Term, value: str):
+    # Will be overridden in each executor
+    raise NotImplementedError(
+        "The insensitive_posix_regex filter operator is not supported by your database backend"
     )
 
 
@@ -508,6 +515,12 @@ def get_filters_for_field(
             "field": actual_field_name,
             "source_field": source_field,
             "operator": posix_regex,
+            "value_encoder": string_encoder,
+        },
+        f"{field_name}__iposix_regex": {
+            "field": actual_field_name,
+            "source_field": source_field,
+            "operator": insensitive_posix_regex,
             "value_encoder": string_encoder,
         },
         f"{field_name}__year": {


### PR DESCRIPTION
This PR adds support for case insentive regex filtering (postgres and sqlite). It also adds support for the REGEXP sqlite module (needs to be installed in sqlite to work).

## Description
Postgres and SQLite offer ways to query with regular expression while ignoring case, similiarly how we already have case insensitive contains, etc. This PR adds support for these filters.

This PR also adds support for [SQLite](https://www.sqlite.org/lang_expr.html) (regexp() function needs to be supplied at runtime, e.g. via [an extension](https://github.com/nalgeon/sqlean/blob/main/docs/regexp.md)). It is installed by default on most linux distributions of sqlite.

## Motivation and Context
I want to query case insensitive regex patterns. Having sqlite support is good for completeness. Many people including me use sqlite for unit tests, so having feature parity across db backends is aa big plus.

## How Has This Been Tested?
Ran the tests suite

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

