### PR TITLE
Fix bug combined expression connectors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,12 @@ Changelog
 0.22
 ====
 
+0.22.2 (unreleased)
+------
+Fixed
+^^^^^
+- Fix bug related to `Connector.div` in combined expressions. (#1794)
+
 0.22.1
 ------
 Fixed

--- a/tortoise/expressions.py
+++ b/tortoise/expressions.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import operator
 from dataclasses import dataclass
 from dataclasses import field as dataclass_field
-from enum import Enum, auto
+from enum import Enum
 from typing import TYPE_CHECKING, Any, Iterator, Type, cast
 
 from pypika import Case as PypikaCase
@@ -70,12 +70,12 @@ class Value(Expression):
 
 
 class Connector(Enum):
-    add = auto()
-    sub = auto()
-    mul = auto()
-    div = auto()
-    pow = auto()
-    mod = auto()
+    add = "add"
+    sub = "sub"
+    mul = "mul"
+    div = "truediv"
+    pow = "pow"
+    mod = "mod"
 
 
 class CombinedExpression(Expression):
@@ -96,7 +96,7 @@ class CombinedExpression(Expression):
         ):
             raise FieldError("Cannot use arithmetic expression between different field type")
 
-        operator_func = getattr(operator, self.connector.name)
+        operator_func = getattr(operator, self.connector.value)
         return ResolveResult(
             term=operator_func(left.term, right.term),
             joins=list(set(left.joins + right.joins)),  # dedup joins


### PR DESCRIPTION
This PR changes `expressions.Connector` values to be explicit strings. This is because the `operator` module does not have a function called `div` (it is `truediv`).

## Motivation and Context
We use enum values instead of names to get the operator function from `operator` module.

## How Has This Been Tested?
Running existing tests.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

