### PR TITLE
Implement `latest`  and `earliest` methods for a queryset

### DIFF
--- a/tests/test_latest_earliest.py
+++ b/tests/test_latest_earliest.py
@@ -1,26 +1,5 @@
-from typing import Type
-
-from tests.testmodels import (
-    Event,
-    IntFields,
-    MinRelation,
-    Node,
-    Reporter,
-    Team,
-    Tournament,
-)
-from tortoise import connections
+from tests.testmodels import Event, Tournament
 from tortoise.contrib import test
-from tortoise.contrib.test.condition import NotEQ
-from tortoise.exceptions import (
-    DoesNotExist,
-    FieldError,
-    IntegrityError,
-    MultipleObjectsReturned,
-    NotExistOrMultiple,
-    ParamsError,
-)
-from tortoise.expressions import F, RawSQL, Subquery
 
 
 class TestLatestEarliest(test.TestCase):

--- a/tests/test_latest_earliest.py
+++ b/tests/test_latest_earliest.py
@@ -1,0 +1,72 @@
+from typing import Type
+
+from tests.testmodels import (
+    Event,
+    IntFields,
+    MinRelation,
+    Node,
+    Reporter,
+    Team,
+    Tournament,
+)
+from tortoise import connections
+from tortoise.contrib import test
+from tortoise.contrib.test.condition import NotEQ
+from tortoise.exceptions import (
+    DoesNotExist,
+    FieldError,
+    IntegrityError,
+    MultipleObjectsReturned,
+    NotExistOrMultiple,
+    ParamsError,
+)
+from tortoise.expressions import F, RawSQL, Subquery
+
+
+class TestLatestEarliest(test.TestCase):
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
+        tournament = Tournament(name="Tournament 1")
+        await tournament.save()
+
+        second_tournament = Tournament(name="Tournament 2")
+        await second_tournament.save()
+
+        event_first = Event(name="1", tournament=tournament)
+        await event_first.save()
+        event_second = Event(name="2", tournament=second_tournament)
+        await event_second.save()
+        event_third = Event(name="3", tournament=tournament)
+        await event_third.save()
+        event_forth = Event(name="4", tournament=second_tournament)
+        await event_forth.save()
+
+    async def test_latest(self):
+        self.assertEqual(await Event.latest("-name"), await Event.get(name="1"))
+        self.assertEqual(await Event.latest("name"), await Event.get(name="4"))
+        self.assertEqual(await Event.latest("-name"), await Event.all().order_by("name").first())
+        self.assertEqual(await Event.latest("name"), await Event.all().order_by("-name").first())
+        self.assertEqual(await Event.latest("tournament__name", "name"), await Event.get(name="4"))
+        self.assertEqual(await Event.latest("-tournament__name", "name"), await Event.get(name="3"))
+        self.assertEqual(await Event.latest("tournament__name", "-name"), await Event.get(name="2"))
+        self.assertEqual(
+            await Event.latest("-tournament__name", "-name"), await Event.get(name="1")
+        )
+
+    async def test_earliest(self):
+        self.assertEqual(await Event.earliest("name"), await Event.get(name="1"))
+        self.assertEqual(await Event.earliest("-name"), await Event.get(name="4"))
+        self.assertEqual(await Event.earliest("name"), await Event.all().order_by("name").first())
+        self.assertEqual(await Event.earliest("-name"), await Event.all().order_by("-name").first())
+        self.assertEqual(
+            await Event.earliest("-tournament__name", "-name"), await Event.get(name="4")
+        )
+        self.assertEqual(
+            await Event.earliest("tournament__name", "-name"), await Event.get(name="3")
+        )
+        self.assertEqual(
+            await Event.earliest("-tournament__name", "name"), await Event.get(name="2")
+        )
+        self.assertEqual(
+            await Event.earliest("tournament__name", "name"), await Event.get(name="1")
+        )

--- a/tests/test_model_methods.py
+++ b/tests/test_model_methods.py
@@ -210,6 +210,14 @@ class TestModelMethods(test.TestCase):
         mdl = await self.cls.first()
         self.assertEqual(self.mdl.id, mdl.id)
 
+    async def test_latest(self):
+        mdl = await self.cls.latest("name")
+        self.assertEqual(self.mdl.id, mdl.id)
+
+    async def test_earliest(self):
+        mdl = await self.cls.earliest("name")
+        self.assertEqual(self.mdl.id, mdl.id)
+
     async def test_filter(self):
         mdl = await self.cls.filter(name="Test").first()
         self.assertEqual(self.mdl.id, mdl.id)

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -273,7 +273,6 @@ class TestQueryset(test.TestCase):
 
     async def test_latest(self):
         self.assertEqual((await IntFields.all().latest("intnum")).intnum, 97)
