### PR TITLE
Fix N-level transactions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,12 @@ Changelog
 
 0.22
 ====
+0.22.3 (unreleased)
+------
+Fixed
+^^^^^
+- Fixed a deadlock in three level nested transactions (#1810)
+
 
 0.22.2
 ------

--- a/docs/transactions.rst
+++ b/docs/transactions.rst
@@ -4,6 +4,17 @@
 Transactions
 ============
 
+Tortoise ORM provides a simple way to manage transactions. You can use the
+``atomic()`` decorator or ``in_transaction()`` context manager.
+
+``atomic()`` and ``in_transaction()`` can be nested, and the outermost block will
+be the one that actually commits the transaciton. Tortoise ORM doesn't support savepoints yet.
+
+In most cases ``asyncio.gather`` or similar ways to spin up concurrent tasks can be used safely
+when querying the database or using transactions. Tortoise ORM will ensure that for the duration
+of a query, the database connection is used exclusively by the task that initiated the query.
+
+
 .. automodule:: tortoise.transactions
     :members:
     :undoc-members:

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -69,6 +69,7 @@ class TestConcurrencyIsolated(test.IsolatedTestCase):
         count = await Tournament.all().count()
         self.assertEqual(count, 1000)
 
+
 @test.requireCapability(supports_transactions=True)
 class TestConcurrencyTransactioned(test.TestCase):
     async def test_concurrency_read(self):

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -19,10 +19,6 @@ class TestConcurrencyIsolated(test.IsolatedTestCase):
         all_read = await Tournament.all()
         self.assertEqual(set(all_write), set(all_read))
 
-    async def create_trans_concurrent(self):
-        async with in_transaction():
-            await asyncio.gather(*[Tournament.create(name="Test") for _ in range(100)])
-
     async def test_nonconcurrent_get_or_create(self):
         unas = [await UniqueName.get_or_create(name="c") for _ in range(10)]
         una_created = [una[1] for una in unas if una[1] is True]
@@ -41,22 +37,37 @@ class TestConcurrencyIsolated(test.IsolatedTestCase):
 
     @test.skipIf(sys.version_info < (3, 7), "aiocontextvars backport not handling this well")
     @test.requireCapability(supports_transactions=True)
-    async def test_concurrency_transactions_concurrent(self):
-        await asyncio.gather(*[self.create_trans_concurrent() for _ in range(10)])
+    async def test_concurrent_transactions_with_multiple_ops(self):
+        async def create_in_transaction():
+            async with in_transaction():
+                await asyncio.gather(*[Tournament.create(name="Test") for _ in range(100)])
+
+        await asyncio.gather(*[create_in_transaction() for _ in range(10)])
         count = await Tournament.all().count()
         self.assertEqual(count, 1000)
 
-    async def create_trans(self):
-        async with in_transaction():
-            await Tournament.create(name="Test")
-
     @test.skipIf(sys.version_info < (3, 7), "aiocontextvars backport not handling this well")
     @test.requireCapability(supports_transactions=True)
-    async def test_concurrency_transactions(self):
-        await asyncio.gather(*[self.create_trans() for _ in range(100)])
+    async def test_concurrent_transactions_with_single_op(self):
+        async def create():
+            async with in_transaction():
+                await Tournament.create(name="Test")
+
+        await asyncio.gather(*[create() for _ in range(100)])
         count = await Tournament.all().count()
         self.assertEqual(count, 100)
 
+    @test.skipIf(sys.version_info < (3, 7), "aiocontextvars backport not handling this well")
+    @test.requireCapability(supports_transactions=True)
+    async def test_nested_concurrent_transactions_with_multiple_ops(self):
+        async def create_in_transaction():
+            async with in_transaction():
+                async with in_transaction():
+                    await asyncio.gather(*[Tournament.create(name="Test") for _ in range(100)])
+
+        await asyncio.gather(*[create_in_transaction() for _ in range(10)])
+        count = await Tournament.all().count()
+        self.assertEqual(count, 1000)
 
 @test.requireCapability(supports_transactions=True)
 class TestConcurrencyTransactioned(test.TestCase):

--- a/tortoise/backends/asyncpg/client.py
+++ b/tortoise/backends/asyncpg/client.py
@@ -9,7 +9,7 @@ from tortoise.backends.asyncpg.schema_generator import AsyncpgSchemaGenerator
 from tortoise.backends.base.client import (
     BaseTransactionWrapper,
     ConnectionWrapper,
-    NestedTransactionPooledContext,
+    NestedTransactionContext,
     PoolConnectionWrapper,
     TransactionContext,
     TransactionContextPooled,
@@ -169,7 +169,7 @@ class TransactionWrapper(AsyncpgDBClient, BaseTransactionWrapper):
         self._parent: AsyncpgDBClient = connection
 
     def _in_transaction(self) -> "TransactionContext":
-        return NestedTransactionPooledContext(self)
+        return NestedTransactionContext(self)
 
     def acquire_connection(self) -> ConnectionWrapper[asyncpg.Connection]:
         return ConnectionWrapper(self._lock, self)

--- a/tortoise/backends/asyncpg/client.py
+++ b/tortoise/backends/asyncpg/client.py
@@ -161,7 +161,6 @@ class TransactionWrapper(AsyncpgDBClient, BaseTransactionWrapper):
     def __init__(self, connection: AsyncpgDBClient) -> None:
         self._connection: asyncpg.Connection = connection._connection
         self._lock = asyncio.Lock()
-        self._trxlock = asyncio.Lock()
         self.log = connection.log
         self.connection_name = connection.connection_name
         self.transaction: Transaction = None

--- a/tortoise/backends/mysql/client.py
+++ b/tortoise/backends/mysql/client.py
@@ -29,7 +29,7 @@ from tortoise.backends.base.client import (
     BaseTransactionWrapper,
     Capabilities,
     ConnectionWrapper,
-    NestedTransactionPooledContext,
+    NestedTransactionContext,
     PoolConnectionWrapper,
     TransactionContext,
     TransactionContextPooled,
@@ -236,7 +236,7 @@ class TransactionWrapper(MySQLClient, BaseTransactionWrapper):
         self._parent = connection
 
     def _in_transaction(self) -> "TransactionContext":
-        return NestedTransactionPooledContext(self)
+        return NestedTransactionContext(self)
 
     def acquire_connection(self) -> ConnectionWrapper[mysql.Connection]:
         return ConnectionWrapper(self._lock, self)

--- a/tortoise/backends/mysql/client.py
+++ b/tortoise/backends/mysql/client.py
@@ -229,7 +229,6 @@ class TransactionWrapper(MySQLClient, BaseTransactionWrapper):
         self.connection_name = connection.connection_name
         self._connection: mysql.Connection = connection._connection
         self._lock = asyncio.Lock()
-        self._trxlock = asyncio.Lock()
         self.log = connection.log
         self._finalized: Optional[bool] = None
         self.fetch_inserted = connection.fetch_inserted

--- a/tortoise/backends/odbc/client.py
+++ b/tortoise/backends/odbc/client.py
@@ -10,7 +10,7 @@ from tortoise import BaseDBAsyncClient
 from tortoise.backends.base.client import (
     BaseTransactionWrapper,
     ConnectionWrapper,
-    NestedTransactionPooledContext,
+    NestedTransactionContext,
     PoolConnectionWrapper,
     TransactionContext,
 )
@@ -175,7 +175,7 @@ class ODBCTransactionWrapper(BaseTransactionWrapper):
         self._parent = connection
 
     def _in_transaction(self) -> "TransactionContext":
-        return NestedTransactionPooledContext(self)
+        return NestedTransactionContext(self)
 
     def acquire_connection(self) -> ConnWrapperType:
         return ConnectionWrapper(self._lock, self)

--- a/tortoise/backends/odbc/client.py
+++ b/tortoise/backends/odbc/client.py
@@ -168,7 +168,6 @@ class ODBCTransactionWrapper(BaseTransactionWrapper):
         self.connection_name = connection.connection_name
         self._connection: asyncodbc.Connection = connection._connection
         self._lock = asyncio.Lock()
-        self._trxlock = asyncio.Lock()
         self.log = connection.log
         self._finalized: Optional[bool] = None
         self.fetch_inserted = connection.fetch_inserted

--- a/tortoise/backends/psycopg/client.py
+++ b/tortoise/backends/psycopg/client.py
@@ -214,7 +214,6 @@ class TransactionWrapper(PsycopgClient, base_client.BaseTransactionWrapper):
     def __init__(self, connection: PsycopgClient) -> None:
         self._connection: psycopg.AsyncConnection = connection._connection
         self._lock = asyncio.Lock()
-        self._trxlock = asyncio.Lock()
         self.log = connection.log
         self.connection_name = connection.connection_name
         self._finalized = False

--- a/tortoise/backends/psycopg/client.py
+++ b/tortoise/backends/psycopg/client.py
@@ -221,7 +221,7 @@ class TransactionWrapper(PsycopgClient, base_client.BaseTransactionWrapper):
         self._parent = connection
 
     def _in_transaction(self) -> base_client.TransactionContext:
-        return base_client.NestedTransactionPooledContext(self)
+        return base_client.NestedTransactionContext(self)
 
     def acquire_connection(self) -> base_client.ConnectionWrapper[psycopg.AsyncConnection]:
         return base_client.ConnectionWrapper(self._lock, self)


### PR DESCRIPTION
## Description
- Allow having more than 2 nested transaction blocks, e.g.
```python
async with in_transaction():
  async with in_transaction():
    async with in_transaction():
      ...
```
- Do no lock in nested transactions. This is not really needed because safepoints are not supposed by Tortoise ORM yet. This enabled the fix for the issue above. When we introduce safepoints, we will have to revisit this again, or... Make stricter rules on using `asyncio.gather` or similar tools within a transaction. For instance, [SQLAlchemy states that it is unsafe](https://docs.sqlalchemy.org/en/20/orm/session_basics.html#session-faq-threadsafe). 
- Refactor the clients code by making `TransactionContext` an interface and moving the original code of `TransactionContext` to `tortoise.backends.sqlite.client.SqliteTransactionContext` because it is really only used by SQLite
- Add a few comments to the clients code. Hopefully, it will be a bit easier to read for the next person.
- Added documentation on transactions.

## Motivation and Context
This should fix https://github.com/tortoise/tortoise-orm/issues/1128.

## How Has This Been Tested?
`make ci` and running an app locally.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

