### PR TITLE
Implement `last` for querysets and models

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -60,6 +60,7 @@ Contributors
 * Abdeldjalil Hezouat ``@Abdeldjalil-H``
 * Andrea Magistà ``@vlakius``
 * Daniel Szucs ``@Quasar6X``
+* Rui Catarino ``@ruitcatarino``
 
 Special Thanks
 ==============

--- a/tests/test_model_methods.py
+++ b/tests/test_model_methods.py
@@ -210,6 +210,10 @@ class TestModelMethods(test.TestCase):
         mdl = await self.cls.first()
         self.assertEqual(self.mdl.id, mdl.id)
 
+    async def test_last(self):
+        mdl = await self.cls.last()
+        self.assertEqual(self.mdl.id, mdl.id)
+
     async def test_latest(self):
         mdl = await self.cls.latest("name")
         self.assertEqual(self.mdl.id, mdl.id)

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -272,6 +272,35 @@ class TestQueryset(test.TestCase):
             None,
         )
 
+    async def test_last(self):
+        self.assertEqual(
+            (await IntFields.all().order_by("intnum").filter(intnum__gte=40).last()).intnum, 97
+        )
+        self.assertEqual(
+            (await IntFields.all().order_by("intnum").filter(intnum__gte=40).last().values())[
+                "intnum"
+            ],
+            97,
+        )
+        self.assertEqual(
+            (await IntFields.all().order_by("intnum").filter(intnum__gte=40).last().values_list())[
+                1
+            ],
+            97,
+        )
+
+        self.assertEqual(
+            await IntFields.all().order_by("intnum").filter(intnum__gte=400).last(), None
+        )
+        self.assertEqual(
+            await IntFields.all().order_by("intnum").filter(intnum__gte=400).last().values(), None
+        )
+        self.assertEqual(
+            await IntFields.all().order_by("intnum").filter(intnum__gte=400).last().values_list(),
+            None,
+        )
+        self.assertEqual((await IntFields.all().filter(intnum__gte=40).last()).intnum, 97)
+
     async def test_latest(self):
         self.assertEqual((await IntFields.all().latest("intnum")).intnum, 97)
         self.assertEqual(

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -1248,6 +1248,13 @@ class Model(metaclass=ModelMeta):
         return cls._db_queryset(using_db).first()
 
     @classmethod
+    def last(cls, using_db: Optional[BaseDBAsyncClient] = None) -> QuerySetSingle[Optional[Self]]:
+        """
+        Generates a QuerySet that returns the last record.
+        """
+        return cls._db_queryset(using_db).last()
+
+    @classmethod
     def filter(cls, *args: Q, **kwargs: Any) -> QuerySet[Self]:
         """
         Generates a QuerySet with the filter applied.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This implements the `last` (https://docs.djangoproject.com/en/5.1/ref/models/querysets/#last methods similar to Django.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Like I explained in the issue https://github.com/tortoise/tortoise-orm/issues/1753 I miss this method as someone coming from Django.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Well I implemented tests to validate the usage of this method and ran them with `make test`. I also did some local testing.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

The existing tests are not passing in the develop branch for me. But the new created tests are passing. I'll post the output of my tests here
```
==================================================================================================== short test summary info ====================================================================================================
FAILED tests/test_queryset.py::TestQueryset::test_delete_limit - tortoise.exceptions.OperationalError: near "LIMIT": syntax error
FAILED tests/test_queryset.py::TestQueryset::test_delete_limit_order_by - tortoise.exceptions.OperationalError: near "ORDER": syntax error
FAILED tests/test_queryset.py::TestQueryset::test_delete - tortoise.exceptions.OperationalError: near "ORDER": syntax error
FAILED tests/test_update.py::TestUpdate::test_update_with_limit_ordering - tortoise.exceptions.OperationalError: near "ORDER": syntax error
ERROR tests/test_default.py
ERROR tests/test_two_databases.py
4 failed, 1156 passed, 67 skipped, 4 xfailed, 20 warnings, 2 errors in 69.54s (0:01:09)
```