### PR TITLE
Same model returned by pydantic_model_creator calls with different arguments

### DIFF
--- a/tests/contrib/test_pydantic.py
+++ b/tests/contrib/test_pydantic.py
@@ -8,6 +8,7 @@ from tests.testmodels import (
     CamelCaseAliasPerson,
     Employee,
     Event,
+    IntFields,
     JSONFields,
     Reporter,
     Team,
@@ -231,7 +232,7 @@ class TestPydantic(test.TestCase):
             self.Event_Pydantic_List.model_json_schema(),
             {
                 "$defs": {
-                    "Event_ct5gv4": {
+                    "Event_bliobj": {
                         "additionalProperties": False,
                         "description": "Events on the calendar",
                         "properties": {
@@ -398,7 +399,7 @@ class TestPydantic(test.TestCase):
                     },
                 },
                 "description": "Events on the calendar",
-                "items": {"$ref": "#/$defs/Event_ct5gv4"},
+                "items": {"$ref": "#/$defs/Event_bliobj"},
                 "title": "Event_list",
                 "type": "array",
             },
@@ -409,7 +410,7 @@ class TestPydantic(test.TestCase):
             self.Address_Pydantic.model_json_schema(),
             {
                 "$defs": {
-                    "Event_aajoh6": {
+                    "Event_jim4na": {
                         "additionalProperties": False,
                         "description": "Events on the calendar",
                         "properties": {
@@ -552,7 +553,7 @@ class TestPydantic(test.TestCase):
                 "properties": {
                     "city": {"maxLength": 64, "title": "City", "type": "string"},
                     "street": {"maxLength": 128, "title": "Street", "type": "string"},
-                    "event": {"$ref": "#/$defs/Event_aajoh6"},
+                    "event": {"$ref": "#/$defs/Event_jim4na"},
                     "event_id": {
                         "maximum": 9223372036854775807,
                         "minimum": -9223372036854775808,
@@ -571,7 +572,7 @@ class TestPydantic(test.TestCase):
             self.Tournament_Pydantic.model_json_schema(),
             {
                 "$defs": {
-                    "Event_h4reuz": {
+                    "Event_ml4ytz": {
                         "additionalProperties": False,
                         "description": "Events on the calendar",
                         "properties": {
@@ -723,7 +724,7 @@ class TestPydantic(test.TestCase):
                     },
                     "events": {
                         "description": "What tournaments is a happenin'",
-                        "items": {"$ref": "#/$defs/Event_h4reuz"},
+                        "items": {"$ref": "#/$defs/Event_ml4ytz"},
                         "title": "Events",
                         "type": "array",
                     },
@@ -739,7 +740,7 @@ class TestPydantic(test.TestCase):
             self.Team_Pydantic.model_json_schema(),
             {
                 "$defs": {
-                    "Event_mfn2l6": {
+                    "Event_vrm2bi": {
                         "additionalProperties": False,
                         "description": "Events on the calendar",
                         "properties": {
@@ -888,7 +889,7 @@ class TestPydantic(test.TestCase):
                         "title": "Alias",
                     },
                     "events": {
-                        "items": {"$ref": "#/$defs/Event_mfn2l6"},
+                        "items": {"$ref": "#/$defs/Event_vrm2bi"},
                         "title": "Events",
                         "type": "array",
                     },
@@ -1268,10 +1269,28 @@ class TestPydantic(test.TestCase):
             PydanticModel.model_config["from_attributes"],
         )
 
-    def test_exclude_read_only(self):
+    def test_exclude_readonly(self):
         ModelPydantic = pydantic_model_creator(Event, exclude_readonly=True)
 
         self.assertNotIn("modified", ModelPydantic.model_json_schema()["properties"])
+
+    def test_exclude_readonly_multiple_leaf_models_without_name(self):
+        ModelPydantic = pydantic_model_creator(IntFields)
+        ModelPydantic_ExcludeReadonly = pydantic_model_creator(IntFields, exclude_readonly=True)
+
+        assert ModelPydantic is not ModelPydantic_ExcludeReadonly
+        self.assertIn("id", ModelPydantic.model_json_schema()["properties"])
+        self.assertNotIn("id", ModelPydantic_ExcludeReadonly.model_json_schema()["properties"])
+
+    def test_exclude_readonly_multiple_complex_models_without_name(self):
+        ModelPydantic = pydantic_model_creator(Event)
+        ModelPydantic_ExcludeReadonly = pydantic_model_creator(Event, exclude_readonly=True)
+
+        assert ModelPydantic is not ModelPydantic_ExcludeReadonly
+        self.assertIn("event_id", ModelPydantic.model_json_schema()["properties"])
+        self.assertNotIn(
+            "event_id", ModelPydantic_ExcludeReadonly.model_json_schema()["properties"]
+        )
 
 
 class TestPydanticCycle(test.TestCase):
@@ -1297,7 +1316,7 @@ class TestPydanticCycle(test.TestCase):
             self.Employee_Pydantic.model_json_schema(),
             {
                 "$defs": {
-                    "Employee_4fgkwn": {
+                    "Employee_ibbaiu": {
                         "additionalProperties": False,
                         "properties": {
                             "id": {
@@ -1334,7 +1353,7 @@ class TestPydanticCycle(test.TestCase):
                         "title": "Employee",
                         "type": "object",
                     },
-                    "Employee_5gupxf": {
+                    "Employee_obdn4z": {
                         "additionalProperties": False,
                         "properties": {
                             "id": {
@@ -1409,7 +1428,7 @@ class TestPydanticCycle(test.TestCase):
                     },
                     "name": {"maxLength": 50, "title": "Name", "type": "string"},
                     "talks_to": {
-                        "items": {"$ref": "#/$defs/Employee_5gupxf"},
+                        "items": {"$ref": "#/$defs/Employee_obdn4z"},
                         "title": "Talks To",
                         "type": "array",
                     },
@@ -1422,7 +1441,7 @@ class TestPydanticCycle(test.TestCase):
                         "title": "Manager Id",
                     },
                     "team_members": {
-                        "items": {"$ref": "#/$defs/Employee_4fgkwn"},
+                        "items": {"$ref": "#/$defs/Employee_ibbaiu"},
                         "title": "Team Members",
                         "type": "array",
                     },

--- a/tortoise/contrib/pydantic/creator.py
+++ b/tortoise/contrib/pydantic/creator.py
@@ -183,10 +183,9 @@ def pydantic_model_creator(
             and computed == ()
             and sort_alphabetically is None
             and allow_cycles is None
+            and not exclude_readonly
         )
-        hashval = (
-            f"{fqname};{exclude};{include};{computed};{_stack}:{sort_alphabetically}:{allow_cycles}"
-        )
+        hashval = f"{fqname};{exclude};{include};{computed};{_stack}:{sort_alphabetically}:{allow_cycles}:{exclude_readonly}"
         postfix = (
             ":" + b32encode(sha3_224(hashval.encode("utf-8")).digest()).decode("utf-8").lower()[:6]
             if not is_default
@@ -433,9 +432,9 @@ def pydantic_model_creator(
                 properties[fname] = (ftype, Field(**fconfig))
 
     # Here we endure that the name is unique, but complete objects are still labeled verbatim
-    if not has_submodel:
+    if not has_submodel and _stack:
         _name = name or f"{fqname}.leaf"
-    elif has_submodel:
+    else:
         _name = name or get_name()
 
     # Here we de-dup to ensure that a uniquely named object is a unique object


### PR DESCRIPTION
## Description

This PR fixes the issue where calling `pydantic_model_creator` multiple times with different arguments without specifying a name might return the same model due to caching (`_MODEL_INDEX` in `creator.py`). The example below demonstrates the issue.

```python
from tortoise import fields
from tortoise.contrib.pydantic import pydantic_model_creator
from tortoise.models import Model


class People(Model):
    id = fields.IntField(pk=True)
    created_at = fields.DatetimeField(auto_now_add=True)
    modified_at = fields.DatetimeField(auto_now=True)

    first_name = fields.CharField(max_length=50)
    last_name = fields.CharField(max_length=50)


Person = pydantic_model_creator(People)
PersonIn = pydantic_model_creator(People, exclude_readonly=True)

print(list(Person.model_fields))  
# [id, created_at, modified_at, first_name_last_name]
print(list(PersonIn.model_fields))  
# [id, created_at, modified_at, first_name_last_name] 
# However, it should be ['first_name', 'last_name'] because of exclude_readonly=True

print(Person is PersonIn)  
# True (!)
```

This issues affects the models that have no backward or forward reference to any other model. 

This PR:
* Makes `pydantic_model_creator` to create verbatim names for "root" models even if they do not have relations 
* Adds the `exclude_readonly` to the hash used for naming unnamed models so `pydantic_model_creator(People)` and `pydantic_model_creator(People, exclude_readonly=True)`

## Motivation and Context
The issues that will be fixed by this PR:
- Closes https://github.com/tortoise/tortoise-orm/issues/594
- Closes https://github.com/tortoise/tortoise-orm/issues/647

There was [an attempt](https://github.com/tortoise/tortoise-orm/pull/735) to solve this issue previously but it was never merged. The approach used does not seem to work anymore.

## How Has This Been Tested?
- Tested the snippets from the issues above
- Added unit tests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

