### PR TITLE
Support annotations and joins in F()

### DIFF
--- a/docs/functions.rst
+++ b/docs/functions.rst
@@ -84,11 +84,15 @@ And you can also use functions in update, the example is only suitable for MySQL
 .. code-block:: python3
 
     from tortoise.expressions import F
-    from pypika.terms import Function
+    from tortoise.functions import Function
+    from pypika.terms import Function as PupikaFunction
 
     class JsonSet(Function):
-        def __init__(self, field: F, expression: str, value: Any):
-            super().__init__("JSON_SET", field, expression, value)
+        class PypikaJsonSet(PupikaFunction):
+            def __init__(self, field: F, expression: str, value: Any):
+                super().__init__("JSON_SET", field, expression, value)
+
+        database_func = PypikaJsonSet
 
     json = await JSONFields.create(data_default={"a": 1})
     json.data_default = JsonSet(F("data_default"), "$.a", 2)

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -247,6 +247,17 @@ class TestAggregation(test.TestCase):
         res = await query.count()
         assert res == 2
 
+    async def test_where_and_having(self):
+        author = await Author.create(name="1")
+        await Book.create(name="First!", author=author, rating=4)
+        await Book.create(name="Second!", author=author, rating=3)
+        await Book.create(name="Third!", author=author, rating=3)
+
+        query = Book.exclude(name="First!").annotate(avg_rating=Avg("rating")).values("avg_rating")
+        result = await query
+        assert len(result) == 1
+        assert result[0]["avg_rating"] == 3
+
     async def test_count_without_matching(self) -> None:
         await Tournament.create(name="Test")
 

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -298,13 +298,10 @@ class TestAggregation(test.TestCase):
         self.assertEqual(result, [{"sum": Decimal("-2.0")}])
 
     async def test_function_requiring_nested_joins(self):
-        tournament = Tournament(name="Tournament")
-        await tournament.save()
+        tournament = await Tournament.create(name="Tournament")
 
-        event_first = Event(name="1", tournament=tournament)
-        await event_first.save()
-        event_second = Event(name="2", tournament=tournament)
-        await event_second.save()
+        event_first = await Event.create(name="1", tournament=tournament)
+        event_second = await Event.create(name="2", tournament=tournament)
 
         team_first = await Team.create(name="First", alias=2)
         team_second = await Team.create(name="Second", alias=10)

--- a/tests/test_f.py
+++ b/tests/test_f.py
@@ -1,0 +1,60 @@
+from tortoise.contrib import test
+from tortoise.expressions import Connector, F
+
+
+class TestF(test.TestCase):
+    def test_arithmetic(self):
+        f = F("name")
+
+        negated = -f
+        self.assertEqual(negated.connector, Connector.mul)
+        self.assertEqual(negated.right.value, -1)
+
+        added = f + 1
+        self.assertEqual(added.connector, Connector.add)
+        self.assertEqual(added.right.value, 1)
+
+        radded = 1 + f
+        self.assertEqual(radded.connector, Connector.add)
+        self.assertEqual(radded.left.value, 1)
+        self.assertEqual(radded.right, f)
+
+        subbed = f - 1
+        self.assertEqual(subbed.connector, Connector.sub)
+        self.assertEqual(subbed.right.value, 1)
+
+        rsubbed = 1 - f
+        self.assertEqual(rsubbed.connector, Connector.sub)
+        self.assertEqual(rsubbed.left.value, 1)
+
+        mulled = f * 2
+        self.assertEqual(mulled.connector, Connector.mul)
+        self.assertEqual(mulled.right.value, 2)
+
+        rmulled = 2 * f
+        self.assertEqual(rmulled.connector, Connector.mul)
+        self.assertEqual(rmulled.left.value, 2)
+
+        divved = f / 2
+        self.assertEqual(divved.connector, Connector.div)
+        self.assertEqual(divved.right.value, 2)
+
+        rdivved = 2 / f
+        self.assertEqual(rdivved.connector, Connector.div)
+        self.assertEqual(rdivved.left.value, 2)
+
+        powed = f**2
+        self.assertEqual(powed.connector, Connector.pow)
+        self.assertEqual(powed.right.value, 2)
+
+        rpowed = 2**f
+        self.assertEqual(rpowed.connector, Connector.pow)
+        self.assertEqual(rpowed.left.value, 2)
+
+        modded = f % 2
+        self.assertEqual(modded.connector, Connector.mod)
+        self.assertEqual(modded.right.value, 2)
+
+        rmodded = 2 % f
+        self.assertEqual(rmodded.connector, Connector.mod)
+        self.assertEqual(rmodded.left.value, 2)

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -434,3 +434,18 @@ class TestFiltering(test.TestCase):
         self.assertEqual(tournaments[0].name, "Tournament")
         self.assertEqual(tournaments[0].name_lower, "tournament")
         self.assertEqual(tournaments[0].is_tournament, "yes")