-        self.assertEqual((await IntFields.all().order_by("intnum").latest()).intnum, 97)
         self.assertEqual(
             (await IntFields.all().order_by("-intnum").first()).intnum,
             (await IntFields.all().latest("intnum")).intnum,
@@ -297,9 +296,14 @@ class TestQueryset(test.TestCase):
             None,
         )
 
+        with self.assertRaises(FieldError):
+            await IntFields.all().latest()
+
+        with self.assertRaises(FieldError):
+            await IntFields.all().latest("some_unkown_field")
+
     async def test_earliest(self):
         self.assertEqual((await IntFields.all().earliest("intnum")).intnum, 10)
-        self.assertEqual((await IntFields.all().order_by("intnum").earliest()).intnum, 10)
         self.assertEqual(
             (await IntFields.all().order_by("intnum").first()).intnum,
             (await IntFields.all().earliest("intnum")).intnum,
@@ -324,6 +328,12 @@ class TestQueryset(test.TestCase):
             await IntFields.all().filter(intnum__gte=400).earliest("intnum").values_list(),
             None,
         )
+
+        with self.assertRaises(FieldError):
+            await IntFields.all().earliest()
+
+        with self.assertRaises(FieldError):
+            await IntFields.all().earliest("some_unkown_field")
 
     async def test_get_or_none(self):
         self.assertEqual((await IntFields.all().get_or_none(intnum=40)).intnum, 40)

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -271,6 +271,60 @@ class TestQueryset(test.TestCase):
             None,
         )
 
+    async def test_latest(self):
+        self.assertEqual((await IntFields.all().latest("intnum")).intnum, 97)
+        self.assertEqual((await IntFields.all().order_by("intnum").latest()).intnum, 97)
+        self.assertEqual(
+            (await IntFields.all().order_by("-intnum").first()).intnum,
+            (await IntFields.all().latest("intnum")).intnum,
+        )
+        self.assertEqual((await IntFields.all().filter(intnum__gte=40).latest("intnum")).intnum, 97)
+        self.assertEqual(
+            (await IntFields.all().filter(intnum__gte=40).latest("intnum").values())["intnum"],
+            97,
+        )
+        self.assertEqual(
+            (await IntFields.all().filter(intnum__gte=40).latest("intnum").values_list())[1],
+            97,
+        )
+
+        self.assertEqual(await IntFields.all().filter(intnum__gte=400).latest("intnum"), None)
+        self.assertEqual(
+            await IntFields.all().filter(intnum__gte=400).latest("intnum").values(), None
+        )
+        self.assertEqual(
+            await IntFields.all().filter(intnum__gte=400).latest("intnum").values_list(),
+            None,
+        )
+
+    async def test_earliest(self):
+        self.assertEqual((await IntFields.all().earliest("intnum")).intnum, 10)
+        self.assertEqual((await IntFields.all().order_by("intnum").earliest()).intnum, 10)
+        self.assertEqual(
+            (await IntFields.all().order_by("intnum").first()).intnum,
+            (await IntFields.all().earliest("intnum")).intnum,
+        )
+        self.assertEqual(
+            (await IntFields.all().filter(intnum__gte=40).earliest("intnum")).intnum, 40
+        )
+        self.assertEqual(
+            (await IntFields.all().filter(intnum__gte=40).earliest("intnum").values())["intnum"],
+            40,
+        )
+        self.assertEqual(
+            (await IntFields.all().filter(intnum__gte=40).earliest("intnum").values_list())[1],
+            40,
+        )
+
+        self.assertEqual(await IntFields.all().filter(intnum__gte=400).earliest("intnum"), None)
+        self.assertEqual(
+            await IntFields.all().filter(intnum__gte=400).earliest("intnum").values(), None
+        )
+        self.assertEqual(
+            await IntFields.all().filter(intnum__gte=400).earliest("intnum").values_list(),
+            None,
+        )
+
     async def test_get_or_none(self):
         self.assertEqual((await IntFields.all().get_or_none(intnum=40)).intnum, 40)
         self.assertEqual((await IntFields.all().get_or_none(intnum=40).values())["intnum"], 40)

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -1258,7 +1258,7 @@ class Model(metaclass=ModelMeta):
         return cls._meta.manager.get_queryset().filter(*args, **kwargs)
 
     @classmethod
