### PR TITLE
change old pydantic docs url

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,9 @@ Added
 - Add POSIX Regex support for PostgreSQL and MySQL (#1714)
 - support app=None for tortoise.contrib.fastapi.RegisterTortoise (#1733)
 
+Changed
+^^^^^^^
+- Change old pydantic docs link to new one (#1775).
 
 0.21.6
 ------

--- a/docs/contrib/pydantic.rst
+++ b/docs/contrib/pydantic.rst
@@ -54,7 +54,7 @@ Lets start with a basic Tortoise Model:
 
     Tournament_Pydantic = pydantic_model_creator(Tournament)
 
-And now have a `Pydantic Model <https://pydantic-docs.helpmanual.io/usage/models/>`__ that can be used for representing schema and serialisation.
+And now have a `Pydantic Model <https://docs.pydantic.dev/latest/concepts/models/>`__ that can be used for representing schema and serialisation.
 
 The JSON-Schema of ``Tournament_Pydantic`` is now:
 
@@ -92,7 +92,7 @@ To serialise an object it is simply *(in an async context)*:
     tournament = await Tournament.create(name="New Tournament")
     tourpy = await Tournament_Pydantic.from_tortoise_orm(tournament)
 
-And one could get the contents by using `regular Pydantic-object methods <https://pydantic-docs.helpmanual.io/usage/exporting_models/>`_, such as ``.model_dump()`` or ``.model_dump_json()``
+And one could get the contents by using `regular Pydantic-object methods <https://docs.pydantic.dev/latest/concepts/serialization/>`_, such as ``.model_dump()`` or ``.model_dump_json()``
 
 .. code-block:: py3
 
@@ -150,7 +150,7 @@ Source to example: :ref:`example_pydantic_tut2`
 
     Tournament_Pydantic_List = pydantic_queryset_creator(Tournament)
 
-And now have a `Pydantic Model <https://pydantic-docs.helpmanual.io/usage/models/>`__ that can be used for representing schema and serialisation.
+And now have a `Pydantic Model <https://docs.pydantic.dev/latest/concepts/models/>`__ that can be used for representing schema and serialisation.
 
 The JSON-Schema of ``Tournament_Pydantic_List`` is now:
 
@@ -202,7 +202,7 @@ To serialise an object it is simply *(in an async context)*:
 
     tourpy = await Tournament_Pydantic_List.from_queryset(Tournament.all())
 
-And one could get the contents by using `regular Pydantic-object methods <https://pydantic-docs.helpmanual.io/usage/exporting_models/>`_, such as ``.model_dump()`` or ``.model_dump_json()``
+And one could get the contents by using `regular Pydantic-object methods <https://docs.pydantic.dev/latest/concepts/serialization/>`_, such as ``.model_dump()`` or ``.model_dump_json()``
 
 .. code-block:: py3
 
@@ -296,7 +296,7 @@ We define our models with a relationship:
             "models.Tournament", related_name="events", description="The Tournament this happens in"
         )
 
-Next we create our `Pydantic Model <https://pydantic-docs.helpmanual.io/usage/models/>`__ using ``pydantic_model_creator``:
+Next we create our `Pydantic Model <https://docs.pydantic.dev/latest/concepts/models/>`__ using ``pydantic_model_creator``:
 
 .. code-block:: py3
 
@@ -597,7 +597,7 @@ Note that the Pydantic serializer can't call async methods, but since the tortoi
 So we don't need to await the relation.
 We should however protect against the case where no prefetching was done, hence catching and handling the ``tortoise.exceptions.NoValuesFetched`` exception.
 
-Next we create our `Pydantic Model <https://pydantic-docs.helpmanual.io/usage/models/>`__ using ``pydantic_model_creator``:
+Next we create our `Pydantic Model <https://docs.pydantic.dev/latest/concepts/models/>`__ using ``pydantic_model_creator``:
 
 .. code-block:: py3
 

--- a/tortoise/contrib/pydantic/base.py
+++ b/tortoise/contrib/pydantic/base.py
@@ -123,7 +123,7 @@ class PydanticListModel(RootModel):
     Pydantic BaseModel for List of Tortoise Models
 
     This provides an extra method above the usual Pydantic
-    `model properties <https://pydantic-docs.helpmanual.io/usage/models/#model-properties>`__
+    `model properties <https://docs.pydantic.dev/latest/concepts/models/#model-methods-and-properties>`__
     """
 
     @classmethod

--- a/tortoise/contrib/pydantic/creator.py
+++ b/tortoise/contrib/pydantic/creator.py
@@ -156,7 +156,7 @@ def pydantic_queryset_creator(
         sort_alphabetically: Optional[bool] = None,
 ) -> Type[PydanticListModel]:
     """
-    Function to build a `Pydantic Model <https://pydantic-docs.helpmanual.io/usage/models/>`__ list off Tortoise Model.
+    Function to build a `Pydantic Model <https://docs.pydantic.dev/latest/concepts/models/>`__ list off Tortoise Model.
 
     :param cls: The Tortoise Model to put in a list.
     :param name: Specify a custom name explicitly, instead of a generated name.
@@ -572,7 +572,7 @@ def pydantic_model_creator(
         module: str = __name__,
 ) -> Type[PydanticModel]:
     """
-    Function to build `Pydantic Model <https://pydantic-docs.helpmanual.io/usage/models/>`__ off Tortoise Model.
+    Function to build `Pydantic Model <https://docs.pydantic.dev/latest/concepts/models/>`__ off Tortoise Model.
 
     :param cls: The Tortoise Model
     :param name: Specify a custom name explicitly, instead of a generated name.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This simple PR changes the old pydantic docs urls to the new ones.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