+
+    async def test_f_annotation_filter(self):
+        await IntFields.create(intnum=1)
+
+        events = await IntFields.annotate(intnum_plus_1=F("intnum") + 1).filter(intnum_plus_1=2)
+        self.assertEqual(len(events), 1)
+
+    async def test_f_annotation_custom_filter(self):
+        await IntFields.create(intnum=1)
+
+        events = await IntFields.annotate(intnum_plus_1=F("intnum") + 1).filter(intnum_plus_1__gt=1)
+        self.assertEqual(len(events), 1)
+
+        events = await IntFields.annotate(intnum_plus_1=F("intnum") + 1).filter(intnum_plus_1__lt=3)
+        self.assertEqual(len(events), 1)

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -436,24 +436,27 @@ class TestFiltering(test.TestCase):
         self.assertEqual(tournaments[0].is_tournament, "yes")
 
     async def test_f_annotation_filter(self):
-        await IntFields.create(intnum=1)
+        event = await IntFields.create(intnum=1)
 
-        events = await IntFields.annotate(intnum_plus_1=F("intnum") + 1).filter(intnum_plus_1=2)
-        self.assertEqual(len(events), 1)
+        ret_events = await IntFields.annotate(intnum_plus_1=F("intnum") + 1).filter(intnum_plus_1=2)
+        self.assertEqual(ret_events, [event])
 
     async def test_f_annotation_custom_filter(self):
-        await IntFields.create(intnum=1)
+        event = await IntFields.create(intnum=1)
 
         base_query = IntFields.annotate(intnum_plus_1=F("intnum") + 1)
 
-        events = await base_query.filter(intnum_plus_1__gt=1)
-        self.assertEqual(len(events), 1)
+        ret_events = await base_query.filter(intnum_plus_1__gt=1)
+        self.assertEqual(ret_events, [event])
 
-        events = await base_query.filter(intnum_plus_1__lt=3)
-        self.assertEqual(len(events), 1)
+        ret_events = await base_query.filter(intnum_plus_1__lt=3)
+        self.assertEqual(ret_events, [event])
 
-        events = await base_query.filter(Q(intnum_plus_1__gt=1) & Q(intnum_plus_1__lt=3))
-        self.assertEqual(len(events), 1)
+        ret_events = await base_query.filter(Q(intnum_plus_1__gt=1) & Q(intnum_plus_1__lt=3))
+        self.assertEqual(ret_events, [event])
+
+        ret_events = await base_query.filter(intnum_plus_1__isnull=True)
+        self.assertEqual(ret_events, [])
 
     async def test_f_annotation_join(self):
         tournament_a = await Tournament.create(name="A")
@@ -484,25 +487,17 @@ class TestFiltering(test.TestCase):
         self.assertEqual(events, [event_b])
 
     async def test_f_annotation_custom_filter_requiring_nested_joins(self):
-        tournament = Tournament(name="Tournament")
-        await tournament.save()
+        tournament = await Tournament.create(name="Tournament")
 
-        second_tournament = Tournament(name="Tournament 2")
-        await second_tournament.save()
+        second_tournament = await Tournament.create(name="Tournament 2")
 
-        event_first = Event(name="1", tournament=tournament)
-        await event_first.save()
-        event_second = Event(name="2", tournament=second_tournament)
-        await event_second.save()
-        event_third = Event(name="3", tournament=tournament)
-        await event_third.save()
-        event_forth = Event(name="4", tournament=second_tournament)
-        await event_forth.save()
+        event_first = await Event.create(name="1", tournament=tournament)
+        event_second = await Event.create(name="2", tournament=second_tournament)
+        await Event.create(name="3", tournament=tournament)
+        await Event.create(name="4", tournament=second_tournament)
 
