### PR TITLE
Primary key field should not be nullable

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ Changelog
 ------
 Fixed
 ^^^^^
-- Primary key field should not be nullable
+- Primary key field should not be nullable (#1778)
 
 Added
 ^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ Changelog
 ------
 Fixed
 ^^^^^
-- TODO
+- Primary key field should not be nullable
 
 Added
 ^^^^^

--- a/tortoise/contrib/pydantic/creator.py
+++ b/tortoise/contrib/pydantic/creator.py
@@ -513,7 +513,9 @@ class PydanticModelCreator:
         ptype = python_type
         if field.null:
             json_schema_extra["nullable"] = True
-        if field_name in self._optional or field.default is not None or field.null:
+        if not field.pk and (
+            field_name in self._optional or field.default is not None or field.null
+        ):
             ptype = Optional[ptype]
         if not (self._exclude_read_only and json_schema_extra.get("readOnly") is True):
             return annotation or ptype


### PR DESCRIPTION
Primary key field should not be nullable

## Description
If a value is a primary key, it should not be optional(nullable). For example, there is a Model called `Foo`, whose primary key is a `UUIDField` called `id`. Submitting a form using `FooIn` will use `exclude_readonly=True`, so the `id` field will not be included. And for output `FooOut` id cannot be nullable because it is the primary key. This PR fixes this problem.

Before:
![image](https://github.com/user-attachments/assets/0097fd82-38c9-4cbc-ba64-1c429a4df87d)

After:
![image](https://github.com/user-attachments/assets/ad09e97e-eb80-4f7b-9d26-be73464a022e)


## Motivation and Context
My projects use OpenAPI documentation auto-generated as a TypeScript client. It helps a lot to annotate the types correctly.

## How Has This Been Tested?
This is a minor change, and it passes all existing tests. I tested it in a few of my live projects and it works fine.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

