### PR TITLE
refactor: remove duplicated code in postgres indexes

### DIFF
--- a/tortoise/contrib/postgres/indexes.py
+++ b/tortoise/contrib/postgres/indexes.py
@@ -1,7 +1,3 @@
-from typing import Optional, Tuple
-
-from pypika.terms import Term, ValueWrapper
-
 from tortoise.indexes import PartialIndex
 
 
@@ -9,22 +5,6 @@ class PostgreSQLIndex(PartialIndex):
     INDEX_CREATE_TEMPLATE = (
         "CREATE INDEX {exists}{index_name} ON {table_name} USING{index_type}({fields}){extra};"
     )
-
-    def __init__(
-        self,
-        *expressions: Term,
-        fields: Optional[Tuple[str, ...]] = None,
-        name: Optional[str] = None,
-        condition: Optional[dict] = None,
-    ) -> None:
-        super().__init__(*expressions, fields=fields, name=name)
-        if condition:
-            cond = " WHERE "
-            items = []
-            for k, v in condition.items():
-                items.append(f"{k} = {ValueWrapper(v)}")
-            cond += " AND ".join(items)
-            self.extra = cond
 
 
 class BloomIndex(PostgreSQLIndex):

--- a/tortoise/indexes.py
+++ b/tortoise/indexes.py
@@ -71,8 +71,6 @@ class PartialIndex(Index):
         super().__init__(*expressions, fields=fields, name=name)
         if condition:
             cond = " WHERE "
-            items = []
-            for k, v in condition.items():
-                items.append(f"{k} = {ValueWrapper(v)}")
+            items = [f"{k} = {ValueWrapper(v)}" for k, v in condition.items()]
             cond += " AND ".join(items)
             self.extra = cond


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Code of `__init__` function in tortoise.contrib.postgres.indexes.PostgreSQLIndex is duplicated with its parent class PartialIndex 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