-        team_first = Team(name="First")
-        await team_first.save()
-        team_second = Team(name="Second")
-        await team_second.save()
+        team_first = await Team.create(name="First")
+        team_second = await Team.create(name="Second")
 
         await team_first.events.add(event_first)
         await event_second.participants.add(team_second)

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -444,8 +444,13 @@ class TestFiltering(test.TestCase):
     async def test_f_annotation_custom_filter(self):
         await IntFields.create(intnum=1)
 
-        events = await IntFields.annotate(intnum_plus_1=F("intnum") + 1).filter(intnum_plus_1__gt=1)
+        base_query = IntFields.annotate(intnum_plus_1=F("intnum") + 1)
+
+        events = await base_query.filter(intnum_plus_1__gt=1)
         self.assertEqual(len(events), 1)
 
-        events = await IntFields.annotate(intnum_plus_1=F("intnum") + 1).filter(intnum_plus_1__lt=3)
+        events = await base_query.filter(intnum_plus_1__lt=3)
+        self.assertEqual(len(events), 1)
+
+        events = await base_query.filter(Q(intnum_plus_1__gt=1) & Q(intnum_plus_1__lt=3))
         self.assertEqual(len(events), 1)

--- a/tests/test_group_by.py
+++ b/tests/test_group_by.py
@@ -234,15 +234,15 @@ class TestGroupBy(test.TestCase):
         )
 
     async def test_group_by_requiring_nested_joins(self):
-        tournament_first = await Tournament.create(name="Tournament 1")
-        tournament_second = await Tournament.create(name="Tournament 2")
+        tournament_first = await Tournament.create(name="Tournament 1", desc="d1")
+        tournament_second = await Tournament.create(name="Tournament 2", desc="d2")
 
         event_first = await Event.create(name="1", tournament=tournament_first)
         event_second = await Event.create(name="2", tournament=tournament_first)
         event_third = await Event.create(name="3", tournament=tournament_second)
 
         team_first = await Team.create(name="First", alias=2)
-        team_second = await Team.create(name="Second", alias=3)
+        team_second = await Team.create(name="Second", alias=4)
         team_third = await Team.create(name="Third", alias=5)
 
         await team_first.events.add(event_first)
@@ -251,10 +251,8 @@ class TestGroupBy(test.TestCase):
 
         res = (
             await Tournament.annotate(avg=Avg("events__participants__alias"))
-            .group_by("id")
-            .order_by("name")
-            .values("name", "avg")
+            .group_by("desc")
+            .order_by("desc")
+            .values("desc", "avg")
         )
-        self.assertEqual(
-            res, [{"avg": 2, "name": "Tournament 1"}, {"avg": 5, "name": "Tournament 2"}]
-        )
+        self.assertEqual(res, [{"avg": 3, "desc": "d1"}, {"avg": 5, "desc": "d2"}])

--- a/tests/test_group_by.py
+++ b/tests/test_group_by.py
@@ -1,4 +1,4 @@
-from tests.testmodels import Author, Book
+from tests.testmodels import Author, Book, Event, Team, Tournament
 from tortoise.contrib import test
 from tortoise.functions import Avg, Count, Sum, Upper
 
@@ -231,4 +231,30 @@ class TestGroupBy(test.TestCase):
             ret,
             [{"upper_name": "AUTHOR1", "count": 10}, {"upper_name": "AUTHOR2", "count": 5}],
             sorted_key="upper_name",
+        )
+
+    async def test_group_by_requiring_nested_joins(self):
+        tournament_first = await Tournament.create(name="Tournament 1")
+        tournament_second = await Tournament.create(name="Tournament 2")
+
+        event_first = await Event.create(name="1", tournament=tournament_first)
+        event_second = await Event.create(name="2", tournament=tournament_first)
+        event_third = await Event.create(name="3", tournament=tournament_second)
+
+        team_first = await Team.create(name="First", alias=2)
+        team_second = await Team.create(name="Second", alias=3)
+        team_third = await Team.create(name="Third", alias=5)
+
+        await team_first.events.add(event_first)
+        await team_second.events.add(event_second)
+        await team_third.events.add(event_third)
+
+        res = (
+            await Tournament.annotate(avg=Avg("events__participants__alias"))
+            .group_by("id")
+            .order_by("name")
+            .values("name", "avg")
+        )
+        self.assertEqual(
+            res, [{"avg": 2, "name": "Tournament 1"}, {"avg": 5, "name": "Tournament 2"}]
         )

