### PR TITLE
feat: add mixin for int enum field custom

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,15 +11,14 @@ Changelog
 
 0.22.1
 ------
-
 Fixed
 ^^^^^
 - Fix unable to use ManyToManyField if OneToOneField passed as Primary Key (#1783)
 - Fix sorting by Term (e.g. RawSQL) (#1788)
 
-Changed
-^^^^^^^
-- Change IntEnumField sql type from small int to int (#1781)
+Added
+^^^^^
+- Add IntEnumFieldMixin to make it easy to Custom IntEnumField (#1781)
 
 0.22.0
 ------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,13 @@ Changelog
 0.22
 ====
 
+0.22.1
+------
+
+Added
+^^^^^
+- Add IntEnumFieldMixin to make it easy to Custom IntEnumField (#1781)
+
 0.22.0
 ------
 Fixed

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ docs: deps
 _style:
 	isort -src $(checkfiles)
 	black $(checkfiles)
-style: _style deps
+style: deps _style
 
 build: deps
 	rm -fR dist/

--- a/examples/enum_fields.py
+++ b/examples/enum_fields.py
@@ -1,7 +1,8 @@
 from enum import Enum, IntEnum
+from typing import Type, cast
 
 from tortoise import Tortoise, fields, run_async
-from tortoise.fields.data import IntEnumFieldMixin, IntField
+from tortoise.fields.data import IntEnumFieldMixin, IntEnumType, IntField
 from tortoise.models import Model
 
 
@@ -19,21 +20,23 @@ class Currency(str, Enum):
 
 class Protocol(IntEnum):
     A = 10000
-    B = 80000
+    B = 80000  # >32767, beyond the value range of fields.IntEnumField
 
 
-class Int32EnumInstance(IntEnumFieldMixin, IntField):
+class IntEnumInstance(IntEnumFieldMixin, IntField):
     pass
 
 
-def Int32EnumField(enum_type, **kwargs):
-    return Int32EnumInstance(enum_type, **kwargs)
+def IntEnumField(enum_type: Type[IntEnumType], **kwargs) -> IntEnumType:
+    return cast(IntEnumType, IntEnumInstance(enum_type, **kwargs))
 
 
 class EnumFields(Model):
-    service: Service = fields.IntEnumField(Service)
     currency: Currency = fields.CharEnumField(Currency, default=Currency.HUF)
-    protocol: Protocol = Int32EnumField(Protocol)
+    # When each value of the enum_type is between [-32768, 32767], use the fields.IntEnumField
+    service: Service = fields.IntEnumField(Service)
+    # Else, you can use a custom Field
+    protocol: Protocol = IntEnumField(Protocol)
 
 
 async def run():

--- a/examples/enum_fields.py
+++ b/examples/enum_fields.py
@@ -20,15 +20,15 @@ class Currency(str, Enum):
 
 class Protocol(IntEnum):
     A = 10000
-    B = 80000  # >32767, beyond the value range of fields.IntEnumField
+    B = 80000  # >32767, beyond the 'le' value in fields.IntEnumFieldInstance.constraints
 
 
-class IntEnumInstance(IntEnumFieldMixin, IntField):
+class IntEnumFieldInstance(IntEnumFieldMixin, IntField):
     pass
 
 
 def IntEnumField(enum_type: Type[IntEnumType], **kwargs) -> IntEnumType:
-    return cast(IntEnumType, IntEnumInstance(enum_type, **kwargs))
+    return cast(IntEnumType, IntEnumFieldInstance(enum_type, **kwargs))
 
 
 class EnumFields(Model):

--- a/examples/enum_fields.py
+++ b/examples/enum_fields.py
@@ -1,6 +1,7 @@
 from enum import Enum, IntEnum
 
 from tortoise import Tortoise, fields, run_async
+from tortoise.fields.data import IntEnumFieldMixin, IntField
 from tortoise.models import Model
 
 
@@ -16,18 +17,34 @@ class Currency(str, Enum):
     USD = "USD"
 
 
+class Protocol(IntEnum):
+    A = 10000
+    B = 80000
+
+
+class Int32EnumInstance(IntEnumFieldMixin, IntField):
+    pass
+
+
+def Int32EnumField(enum_type, **kwargs):
+    return Int32EnumInstance(enum_type, **kwargs)
+
+
 class EnumFields(Model):
     service: Service = fields.IntEnumField(Service)
     currency: Currency = fields.CharEnumField(Currency, default=Currency.HUF)
+    protocol: Protocol = Int32EnumField(Protocol)
 
 
 async def run():
     await Tortoise.init(db_url="sqlite://:memory:", modules={"models": ["__main__"]})
     await Tortoise.generate_schemas()
 
-    obj0 = await EnumFields.create(service=Service.python_programming, currency=Currency.USD)
+    obj0 = await EnumFields.create(
+        service=Service.python_programming, currency=Currency.USD, protocol=Protocol.A
+    )
     # also you can use valid int and str value directly
-    await EnumFields.create(service=1, currency="USD")
+    await EnumFields.create(service=1, currency="USD", protocol=Protocol.B.value)
 
     try:
         # invalid enum value will raise ValueError

--- a/tests/fields/test_enum.py
+++ b/tests/fields/test_enum.py
@@ -1,9 +1,10 @@
 from enum import IntEnum
 
+from examples.enum_fields import IntEnumField as CustomIntEnumField
 from tests import testmodels
 from tortoise.contrib import test
 from tortoise.exceptions import ConfigurationError, IntegrityError
-from tortoise.fields import CharEnumField, IntEnumField
+from tortoise.fields import CharEnumField, IntEnumField, IntField
 
 
 class BadIntEnum1(IntEnum):
@@ -20,6 +21,12 @@ class BadIntEnum2(IntEnum):
 
 class BadIntEnumIfGenerated(IntEnum):
     python_programming = -1
+    database_design = 2
+    system_administration = 3
+
+
+class BadCustomIntEnum(IntEnum):
+    python_programming = IntField.VALUE_RANGE[1] + 1
     database_design = 2
     system_administration = 3
 
@@ -117,6 +124,11 @@ class TestIntEnumFields(test.TestCase):
     def test_manual_description(self):
         fld = IntEnumField(testmodels.Service, description="foo")
         self.assertEqual(fld.description, "foo")
+
+    def test_custom_int_enum_field(self):
+        assert CustomIntEnumField(BadIntEnum1)
+        with self.assertRaises(ConfigurationError):
+            CustomIntEnumField(BadCustomIntEnum)
 
 
 class TestCharEnumFields(test.TestCase):

--- a/tests/fields/test_enum.py
+++ b/tests/fields/test_enum.py
@@ -4,7 +4,7 @@ from examples.enum_fields import IntEnumField as CustomIntEnumField
 from tests import testmodels
 from tortoise.contrib import test
 from tortoise.exceptions import ConfigurationError, IntegrityError
-from tortoise.fields import CharEnumField, IntEnumField, IntField
+from tortoise.fields import CharEnumField, IntEnumField
 
 
 class BadIntEnum1(IntEnum):
@@ -26,7 +26,7 @@ class BadIntEnumIfGenerated(IntEnum):
 
 
 class BadCustomIntEnum(IntEnum):
-    python_programming = IntField.VALUE_RANGE[1] + 1
+    python_programming = 2147483648
     database_design = 2
     system_administration = 3
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
As #966 said, IntEnumField inherit from SmallIntField, so it can not use a enum_type with value > 32767

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR add a IntEnumFieldMixin to make it easy to custom a new IntEnumField:
```py
from typing import Type, cast
from tortoise.fields.data import IntEnumFieldMixin, IntEnumType, IntField

class IntEnumInstance(IntEnumFieldMixin, IntField):
    pass

def IntEnumField(enum_type: Type[IntEnumType], **kwargs) -> IntEnumType:
    return cast(IntEnumType, IntEnumInstance(enum_type, **kwargs))
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
make ci

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

