### PR TITLE
add enum support to pydantic_model_creator

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -54,7 +54,7 @@ Added
 Changed
 ^^^^^^^
 - Change old pydantic docs link to new one (#1775).
-- Refactored pydantic_model_creator, interface not changed  (#1763)
+- Refactored pydantic_model_creator, interface not changed  (#1745)
 - Values are no longer validated to be right type upon loading from database (#1750)
 - Refactored private field names in queryset classes (#1751)
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,10 @@ Changed
 ^^^^^^^
 - Parametrizes UPDATE, DELETE, bulk update and create operations (#1785)
 
+Added
+^^^^^
+- CharEnumField and IntEnumField is supported by pydantic_model_creator (#1798)
+
 0.22.1
 ------
 Fixed

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -62,7 +62,7 @@ Contributors
 * Daniel Szucs ``@Quasar6X``
 * Rui Catarino ``@ruitcatarino``
 * Lance Moe ``@lancemoe``
-* Markus Beckschulte ``@markus96``
+* Markus Beckschulte ``@markus-96``
 
 Special Thanks
 ==============

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -62,6 +62,7 @@ Contributors
 * Daniel Szucs ``@Quasar6X``
 * Rui Catarino ``@ruitcatarino``
 * Lance Moe ``@lancemoe``
+* Markus Beckschulte ``@markus96``
 
 Special Thanks
 ==============

--- a/tortoise/contrib/pydantic/creator.py
+++ b/tortoise/contrib/pydantic/creator.py
@@ -1,6 +1,7 @@
 import inspect
 from base64 import b32encode
 from copy import copy
+from enum import IntEnum, Enum
 from hashlib import sha3_224
 from typing import (
     TYPE_CHECKING,
@@ -33,6 +34,7 @@ from tortoise.contrib.pydantic.descriptions import (
 )
 from tortoise.contrib.pydantic.utils import get_annotations
 from tortoise.fields import Field, JSONField
+from tortoise.fields.data import IntEnumFieldInstance, CharEnumFieldInstance
 
 if TYPE_CHECKING:  # pragma: nocoverage
     from tortoise.models import Model
@@ -509,7 +511,11 @@ class PydanticModelCreator:
             json_schema_extra["readOnly"] = constraints["readOnly"]
             del constraints["readOnly"]
         fconfig.update(constraints)
-        python_type = getattr(field, "related_model", field.field_type)
+        python_type: Union[Type[Enum], Type[IntEnum], Type]
+        if isinstance(field, (IntEnumFieldInstance, CharEnumFieldInstance)):
+            python_type = field.enum_type
+        else:
+            python_type = getattr(field, "related_model", field.field_type)
         ptype = python_type
         if field.null:
             json_schema_extra["nullable"] = True


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add support for `CharEnumField` and `IntEnumField` in `pydantic_model_creator`, as described in #601 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Pydantic should raise a `ValidationError` if no proper enum value is given. Otherwise, a `ValueError` from `Enum` or `IntEnum` is raised, but only if to_db_value is called. Also, it is useful if you want to use something like fastapi.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tested with: the current tests, added tests, and react-jsonschema-form as a special use case.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation. (Shouldn't, since it is an expected behaviour)
- [ ] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