--- a/tests/test_q.py
+++ b/tests/test_q.py
@@ -239,7 +239,7 @@ class TestQCall(TestCase):
             ResolveContext(
                 model=IntFields,
                 table=IntFields._meta.basequery,
-                annotations={"annotated": F("annotated")},
+                annotations={"annotated": F("intnum")},
                 custom_filters={
                     "annotated__lt": {
                         "field": "annotated",
@@ -249,4 +249,4 @@ class TestQCall(TestCase):
                 },
             )
         )
-        self.assertEqual(r.where_criterion.get_sql(), '"id">5 OR "annotated"<5')
+        self.assertEqual(r.where_criterion.get_sql(), '"id">5 OR "intnum"<5')

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -870,7 +870,14 @@ class TestQueryReuse(test.TestCase):
         events = await IntFields.annotate(intnum_plus_1=F("intnum") + 1).annotate(
             intnum_plus_2=F("intnum_plus_1") + 1
         )
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].intnum_plus_1, 2)
+        self.assertEqual(events[0].intnum_plus_2, 3)
 
+        # in a single annotate call
+        events = await IntFields.annotate(
+            intnum_plus_1=F("intnum") + 1, intnum_plus_2=F("intnum_plus_1") + 1
+        )
         self.assertEqual(len(events), 1)
         self.assertEqual(events[0].intnum_plus_1, 2)
         self.assertEqual(events[0].intnum_plus_2, 3)

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -863,3 +863,23 @@ class TestQueryReuse(test.TestCase):
 
         tournaments = await base_query.values_list("name_length")
         self.assertListSortEqual(tournaments, [(10,), (12,)])
+
+    async def test_f_annotation_referenced_in_annotation(self):
+        await IntFields.create(intnum=1)
+
+        events = await IntFields.annotate(intnum_plus_1=F("intnum") + 1).annotate(
+            intnum_plus_2=F("intnum_plus_1") + 1
+        )
+
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].intnum_plus_1, 2)
+        self.assertEqual(events[0].intnum_plus_2, 3)
+
+    async def test_rawsql_annotation_referenced_in_annotation(self):
+        await IntFields.create(intnum=1)
+
+        events = await IntFields.annotate(ten=RawSQL("20 / 2")).annotate(ten_plus_1=F("ten") + 1)
+
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].ten, 10)
+        self.assertEqual(events[0].ten_plus_1, 11)

--- a/tests/test_source_field.py
+++ b/tests/test_source_field.py
@@ -257,6 +257,28 @@ class StraightFieldTests(test.TestCase):
         obj = await self.model.filter(chars="bbb").values("fk__chars")
         self.assertEqual(obj, [{"fk__chars": "aaa"}])
 
+    async def test_filter_with_field_f(self):
+        obj = await self.model.create(chars="a")
+        ret_obj = await self.model.filter(eyedee=F("eyedee")).first()
+        self.assertEqual(obj, ret_obj)
+
+        ret_obj = await self.model.filter(eyedee__lt=F("eyedee") + 1).first()
+        self.assertEqual(obj, ret_obj)
+
+    async def test_filter_with_field_f_annotation(self):
+        obj = await self.model.create(chars="a")
+        ret_obj = (
+            await self.model.annotate(eyedee_a=F("eyedee")).filter(eyedee=F("eyedee_a")).first()
+        )
+        self.assertEqual(obj, ret_obj)
+
+        ret_obj = (
+            await self.model.annotate(eyedee_a=F("eyedee") + 1)
+            .filter(eyedee__lt=F("eyedee_a"))
+            .first()
+        )
+        self.assertEqual(obj, ret_obj)
+
 
 class SourceFieldTests(StraightFieldTests):
     def setUp(self) -> None:

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from typing import Any
 
 import pytz
