### PR TITLE
Restore connection context if exception happens during rollback or commit

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Changelog
 Fixed
 ^^^^^
 - Fix bug related to `Connector.div` in combined expressions. (#1794)
+- Fix recovery in case of database downtime (#1796)
 
 Changed
 ^^^^^^^

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -1,4 +1,5 @@
 from unittest.mock import Mock
+
 from tests.testmodels import CharPkModel, Event, Team, Tournament
 from tortoise import connections
 from tortoise.contrib import test
@@ -215,6 +216,11 @@ class TestTransactions(test.TruncationTestCase):
         self.assertEqual(
             await Tournament.all().values("id", "name"), [{"id": obj.id, "name": "Test1"}]
         )
+
+
+@test.requireCapability(supports_transactions=True)
+class TestIsolatedTransactions(test.IsolatedTestCase):
+    """Running these in isolation because they mess with the global state of the connections."""
 
     async def test_rollback_raising_exception(self):
         """Tests that if a rollback raises an exception, the connection context is restored."""

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -1,4 +1,6 @@
+from unittest.mock import Mock
 from tests.testmodels import CharPkModel, Event, Team, Tournament
+from tortoise import connections
 from tortoise.contrib import test
 from tortoise.exceptions import OperationalError, TransactionManagementError
 from tortoise.transactions import atomic, in_transaction
@@ -213,3 +215,22 @@ class TestTransactions(test.TruncationTestCase):
         self.assertEqual(
             await Tournament.all().values("id", "name"), [{"id": obj.id, "name": "Test1"}]
         )
+
+    async def test_rollback_raising_exception(self):
+        """Tests that if a rollback raises an exception, the connection context is restored."""
+        conn = connections.get("models")
+        with self.assertRaisesRegex(ValueError, "rollback"):
+            async with conn._in_transaction() as tx_conn:
+                tx_conn.rollback = Mock(side_effect=ValueError("rollback"))
+                raise ValueError("initial exception")
+
+        self.assertEqual(connections.get("models"), conn)
+
+    async def test_commit_raising_exception(self):
+        """Tests that if a commit raises an exception, the connection context is restored."""
+        conn = connections.get("models")
+        with self.assertRaisesRegex(ValueError, "commit"):
+            async with conn._in_transaction() as tx_conn:
+                tx_conn.commit = Mock(side_effect=ValueError("commit"))
+
+        self.assertEqual(connections.get("models"), conn)


### PR DESCRIPTION
## Description
Fixes the issue where if an exception happens during a rollback or commit, the connection context is not properly restored leading to having `TransactionWrapper` where regular connections are supposed to be. This would also cause connections not properly recycled in the case of database downtime.

## Motivation and Context
This should fix https://github.com/tortoise/tortoise-orm/issues/1793 and fix https://github.com/tortoise/tortoise-orm/issues/1604

## How Has This Been Tested?
- Tests
- Ran a web app locally.
- Ran the test case from https://github.com/tortoise/tortoise-orm/issues/1793

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

