### PR TITLE
Introducing Tortoise ORM Guru on Gurubase.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,8 @@ Tortoise ORM
    :target: https://coveralls.io/github/tortoise/tortoise-orm
 .. image:: https://app.codacy.com/project/badge/Grade/844030d0cb8240d6af92c71bfac764ff
    :target: https://www.codacy.com/gh/tortoise/tortoise-orm/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=tortoise/tortoise-orm&amp;utm_campaign=Badge_Grade
+.. image:: https://img.shields.io/badge/Gurubase-Ask%20Tortoise%20ORM%20Guru-006BFF
+   :target: https://gurubase.io/g/tortoise-orm
 
 Introduction
 ============


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Tortoise ORM Guru](https://gurubase.io/g/tortoise-orm) to Gurubase. Tortoise ORM Guru uses the data from this repo and data from the [docs](https://tortoise.github.io) to answer questions by leveraging the LLM.

In this PR, I showcased the "Tortoise ORM Guru", which highlights that Tortoise ORM now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Tortoise ORM Guru in Gurubase, just let me know that's totally fine.