-from pypika.terms import Function
+from pypika.terms import Function as PupikaFunction
 
 from tests.testmodels import (
     Currency,
@@ -22,6 +22,7 @@ from tests.testmodels import (
 from tortoise.contrib import test
 from tortoise.contrib.test.condition import In, NotEQ
 from tortoise.expressions import F
+from tortoise.functions import Function
 
 
 class TestUpdate(test.TestCase):
@@ -155,8 +156,11 @@ class TestUpdate(test.TestCase):
     @test.requireCapability(dialect=In("mysql", "sqlite"))
     async def test_update_with_custom_function(self):
         class JsonSet(Function):
-            def __init__(self, field: F, expression: str, value: Any):
-                super().__init__("JSON_SET", field, expression, value)
+            class PypikaJsonSet(PupikaFunction):
+                def __init__(self, field: F, expression: str, value: Any):
+                    super().__init__("JSON_SET", field, expression, value)
+
+            database_func = PypikaJsonSet
 
         json = await JSONFields.create(data={})
         self.assertEqual(json.data_default, {"a": 1})

--- a/tortoise/backends/base/executor.py
+++ b/tortoise/backends/base/executor.py
@@ -444,17 +444,16 @@ class BaseExecutor:
                     )
                 )
 
-            where_criterion, joins, having_criterion = modifier.get_query_modifiers()
-            for join in joins:
+            for join in modifier.joins:
                 if join[0] not in joined_tables:
                     query = query.join(join[0], how=JoinType.left_outer).on(join[1])
                     joined_tables.append(join[0])
 
-            if where_criterion:
-                query = query.where(where_criterion)
+            if modifier.where_criterion:
+                query = query.where(modifier.where_criterion)
 
-            if having_criterion:
-                query = query.having(having_criterion)
+            if modifier.having_criterion:
+                query = query.having(modifier.having_criterion)
 
         _, raw_results = await self.db.execute_query(query.get_sql())
         relations: List[Tuple[Any, Any]] = []

--- a/tortoise/expressions.py
+++ b/tortoise/expressions.py
@@ -176,7 +176,6 @@ class F(Expression):
         arithmetic_expression_or_field: Term,
     ) -> Tuple[Term, Optional[PypikaField]]:
         field_object = None
-
         if isinstance(arithmetic_expression_or_field, PypikaField):
             name = arithmetic_expression_or_field.name
             try:

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -36,6 +36,7 @@ from tortoise.exceptions import (
     OperationalError,
     ParamsError,
 )
