### PR TITLE
Fix bug in schema_generator When modify a unique field

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Fixed
 - improve jsonfield type hint (#1700)
 - Fix bug in tortoise.models.Model When a QuerySet uses the only function and then uses the print function to print the returned result, an AttributeError is generated (#1724)
 - Update the pylint plugin to latest astroid version (#1708)
-
+- Fix bug in schema_generator When modify a unique field (#1768)
 Added
 ^^^^^
 - Add POSIX Regex support for PostgreSQL and MySQL (#1714)

--- a/tortoise/backends/base/schema_generator.py
+++ b/tortoise/backends/base/schema_generator.py
@@ -172,7 +172,7 @@ class BaseSchemaGenerator:
         )
 
     def _get_unique_index_sql(self, exists: str, table_name: str, field_names: List[str]) -> str:
-        index_name = self._generate_index_name("uidx", table_name, field_names)
+        index_name = self._generate_index_name("uid", table_name, field_names)
         return self.UNIQUE_INDEX_CREATE_TEMPLATE.format(
             exists=exists,
             index_name=index_name,


### PR DESCRIPTION
Here's a detailed description and reproduction of the problem #1768 

<!--- Provide a general summary of your changes in the Title above -->

## Description
file: tortoise.backends.base.schema_generator
reason:  Make it consistent with the prefixes in add_index and drop_index in aerich.ddl.__init__
old:
```
def _get_unique_index_sql(self, exists: str, table_name: str, field_names: List[str]) -> str:
        index_name = self._generate_index_name("uidx", table_name, field_names)
        return self.UNIQUE_INDEX_CREATE_TEMPLATE.format(
            exists=exists,
            index_name=index_name,
            table_name=table_name,
            fields=", ".join([self.quote(f) for f in field_names]),
        )
```
new:
```
def _get_unique_index_sql(self, exists: str, table_name: str, field_names: List[str]) -> str:
        index_name = self._generate_index_name("uid", table_name, field_names)
        return self.UNIQUE_INDEX_CREATE_TEMPLATE.format(
            exists=exists,
            index_name=index_name,
            table_name=table_name,
            fields=", ".join([self.quote(f) for f in field_names]),
        )
```
file: tortoise.backends.mysql.schema_generator
reason: 
1. Delete the unique in FIELD_TEMPLATE because if you don't delete it, you will create an additional unique index but the name will be name, not uid as defined in the code, which will result in two indexes associated with the name field.
2. Add the _get_table_sql function in order to add the sql for creating the unique index to the create table sql.
3. Modify UNIQUE_INDEX_CREATE_TEMPLATE because if you use KEY xxx statement to create must be within the create table sql, but in its internal will appear to create the index name does not contain the name of the table, when deleted and will be with the name of the aerich in the name of the inconsistency, it will be an exception!

old:
```
UNIQUE_CONSTRAINT_CREATE_TEMPLATE = "UNIQUE KEY `{index_name}` ({fields})"
UNIQUE_INDEX_CREATE_TEMPLATE = UNIQUE_CONSTRAINT_CREATE_TEMPLATE
FIELD_TEMPLATE = "`{name}` {type} {nullable} {unique}{primary}{comment}{default}"
```
new:
```
UNIQUE_INDEX_CREATE_TEMPLATE = 'CREATE UNIQUE INDEX {exists}`{index_name}` ON `{table_name}` ({fields});'
UNIQUE_CONSTRAINT_CREATE_TEMPLATE = UNIQUE_INDEX_CREATE_TEMPLATE
FIELD_TEMPLATE = "`{name}` {type} {nullable} {primary}{comment}{default}"
```
## Motivation and Context
If you want to validate my code please make sure that the commit (https://github.com/tortoise/aerich/commit/e9716538519c07d46a2dc6cba87fd096758c9471) mentioned in the re-issue is already in your code.

## How Has This Been Tested?
make ci

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.