### PR TITLE
Annotated Fields in Case-When

### DIFF
--- a/tests/test_q.py
+++ b/tests/test_q.py
@@ -3,7 +3,7 @@ from unittest import TestCase as _TestCase
 from tests.testmodels import CharFields, IntFields
 from tortoise.contrib.test import TestCase
 from tortoise.exceptions import OperationalError
-from tortoise.expressions import Q
+from tortoise.expressions import Q, ResolveContext
 
 
 class TestQ(_TestCase):
@@ -115,59 +115,68 @@ class TestQ(_TestCase):
 
 
 class TestQCall(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.int_fields_context = ResolveContext(
+            model=IntFields, table=IntFields._meta.basequery, annotations={}, custom_filters={}
+        )
+        self.char_fields_context = ResolveContext(
+            model=CharFields, table=CharFields._meta.basequery, annotations={}, custom_filters={}
+        )
+
     def test_q_basic(self):
         q = Q(id=8)
-        r = q.resolve(IntFields, IntFields._meta.basequery)
+        r = q.resolve(self.int_fields_context)
         self.assertEqual(r.where_criterion.get_sql(), '"id"=8')
 
     def test_q_basic_and(self):
         q = Q(join_type="AND", id=8)
-        r = q.resolve(IntFields, IntFields._meta.basequery)
+        r = q.resolve(self.int_fields_context)
         self.assertEqual(r.where_criterion.get_sql(), '"id"=8')
 
     def test_q_basic_or(self):
         q = Q(join_type="OR", id=8)
-        r = q.resolve(IntFields, IntFields._meta.basequery)
+        r = q.resolve(self.int_fields_context)
         self.assertEqual(r.where_criterion.get_sql(), '"id"=8')
 
     def test_q_multiple_and(self):
         q = Q(join_type="AND", id__gt=8, id__lt=10)
-        r = q.resolve(IntFields, IntFields._meta.basequery)
+        r = q.resolve(self.int_fields_context)
         self.assertEqual(r.where_criterion.get_sql(), '"id">8 AND "id"<10')
 
     def test_q_multiple_or(self):
         q = Q(join_type="OR", id__gt=8, id__lt=10)
-        r = q.resolve(IntFields, IntFields._meta.basequery)
+        r = q.resolve(self.int_fields_context)
         self.assertEqual(r.where_criterion.get_sql(), '"id">8 OR "id"<10')
 
     def test_q_multiple_and2(self):
         q = Q(join_type="AND", id=8, intnum=80)
-        r = q.resolve(IntFields, IntFields._meta.basequery)
+        r = q.resolve(self.int_fields_context)
         self.assertEqual(r.where_criterion.get_sql(), '"id"=8 AND "intnum"=80')
 
     def test_q_multiple_or2(self):
         q = Q(join_type="OR", id=8, intnum=80)
-        r = q.resolve(IntFields, IntFields._meta.basequery)
+        r = q.resolve(self.int_fields_context)
         self.assertEqual(r.where_criterion.get_sql(), '"id"=8 OR "intnum"=80')
 
     def test_q_complex_int(self):
         q = Q(Q(intnum=80), Q(id__lt=5, id__gt=50, join_type="OR"), join_type="AND")
-        r = q.resolve(IntFields, IntFields._meta.basequery)
+        r = q.resolve(self.int_fields_context)
         self.assertEqual(r.where_criterion.get_sql(), '"intnum"=80 AND ("id"<5 OR "id">50)')
 
     def test_q_complex_int2(self):
         q = Q(Q(intnum="80"), Q(Q(id__lt="5"), Q(id__gt="50"), join_type="OR"), join_type="AND")
-        r = q.resolve(IntFields, IntFields._meta.basequery)
+        r = q.resolve(self.int_fields_context)
         self.assertEqual(r.where_criterion.get_sql(), '"intnum"=80 AND ("id"<5 OR "id">50)')
 
     def test_q_complex_int3(self):
         q = Q(Q(id__lt=5, id__gt=50, join_type="OR"), join_type="AND", intnum=80)
-        r = q.resolve(IntFields, IntFields._meta.basequery)
+        r = q.resolve(self.int_fields_context)
         self.assertEqual(r.where_criterion.get_sql(), '"intnum"=80 AND ("id"<5 OR "id">50)')
 
     def test_q_complex_char(self):
         q = Q(Q(char_null=80), ~Q(char__lt=5, char__gt=50, join_type="OR"), join_type="AND")
-        r = q.resolve(CharFields, CharFields._meta.basequery)
+        r = q.resolve(self.char_fields_context)
         self.assertEqual(
             r.where_criterion.get_sql(),
             "\"char_null\"='80' AND NOT (\"char\"<'5' OR \"char\">'50')",
@@ -179,7 +188,7 @@ class TestQCall(TestCase):
             ~Q(Q(char__lt="5"), Q(char__gt="50"), join_type="OR"),
             join_type="AND",
         )
-        r = q.resolve(CharFields, CharFields._meta.basequery)
+        r = q.resolve(self.char_fields_context)
         self.assertEqual(
             r.where_criterion.get_sql(),
             "\"char_null\"='80' AND NOT (\"char\"<'5' OR \"char\">'50')",
@@ -187,7 +196,7 @@ class TestQCall(TestCase):
 
     def test_q_complex_char3(self):
         q = Q(~Q(char__lt=5, char__gt=50, join_type="OR"), join_type="AND", char_null=80)
-        r = q.resolve(CharFields, CharFields._meta.basequery)
+        r = q.resolve(self.char_fields_context)
         self.assertEqual(
             r.where_criterion.get_sql(),
             "\"char_null\"='80' AND NOT (\"char\"<'5' OR \"char\">'50')",
@@ -195,30 +204,30 @@ class TestQCall(TestCase):
 
     def test_q_with_blank_and(self):
         q = Q(Q(id__gt=5), Q(), join_type=Q.AND)
-        r = q.resolve(CharFields, CharFields._meta.basequery)
+        r = q.resolve(self.char_fields_context)
         self.assertEqual(r.where_criterion.get_sql(), '"id">5')
 
     def test_q_with_blank_or(self):
         q = Q(Q(id__gt=5), Q(), join_type=Q.OR)
-        r = q.resolve(CharFields, CharFields._meta.basequery)
+        r = q.resolve(self.char_fields_context)
         self.assertEqual(r.where_criterion.get_sql(), '"id">5')
 
     def test_q_with_blank_and2(self):
         q = Q(id__gt=5) & Q()
-        r = q.resolve(CharFields, CharFields._meta.basequery)
+        r = q.resolve(self.char_fields_context)
         self.assertEqual(r.where_criterion.get_sql(), '"id">5')
 
     def test_q_with_blank_or2(self):
         q = Q(id__gt=5) | Q()
-        r = q.resolve(CharFields, CharFields._meta.basequery)
+        r = q.resolve(self.char_fields_context)
         self.assertEqual(r.where_criterion.get_sql(), '"id">5')
 
     def test_q_with_blank_and3(self):
         q = Q() & Q(id__gt=5)
-        r = q.resolve(CharFields, CharFields._meta.basequery)
+        r = q.resolve(self.char_fields_context)
         self.assertEqual(r.where_criterion.get_sql(), '"id">5')
 
     def test_q_with_blank_or3(self):
         q = Q() | Q(id__gt=5)
-        r = q.resolve(CharFields, CharFields._meta.basequery)
+        r = q.resolve(self.char_fields_context)
         self.assertEqual(r.where_criterion.get_sql(), '"id">5')

--- a/tortoise/backends/base/executor.py
+++ b/tortoise/backends/base/executor.py
@@ -24,7 +24,7 @@ from pypika.queries import QueryBuilder
 from pypika.terms import ArithmeticExpression, Function
 
 from tortoise.exceptions import OperationalError
-from tortoise.expressions import F, RawSQL
+from tortoise.expressions import F, RawSQL, ResolveContext
 from tortoise.fields.base import Field
 from tortoise.fields.relational import (
     BackwardFKRelation,
@@ -435,11 +435,13 @@ class BaseExecutor:
             joined_tables: List[Table] = []
             modifier = QueryModifier()
             for node in related_query._q_objects:
-                node._annotations = related_query._annotations
-                node._custom_filters = related_query._custom_filters
                 modifier &= node.resolve(
-                    model=related_query.model,
-                    table=related_query_table,
+                    ResolveContext(
+                        model=related_query.model,
+                        table=related_query_table,
+                        annotations=related_query._annotations,
+                        custom_filters=related_query._custom_filters,
+                    )
                 )
 
             where_criterion, joins, having_criterion = modifier.get_query_modifiers()


### PR DESCRIPTION
## Description
This PR:
- Enables use of annotations in Case-When, e.g. 
```python
IntFields.all()\
  .annotate(intnum_plus_1=F("intnum") + 1)\
  .annotate(bigger_than_10=Case(When(Q(intnum_plus_1__gte=10), then=True), default=False))
```
- Introduces `ResolveContext` that holds the information required to resolve expressions
- Fixes https://github.com/tortoise/tortoise-orm/issues/1299

## Motivation and Context

Django lets you use annotations in Case-When, so it would be nice to have it too.

`ResolveContext` simplifies the code by incapsulating all the information required for resolving expressions, i.e. the model, the table, annotations and custom filters as opposed to the old way of assigning `_annotations` and `_custom_filters` to expressions. I'm planning on using it to resolve `F` expressions, for instance, to allow referring to related models in `F` ([related issue](https://github.com/tortoise/tortoise-orm/issues/477)).

## How Has This Been Tested?
- Added tests
- The following snippet can be used to compare the behavior prior and after the changes

```python
import logging
import sys

from tortoise import Tortoise, fields, run_async
from tortoise.models import Model
from tortoise.expressions import F, Q, Case, When

fmt = logging.Formatter(
    fmt="%(asctime)s - %(name)s:%(lineno)d - %(levelname)s - %(message)s",
    datefmt="%Y-%m-%d %H:%M:%S",
)
sh = logging.StreamHandler(sys.stdout)
sh.setLevel(logging.DEBUG)
sh.setFormatter(fmt)

logger_tortoise = logging.getLogger("tortoise")
logger_tortoise.setLevel(logging.DEBUG)
logger_tortoise.addHandler(sh)


class User(Model):
    value = fields.IntField()


async def main():
    # Initializing Tortoise and creating the schema

    await Tortoise.init(  # type: ignore
        db_url="sqlite://:memory:",
        modules={"models": ["__main__"]},
    )
    await Tortoise.generate_schemas()

    await User.create(value=1)
    await User.create(value=2)

    queryset = User.all()
    queryset = queryset.annotate(
        value2=F("value") + 1,
    )
    queryset = queryset.annotate(
        ignore_priority=Case(
            When(Q(value2=2), then=True),
            default=False,
        ),
    )
    res = await queryset
    for user in res:
        print(user.value, user.value2, user.ignore_priority)


run_async(main())
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