+from tortoise.expressions import Expression
 from tortoise.fields.base import Field
 from tortoise.fields.data import IntField
 from tortoise.fields.relational import (
@@ -49,7 +50,6 @@ from tortoise.fields.relational import (
     ReverseRelation,
 )
 from tortoise.filters import FilterInfoDict, get_filters_for_field
-from tortoise.functions import Function
 from tortoise.indexes import Index
 from tortoise.manager import Manager
 from tortoise.queryset import (
@@ -1293,7 +1293,7 @@ class Model(metaclass=ModelMeta):
         return cls._meta.manager.get_queryset().exclude(*args, **kwargs)
 
     @classmethod
-    def annotate(cls, **kwargs: Union[Function, Term]) -> QuerySet[Self]:
+    def annotate(cls, **kwargs: Union[Expression, Term]) -> QuerySet[Self]:
         """
         Annotates the result set with extra Functions/Aggregations/Expressions.
 

--- a/tortoise/query_utils.py
+++ b/tortoise/query_utils.py
@@ -79,11 +79,12 @@ def get_joins_for_related_field(
 
 
 def resolve_nested_field(
-    model: Type["Model"], table: Table, field: str, populate_field_object: bool = False
+    model: Type["Model"], table: Table, field: str
 ) -> Tuple[Term, List[TableCriterionTuple], Optional[Field]]:
     """
-    Resolves a nested field string like events__participants__name into a ResolveResult
-    that contains the term and joins required to get the field.
+    Resolves a nested field string like events__participants__name and
+    returns the pypika term, required joins and the Field that can be used for
+    converting the value.
     """
     term = field_object = None
     joins = []
@@ -123,14 +124,12 @@ def resolve_nested_field(
         else:
             term = table[last_field]
 
-        if populate_field_object:
-            field_object = model._meta.fields_map.get(last_field, None)
-            if field_object:  # pragma: nobranch
-                func = field_object.get_for_dialect(
-                    model._meta.db.capabilities.dialect, "function_cast"
-                )
-                if func:
-                    term = func(field_object, term)
+        if field_object:  # pragma: nobranch
+            func = field_object.get_for_dialect(
+                model._meta.db.capabilities.dialect, "function_cast"
+            )
+            if func:
+                term = func(field_object, term)
 
     return term, joins, field_object
 

--- a/tortoise/query_utils.py
+++ b/tortoise/query_utils.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:  # pragma: nocoverage
 TableCriterionTuple = Tuple[Table, Criterion]
 
 
-def _get_joins_for_related_field(
+def get_joins_for_related_field(
     table: Table, related_field: RelationalField, related_field_name: str
 ) -> List[TableCriterionTuple]:
     required_joins = []
@@ -142,12 +142,6 @@ class QueryModifier:
         elif self.where_criterion:
             where_criterion = self.where_criterion.negate()
         return self.__class__(where_criterion, self.joins, having_criterion)
-
-    def get_query_modifiers(self) -> Tuple[Criterion, List[TableCriterionTuple], Criterion]:
-        """
-        Returns a tuple of the query criterion.
-        """
-        return self.where_criterion, self.joins, self.having_criterion
 
 
 class Prefetch:

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -42,7 +42,6 @@ from tortoise.fields.relational import (
     RelationalField,
 )
 from tortoise.filters import FilterInfoDict
-from tortoise.functions import Function
 from tortoise.query_utils import (
     Prefetch,
     QueryModifier,
@@ -78,7 +77,9 @@ class QuerySetSingle(Protocol[T_co]):
 
     def select_related(self, *args: str) -> "QuerySetSingle[T_co]": ...  # pragma: nocoverage
 
-    def annotate(self, **kwargs: Function) -> "QuerySetSingle[T_co]": ...  # pragma: nocoverage
+    def annotate(
+        self, **kwargs: Union[Expression, Term]
+    ) -> "QuerySetSingle[T_co]": ...  # pragma: nocoverage
 
     def only(self, *fields_for_select: str) -> "QuerySetSingle[T_co]": ...  # pragma: nocoverage
 
@@ -1241,7 +1242,6 @@ class UpdateQuery(AwaitableQuery):
                     value = executor.column_map[key](value, None)
             if isinstance(value, Term):
                 self.query = self.query.set(db_field, value)
-            # TODO: resolve expressions
             else:
                 self.query = self.query.set(db_field, executor.parameter(count))
                 self.values.append(value)

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -1229,7 +1229,7 @@ class UpdateQuery(AwaitableQuery):
                     raise FieldError(f"Field {key} is virtual and can not be updated")
                 if isinstance(value, Term):
                     value = F.resolver_arithmetic_expression(self.model, value)[0]
-                elif isinstance(value, Function):
+                elif isinstance(value, Expression):
                     value = value.resolve(
                         ResolveContext(
                             model=self.model,

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -1242,6 +1242,7 @@ class UpdateQuery(AwaitableQuery):
                     value = executor.column_map[key](value, None)
             if isinstance(value, Term):
                 self.query = self.query.set(db_field, value)
+            # TODO: resolve expressions
             else:
                 self.query = self.query.set(db_field, executor.parameter(count))
                 self.values.append(value)

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -35,7 +35,7 @@ from tortoise.exceptions import (
     MultipleObjectsReturned,
     ParamsError,
 )
-from tortoise.expressions import Expression, F, Q, RawSQL, ResolveContext
+from tortoise.expressions import Expression, F, Q, RawSQL, ResolveContext, ResolveResult
 from tortoise.fields.relational import (
     ForeignKeyFieldInstance,
     OneToOneFieldInstance,
@@ -43,7 +43,12 @@ from tortoise.fields.relational import (
 )
 from tortoise.filters import FilterInfoDict
 from tortoise.functions import Function
-from tortoise.query_utils import Prefetch, QueryModifier, _get_joins_for_related_field
+from tortoise.query_utils import (
+    Prefetch,
+    QueryModifier,
+    get_joins_for_related_field,
+    TableCriterionTuple,
+)
 from tortoise.router import router
 from tortoise.utils import chunk
 
@@ -131,7 +136,7 @@ class AwaitableQuery(Generic[MODEL]):
         :param annotations: Extra annotations to add.
         :param custom_filters: Pre-resolved filters to be passed through.
         """
-        has_aggregate = self._resolve_annotate(self._annotations, self._custom_filters)
+        has_aggregate = self._resolve_annotate()
 
         modifier = QueryModifier()
         for node in self._q_objects:
@@ -144,16 +149,15 @@ class AwaitableQuery(Generic[MODEL]):
                 )
             )
 
