### PR TITLE
Parametrize related field queries

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Fixed
 Changed
 ^^^^^^^
 - Parametrizes UPDATE, DELETE, bulk update and create operations (#1785)
+- Parametrizes related field queries (#1797)
 
 0.22.1
 ------

--- a/poetry.lock
+++ b/poetry.lock
@@ -2658,15 +2658,11 @@ name = "pypika-tortoise"
 version = "0.3.2"
 description = "Forked from pypika and streamline just for tortoise-orm"
 optional = false
-python-versions = "^3.8"
-files = []
-develop = false
-
-[package.source]
-type = "git"
-url = "https://github.com/henadzit/pypika-tortoise.git"
-reference = "feat/query-supports-parametrization"
-resolved_reference = "764f99478ead03ecb567e316388d432a3fde6c3d"
+python-versions = "<4.0,>=3.8"
+files = [
+    {file = "pypika_tortoise-0.3.2-py3-none-any.whl", hash = "sha256:c5c52bc4473fe6f3db36cf659340750246ec5dd0f980d04ae7811430e299c3a2"},
+    {file = "pypika_tortoise-0.3.2.tar.gz", hash = "sha256:f5d508e2ef00255e52ec6ac79ef889e10dbab328f218c55cd134c4d02ff9f6f4"},
+]
 
 [[package]]
 name = "pytest"
@@ -3859,4 +3855,4 @@ psycopg = ["psycopg"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "9862186f82b8fb88de18be55bcd84223a4778fac185a0f508aa74309a9968b03"
+content-hash = "2773fe40e1a953e4ad5546d8460aa2bde729df7443a14fbaf6ad1f15697a0482"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2655,14 +2655,18 @@ files = [
 
 [[package]]
 name = "pypika-tortoise"
-version = "0.3.1"
+version = "0.3.2"
 description = "Forked from pypika and streamline just for tortoise-orm"
 optional = false
-python-versions = "<4.0,>=3.8"
-files = [
-    {file = "pypika_tortoise-0.3.1-py3-none-any.whl", hash = "sha256:eee0d49c99ed1b932f7c48f8b87d8492aeb3c7e6a48ba69bc462eb9e3b5b20a2"},
-    {file = "pypika_tortoise-0.3.1.tar.gz", hash = "sha256:6f9861dd34fd21a009e79b174159e61699da28cb2607617e688b7e79e6c9ef7e"},
-]
+python-versions = "^3.8"
+files = []
+develop = false
+
+[package.source]
+type = "git"
+url = "https://github.com/henadzit/pypika-tortoise.git"
+reference = "feat/query-supports-parametrization"
+resolved_reference = "764f99478ead03ecb567e316388d432a3fde6c3d"
 
 [[package]]
 name = "pytest"
@@ -3855,4 +3859,4 @@ psycopg = ["psycopg"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "11e83b0160e58f8df186c28ab8c29c6547859a58200b9e0cefc9ef9b632f7629"
+content-hash = "9862186f82b8fb88de18be55bcd84223a4778fac185a0f508aa74309a9968b03"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-pypika-tortoise = "^0.3.1"
+pypika-tortoise = { git = "https://github.com/henadzit/pypika-tortoise.git", branch = "feat/query-supports-parametrization" }
 iso8601 = "^2.1.0"
 aiosqlite = ">=0.16.0, <0.21.0"
 pytz = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-pypika-tortoise = { git = "https://github.com/henadzit/pypika-tortoise.git", branch = "feat/query-supports-parametrization" }
+pypika-tortoise = "^0.3.2"
 iso8601 = "^2.1.0"
 aiosqlite = ">=0.16.0, <0.21.0"
 pytz = "*"

--- a/tortoise/backends/base/executor.py
+++ b/tortoise/backends/base/executor.py
@@ -450,7 +450,7 @@ class BaseExecutor:
             if modifier.having_criterion:
                 query = query.having(modifier.having_criterion)
 
-        _, raw_results = await self.db.execute_query(query.get_sql())
+        _, raw_results = await self.db.execute_query(*query.get_parameterized_sql())
         relations: List[Tuple[Any, Any]] = []
         related_object_list: List["Model"] = []
         model_pk, related_pk = self.model._meta.pk, field_object.related_model._meta.pk

--- a/tortoise/backends/base/executor.py
+++ b/tortoise/backends/base/executor.py
@@ -21,7 +21,6 @@ from typing import (
 
 from pypika import JoinType, Parameter, Table
 from pypika.queries import QueryBuilder
-from pypika.terms import Parameterizer
 
 from tortoise.exceptions import OperationalError
 from tortoise.expressions import Expression, ResolveContext
@@ -191,10 +190,6 @@ class BaseExecutor:
 
     def parameter(self, pos: int) -> Parameter:
         return Parameter(idx=pos + 1)
-
-    @classmethod
-    def parameterizer(cls) -> Parameterizer:
-        return Parameterizer()
 
     async def execute_insert(self, instance: "Model") -> None:
         if not instance._custom_generated_pk:

--- a/tortoise/backends/psycopg/executor.py
+++ b/tortoise/backends/psycopg/executor.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Optional
 
-from pypika import Parameter, Parameterizer
+from pypika import Parameter
 
 from tortoise import Model
 from tortoise.backends.base_postgres.executor import BasePostgresExecutor
@@ -26,7 +26,3 @@ class PsycopgExecutor(BasePostgresExecutor):
 
     def parameter(self, pos: int) -> Parameter:
         return Parameter("%s")
-
-    @classmethod
-    def parameterizer(cls) -> Parameterizer:
-        return Parameterizer(placeholder_factory=lambda _: "%s")

--- a/tortoise/backends/sqlite/executor.py
+++ b/tortoise/backends/sqlite/executor.py
@@ -1,6 +1,6 @@
 import datetime
-from decimal import Decimal
 import sqlite3
+from decimal import Decimal
 from typing import Optional, Type, Union
 
 import pytz

--- a/tortoise/expressions.py
+++ b/tortoise/expressions.py
@@ -205,7 +205,8 @@ class Subquery(Term):
 
     def get_sql(self, **kwargs: Any) -> str:
         self.query._choose_db_if_not_chosen()
-        return self.query._make_query(**kwargs)[0]
+        self.query._make_query()
+        return self.query.query.get_parameterized_sql(**kwargs)[0]
 
     def as_(self, alias: str) -> "Selectable":  # type: ignore
         self.query._choose_db_if_not_chosen()


### PR DESCRIPTION
## Description
This is the final (hopefully) parametrization PR. After this is merged, all queries should be parameterized.

- Updates relational field queries to use parametrized queries
- Refactors QuerySets to use pypika's `get_parameterized_query` instead of doing parameterization itself. It shifts the responsibility of parameterization to pypika. [This PR ](https://github.com/tortoise/pypika-tortoise/pull/20) introduces `QueryBuilder.get_parameterized_query`.

## Motivation and Context
Parameterized queries are crucial for preventing SQL injection attacks and but also can improve performance of database operations.

This PR should finally allow us to close https://github.com/tortoise/tortoise-orm/issues/81.

This also checks one of the requirements for v1.0.0, [related ticket](https://github.com/tortoise/tortoise-orm/issues/19).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

