### PR TITLE
Fix backward_relations in PydanticMeta

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Changelog
 Fixed
 ^^^^^
 - Fixed a deadlock in three level nested transactions (#1810)
+- Fix backward_relations in PydanticMeta (#1814)
 
 
 0.22.2

--- a/tests/contrib/test_pydantic.py
+++ b/tests/contrib/test_pydantic.py
@@ -62,8 +62,7 @@ class TestPydantic(test.TestCase):
         await self.event2.participants.add(self.team1, self.team2)
         self.maxDiff = None
 
-    async def test_backward_relations(self):
-        # from meta_override:
+    async def test_backward_relations_with_meta_override(self):
         event_schema = copy.deepcopy(dict(self.Event_Pydantic.model_json_schema()))
         event_non_backward_schema_by_override = copy.deepcopy(
             dict(self.Event_Pydantic_non_backward_from_override.model_json_schema())
@@ -73,7 +72,7 @@ class TestPydantic(test.TestCase):
         del event_schema["properties"]["address"]
         self.assertEqual(event_schema["properties"], event_non_backward_schema_by_override["properties"])
 
-        # from PydanticMeta:
+    async def test_backward_relations_with_pydantic_meta(self):
         test_model1_schema = self.ModelTestPydanticMetaBackwardRelations1_Pydantic.model_json_schema()
         test_model2_schema = self.ModelTestPydanticMetaBackwardRelations2_Pydantic.model_json_schema()
         self.assertTrue("threes" in test_model2_schema["properties"])

--- a/tests/testmodels.py
+++ b/tests/testmodels.py
@@ -126,6 +126,24 @@ class Event(Model):
         return self.name
 
 
+class ModelTestPydanticMetaBackwardRelations1(Model):
+    class PydanticMeta:
+        backward_relations = False
+
+
+class ModelTestPydanticMetaBackwardRelations2(Model):
+    ...
+
+
+class ModelTestPydanticMetaBackwardRelations3(Model):
+    one: fields.ForeignKeyRelation[ModelTestPydanticMetaBackwardRelations1] = fields.ForeignKeyField(
+        "models.ModelTestPydanticMetaBackwardRelations1", related_name="threes"
+    )
+    two: fields.ForeignKeyRelation[ModelTestPydanticMetaBackwardRelations2] = fields.ForeignKeyField(
+        "models.ModelTestPydanticMetaBackwardRelations2", related_name="threes"
+    )
+
+
 class Node(Model):
     name = fields.CharField(max_length=10)
 

--- a/tortoise/contrib/pydantic/descriptions.py
+++ b/tortoise/contrib/pydantic/descriptions.py
@@ -113,7 +113,7 @@ class PydanticMetaData:
         exclude = tuple(get_param_from_pydantic_meta("exclude", default_meta.exclude))
         computed = tuple(get_param_from_pydantic_meta("computed", default_meta.computed))
         backward_relations = bool(
-            get_param_from_pydantic_meta("backward_relations_raw", default_meta.backward_relations)
+            get_param_from_pydantic_meta("backward_relations", default_meta.backward_relations)
         )
         max_recursion = int(
             get_param_from_pydantic_meta("max_recursion", default_meta.max_recursion)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
the `backward_relations` setting in PydanticMeta did not work, see #1806 

## Description
<!--- Describe your changes in detail -->
During refactoring, it somehow got messed up.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
current and added tests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