-        where_criterion, joins, having_criterion = modifier.get_query_modifiers()
-        for join in joins:
+        for join in modifier.joins:
             if join[0] not in self._joined_tables:
                 self.query = self.query.join(join[0], how=JoinType.left_outer).on(join[1])
                 self._joined_tables.append(join[0])
 
-        self.query._wheres = where_criterion
-        self.query._havings = having_criterion
+        self.query._havings = modifier.having_criterion
+        self.query._wheres = modifier.where_criterion
 
-        if has_aggregate and (self._joined_tables or having_criterion or self.query._orderbys):
+        if has_aggregate and (self._joined_tables or self.query._havings or self.query._orderbys):
             self.query = self.query.groupby(
                 *[self.model._meta.basetable[field] for field in self.model._meta.db_fields]
             )
@@ -161,12 +165,17 @@ class AwaitableQuery(Generic[MODEL]):
     def _join_table_by_field(
         self, table: Table, related_field_name: str, related_field: RelationalField
     ) -> Table:
-        joins = _get_joins_for_related_field(table, related_field, related_field_name)
+        joins = get_joins_for_related_field(table, related_field, related_field_name)
         for join in joins:
-            if join[0] not in self._joined_tables:
-                self.query = self.query.join(join[0], how=JoinType.left_outer).on(join[1])
-                self._joined_tables.append(join[0])
+            self._join_table(join)
         return joins[-1][0]
+
+    def _join_table(self, table_criterio_tuple: TableCriterionTuple):
+        if table_criterio_tuple[0] not in self._joined_tables:
+            self.query = self.query.join(table_criterio_tuple[0], how=JoinType.left_outer).on(
+                table_criterio_tuple[1]
+            )
+            self._joined_tables.append(table_criterio_tuple[0])
 
     @staticmethod
     def _resolve_ordering_string(ordering: str, reverse: bool = False) -> Tuple[str, Order]:
@@ -234,7 +243,7 @@ class AwaitableQuery(Generic[MODEL]):
                             custom_filters={},
                         )
                     )
-                    self.query = self.query.orderby(annotation_info["field"], order=ordering[1])
+                    self.query = self.query.orderby(annotation_info.term, order=ordering[1])
             else:
                 field_object = model._meta.fields_map.get(field_name)
 
@@ -251,35 +260,31 @@ class AwaitableQuery(Generic[MODEL]):
 
                 self.query = self.query.orderby(field, order=ordering[1])
 
-    def _resolve_annotate(
-        self, extra_annotations: Dict[str, Any], extra_custom_filters: Dict[str, FilterInfoDict]
-    ) -> bool:
-        if not self._annotations and not extra_annotations:
+    def _resolve_annotate(self) -> bool:
+        if not self._annotations:
             return False
 
-        all_annotations = {**self._annotations, **extra_annotations}
-        all_custom_filters = {**self._custom_filters, **extra_custom_filters}
-        annotation_info = {}
-        for key, annotation in all_annotations.items():
+        annotation_info: Dict[str, ResolveResult] = {}
+        for key, annotation in self._annotations.items():
             if isinstance(annotation, Term):
-                annotation_info[key] = {"joins": [], "field": annotation}
+                annotation_info[key] = ResolveResult(term=annotation)
             else:
                 annotation_info[key] = annotation.resolve(
                     ResolveContext(
                         model=self.model,
                         table=self.model._meta.basetable,
-                        annotations=all_annotations,
-                        custom_filters=all_custom_filters,
+                        annotations=self._annotations,
+                        custom_filters=self._custom_filters,
                     )
                 )
 
         for key, info in annotation_info.items():
-            for join in info["joins"]:
-                self._join_table_by_field(*join)
+            for join in info.joins:
+                self._join_table(join)
             if key in self._annotations:
-                self.query._select_other(info["field"].as_(key))
+                self.query._select_other(info.term.as_(key))
 
-        return any(info["field"].is_aggregate for info in annotation_info.values())
+        return any(info.term.is_aggregate for info in annotation_info.values())
 
     def sql(self, **kwargs) -> str:
         """Return the actual SQL."""