-    def latest(cls, *orderings: str) -> QuerySet[Self]:
+    def latest(cls, *orderings: str) -> QuerySetSingle[Optional[Self]]:
         """
         Generates a QuerySet with the filter applied that returns the last record.
 
@@ -1267,7 +1267,7 @@ class Model(metaclass=ModelMeta):
         return cls._meta.manager.get_queryset().latest(*orderings)
 
     @classmethod
-    def earliest(cls, *orderings: str) -> QuerySet[Self]:
+    def earliest(cls, *orderings: str) -> QuerySetSingle[Optional[Self]]:
         """
         Generates a QuerySet with the filter applied that returns the first record.
 

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -1258,6 +1258,24 @@ class Model(metaclass=ModelMeta):
         return cls._meta.manager.get_queryset().filter(*args, **kwargs)
 
     @classmethod
+    def latest(cls, *orderings: str) -> QuerySet[Self]:
+        """
+        Generates a QuerySet with the filter applied that returns the last record.
+
+        :params orderings: Fields to order by.
+        """
+        return cls._meta.manager.get_queryset().latest(*orderings)
+
+    @classmethod
+    def earliest(cls, *orderings: str) -> QuerySet[Self]:
+        """
+        Generates a QuerySet with the filter applied that returns the first record.
+
+        :params orderings: Fields to order by.
+        """
+        return cls._meta.manager.get_queryset().earliest(*orderings)
+
+    @classmethod
     def exclude(cls, *args: Q, **kwargs: Any) -> QuerySet[Self]:
         """
         Generates a QuerySet with the exclude applied.

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -450,6 +450,38 @@ class QuerySet(AwaitableQuery[MODEL]):
         queryset._orderings = new_ordering
         return queryset
 
+    def latest(self, field_name: str = "id") -> "QuerySetSingle[Optional[MODEL]]":
+        """
+        Returns the most recent object by ordering descending on the specified field.
+
+        :params field_name: The field name to order by.
+        """
+        queryset = self._clone()
+        if not (
+            field_name.split("__")[0] in self.model._meta.fields or field_name in self._annotations
+        ):
+            raise FieldError(f"Unknown field {field_name} for model {self.model.__name__}")
+        queryset._orderings = [(field_name, Order.desc)]
+        queryset._limit = 1
+        queryset._single = True
+        return queryset  # type: ignore
+
+    def earliest(self, field_name: str = "id") -> "QuerySetSingle[Optional[MODEL]]":
+        """
+        Returns the earliest object by ordering ascending on the specified field.
+
+        :params field_name: The field name to order by.
+        """
+        queryset = self._clone()
+        if not (
+            field_name.split("__")[0] in self.model._meta.fields or field_name in self._annotations
+        ):
+            raise FieldError(f"Unknown field {field_name} for model {self.model.__name__}")
+        queryset._orderings = [(field_name, Order.asc)]
+        queryset._limit = 1
+        queryset._single = True
+        return queryset  # type: ignore
+
     def limit(self, limit: int) -> "QuerySet[MODEL]":
         """
         Limits QuerySet to given length.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This implements the latest (https://docs.djangoproject.com/en/5.1/ref/models/querysets/#latest) and earliest (https://docs.djangoproject.com/en/5.1/ref/models/querysets/#earliest) methods similar to Django.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Like I explained in the issue #1753  I miss these two methods as someone coming from Django.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Well I implemented tests to validate the usage of both and ran them with `make test`. I also did some local testing.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

The existing tests are not passing in the `develop` branch for me. But the new created tests are passing. I'll post the output of my tests here
```
===================================================================================== short test summary info ======================================================================================
FAILED tests/test_queryset.py::TestQueryset::test_delete - tortoise.exceptions.OperationalError: near "ORDER": syntax error
FAILED tests/test_queryset.py::TestQueryset::test_delete_limit - tortoise.exceptions.OperationalError: near "LIMIT": syntax error
FAILED tests/test_queryset.py::TestQueryset::test_delete_limit_order_by - tortoise.exceptions.OperationalError: near "ORDER": syntax error
FAILED tests/test_update.py::TestUpdate::test_update_with_limit_ordering - tortoise.exceptions.OperationalError: near "ORDER": syntax error
ERROR tests/test_default.py
ERROR tests/test_two_databases.py
4 failed, 1134 passed, 67 skipped, 4 xfailed, 2 errors in 36.45s
```