@@ -1232,7 +1237,7 @@ class UpdateQuery(AwaitableQuery):
                             annotations=self._annotations,
                             custom_filters=self._custom_filters,
                         )
-                    )["field"]
+                    ).term
                 else:
                     value = executor.column_map[key](value, None)
             if isinstance(value, Term):

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -35,7 +35,7 @@ from tortoise.exceptions import (
     MultipleObjectsReturned,
     ParamsError,
 )
-from tortoise.expressions import Expression, F, Q, RawSQL, ResolveContext, ResolveResult
+from tortoise.expressions import Expression, Q, RawSQL, ResolveContext, ResolveResult
 from tortoise.fields.relational import (
     ForeignKeyFieldInstance,
     OneToOneFieldInstance,
@@ -46,8 +46,8 @@ from tortoise.functions import Function
 from tortoise.query_utils import (
     Prefetch,
     QueryModifier,
-    get_joins_for_related_field,
     TableCriterionTuple,
+    get_joins_for_related_field,
 )
 from tortoise.router import router
 from tortoise.utils import chunk
@@ -1227,9 +1227,8 @@ class UpdateQuery(AwaitableQuery):
                     db_field = self.model._meta.fields_db_projection[key]
                 except KeyError:
                     raise FieldError(f"Field {key} is virtual and can not be updated")
-                if isinstance(value, Term):
-                    value = F.resolver_arithmetic_expression(self.model, value)[0]
-                elif isinstance(value, Expression):
+
+                if isinstance(value, Expression):
                     value = value.resolve(
                         ResolveContext(
                             model=self.model,


### PR DESCRIPTION
## Description

This PR:
- Adds support for referencing relationship fields in `F()`, e.g. `F("author__name")` that automatically introduces joins to the query
- Allows referencing annotations in `F()`, e.g. `IntFields.annotate(intnum_plus_1=F("intnum") + 1).annotate(intnum_plus_2=F("intnum_plus_1") + 1)`

In order to achieve that, the following implementation details changed
- The behavior of `Expression.resolve` was unified to always return a `ResolveResult`. Previously it could have been either a tuple or dictionary.
- `F` was changed to be an `Expression` instead of pypika's `Field`. This allowed to move the `F`'s resolution code inside `F.resolve` and simplify the resolution code in general because `F` can be treated as other `Expression`s.
- `CombinedExpression` was introduced to handle arithmetic operations on `F()`, e.g. `F("a") + 1`. It was inspired by Django's [CombinedExpression](https://github.com/django/django/blob/042b381e2e37c0c37b8a8f6cc9947f1a2ebfa0dd/django/db/models/expressions.py#L702) and replaces pypika's arithmetic. `CombinedExpression` is a child of `Expression`, so it can be resolved without knowing the exact type of the object as opposed to pypika's `ArithmeticExpression` that was used previosly.

As part of this PR, I had to change how custom functions can be defined. It changed from

```
from tortoise.expressions import F
from pypika.terms import Function

class JsonSet(Function):
    def __init__(self, field: F, expression: str, value: Any):
        super().__init__("JSON_SET", field, expression, value)
```

to

```
from tortoise.functions import Function
from pypika.terms import Function as PupikaFunction

# it is a tortoise Function now, not Pypika's Function
class PypikaJsonSet(Function):
    def __init__(self, field: F, expression: str, value: Any):
        super().__init__("JSON_SET", field, expression, value)
    
    database_func = PypikaJsonSet
```

Effectively now custom functions are supposed to be a tortoise `Function`, not a Pypika's `Function`. The change had to be done because the Pypika's `Function` is no longer compatible with `F` and, frankly, having the interface that accepts both Pypika's functions and tortoise functions is a bit messy and makes the code quite convoluted.

## Motivation and Context

This introduces functionality supported by Django but also there is a clear demand for these features in the tortoise community. The following issues should be fixed by this PR
- fix https://github.com/tortoise/tortoise-orm/issues/1703
- fix https://github.com/tortoise/tortoise-orm/issues/683
- fix https://github.com/tortoise/tortoise-orm/issues/995
- fix https://github.com/tortoise/tortoise-orm/issues/477
- fix https://github.com/tortoise/tortoise-orm/issues/1496

## How Has This Been Tested?
- Tested on a sample web app
- Added tests

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

