### PR TITLE
fix: remove unused 'charset' in generate schema encoders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,5 @@ ENV/
 # MyPy caches
 .mypy_cache/
 
+# macos
+.DS_Store

--- a/tests/schema/models_postgres_fields.py
+++ b/tests/schema/models_postgres_fields.py
@@ -1,0 +1,13 @@
+from tortoise import Model
+from tortoise.contrib.postgres.fields import TSVectorField, ArrayField
+
+
+class PostgresFields(Model):
+    tsvector = TSVectorField()
+    text_array = ArrayField(element_type="text", default=["a", "b", "c"])
+    varchar_array = ArrayField(element_type="varchar(32)", default=["aa", "bbb", "cccc"])
+    int_array = ArrayField(element_type="int", default=[1, 2, 3])
+    real_array = ArrayField(element_type="real", default=[1.1, 2.2, 3.3])
+
+    class Meta:
+        table = "postgres_fields"

--- a/tests/schema/models_postgres_fields.py
+++ b/tests/schema/models_postgres_fields.py
@@ -6,8 +6,12 @@ class PostgresFields(Model):
     tsvector = TSVectorField()
     text_array = ArrayField(element_type="text", default=["a", "b", "c"])
     varchar_array = ArrayField(element_type="varchar(32)", default=["aa", "bbb", "cccc"])
-    int_array = ArrayField(element_type="int", default=[1, 2, 3])
-    real_array = ArrayField(element_type="real", default=[1.1, 2.2, 3.3])
+    int_array = ArrayField(element_type="int", default=[1, 2, 3], null=True)
+    real_array = ArrayField(
+        element_type="real",
+        default=[1.1, 2.2, 3.3],
+        description="this is array of real numbers",
+    )
 
     class Meta:
         table = "postgres_fields"

--- a/tests/schema/models_postgres_index.py
+++ b/tests/schema/models_postgres_index.py
@@ -1,5 +1,5 @@
 from tortoise import Model, fields
-from tortoise.contrib.postgres.fields import TSVectorField
+from tortoise.contrib.postgres.fields import TSVectorField, ArrayField
 from tortoise.contrib.postgres.indexes import (
     BloomIndex,
     BrinIndex,
@@ -19,6 +19,7 @@ class Index(Model):
     sp_gist = fields.CharField(max_length=200)
     hash = fields.CharField(max_length=200)
     partial = fields.CharField(max_length=200)
+    array = ArrayField(element_type="text", default=["a", "b", "c"])
 
     class Meta:
         indexes = [

--- a/tests/schema/models_postgres_index.py
+++ b/tests/schema/models_postgres_index.py
@@ -1,5 +1,5 @@
 from tortoise import Model, fields
-from tortoise.contrib.postgres.fields import TSVectorField, ArrayField
+from tortoise.contrib.postgres.fields import TSVectorField
 from tortoise.contrib.postgres.indexes import (
     BloomIndex,
     BrinIndex,
@@ -19,7 +19,6 @@ class Index(Model):
     sp_gist = fields.CharField(max_length=200)
     hash = fields.CharField(max_length=200)
     partial = fields.CharField(max_length=200)
-    array = ArrayField(element_type="text", default=["a", "b", "c"])
 
     class Meta:
         indexes = [

--- a/tests/schema/test_generate_schema.py
+++ b/tests/schema/test_generate_schema.py
@@ -1094,7 +1094,8 @@ CREATE UNIQUE INDEX IF NOT EXISTS "uidx_teamevents_event_i_664dbc" ON "teamevent
     "gist" TSVECTOR NOT NULL,
     "sp_gist" VARCHAR(200) NOT NULL,
     "hash" VARCHAR(200) NOT NULL,
-    "partial" VARCHAR(200) NOT NULL
+    "partial" VARCHAR(200) NOT NULL,
+    "array" TEXT[] NOT NULL  DEFAULT ('a','b','c')
 );
 CREATE INDEX "idx_index_bloom_280137" ON "index" USING BLOOM ("bloom");
 CREATE INDEX "idx_index_brin_a54a00" ON "index" USING BRIN ("brin");
@@ -1118,7 +1119,8 @@ CREATE INDEX "idx_index_partial_c5be6a" ON "index" USING  ("partial") WHERE id =
     "gist" TSVECTOR NOT NULL,
     "sp_gist" VARCHAR(200) NOT NULL,
     "hash" VARCHAR(200) NOT NULL,
-    "partial" VARCHAR(200) NOT NULL
+    "partial" VARCHAR(200) NOT NULL,
+    "array" TEXT[] NOT NULL  DEFAULT ('a','b','c')
 );
 CREATE INDEX IF NOT EXISTS "idx_index_bloom_280137" ON "index" USING BLOOM ("bloom");
 CREATE INDEX IF NOT EXISTS "idx_index_brin_a54a00" ON "index" USING BRIN ("brin");

--- a/tests/schema/test_generate_schema.py
+++ b/tests/schema/test_generate_schema.py
@@ -1094,8 +1094,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS "uidx_teamevents_event_i_664dbc" ON "teamevent
     "gist" TSVECTOR NOT NULL,
     "sp_gist" VARCHAR(200) NOT NULL,
     "hash" VARCHAR(200) NOT NULL,
-    "partial" VARCHAR(200) NOT NULL,
-    "array" TEXT[] NOT NULL  DEFAULT ('a','b','c')
+    "partial" VARCHAR(200) NOT NULL
 );
 CREATE INDEX "idx_index_bloom_280137" ON "index" USING BLOOM ("bloom");
 CREATE INDEX "idx_index_brin_a54a00" ON "index" USING BRIN ("brin");
@@ -1119,8 +1118,7 @@ CREATE INDEX "idx_index_partial_c5be6a" ON "index" USING  ("partial") WHERE id =
     "gist" TSVECTOR NOT NULL,
     "sp_gist" VARCHAR(200) NOT NULL,
     "hash" VARCHAR(200) NOT NULL,
-    "partial" VARCHAR(200) NOT NULL,
-    "array" TEXT[] NOT NULL  DEFAULT ('a','b','c')
+    "partial" VARCHAR(200) NOT NULL
 );
 CREATE INDEX IF NOT EXISTS "idx_index_bloom_280137" ON "index" USING BLOOM ("bloom");
 CREATE INDEX IF NOT EXISTS "idx_index_brin_a54a00" ON "index" USING BRIN ("brin");
@@ -1184,6 +1182,36 @@ CREATE TABLE "team_team" (
 );
 CREATE UNIQUE INDEX "uidx_team_team_team_re_d994df" ON "team_team" ("team_rel_id", "team_id");
 """.strip(),
+        )
+
+    async def test_pgfields_unsafe(self):
+        await self.init_for("tests.schema.models_postgres_fields")
+        sql = get_schema_sql(connections.get("default"), safe=False)
+        self.assertEqual(
+            sql,
+            """CREATE TABLE "postgres_fields" (
+    "id" SERIAL NOT NULL PRIMARY KEY,
+    "tsvector" TSVECTOR NOT NULL,
+    "text_array" TEXT[] NOT NULL  DEFAULT ('a','b','c'),
+    "varchar_array" VARCHAR(32)[] NOT NULL  DEFAULT ('aa','bbb','cccc'),
+    "int_array" INT[] NOT NULL  DEFAULT (1,2,3),
+    "real_array" REAL[] NOT NULL  DEFAULT (1.1,2.2,3.3)
+);""",
+        )
+
+    async def test_pgfields_safe(self):
+        await self.init_for("tests.schema.models_postgres_fields")
+        sql = get_schema_sql(connections.get("default"), safe=True)
+        self.assertEqual(
+            sql,
+            """CREATE TABLE IF NOT EXISTS "postgres_fields" (
+    "id" SERIAL NOT NULL PRIMARY KEY,
+    "tsvector" TSVECTOR NOT NULL,
+    "text_array" TEXT[] NOT NULL  DEFAULT ('a','b','c'),
+    "varchar_array" VARCHAR(32)[] NOT NULL  DEFAULT ('aa','bbb','cccc'),
+    "int_array" INT[] NOT NULL  DEFAULT (1,2,3),
+    "real_array" REAL[] NOT NULL  DEFAULT (1.1,2.2,3.3)
+);""",
         )
 
 

--- a/tests/schema/test_generate_schema.py
+++ b/tests/schema/test_generate_schema.py
@@ -1192,10 +1192,10 @@ CREATE UNIQUE INDEX "uidx_team_team_team_re_d994df" ON "team_team" ("team_rel_id
             """CREATE TABLE "postgres_fields" (
     "id" SERIAL NOT NULL PRIMARY KEY,
     "tsvector" TSVECTOR NOT NULL,
-    "text_array" TEXT[] NOT NULL DEFAULT ('a','b','c'),
-    "varchar_array" VARCHAR(32)[] NOT NULL DEFAULT ('aa','bbb','cccc'),
-    "int_array" INT[] DEFAULT (1,2,3),
-    "real_array" REAL[] NOT NULL DEFAULT (1.1,2.2,3.3)
+    "text_array" TEXT[] NOT NULL DEFAULT '{"a","b","c"}',
+    "varchar_array" VARCHAR(32)[] NOT NULL DEFAULT '{"aa","bbb","cccc"}',
+    "int_array" INT[] DEFAULT '{1,2,3}',
+    "real_array" REAL[] NOT NULL DEFAULT '{1.1,2.2,3.3}'
 );
 COMMENT ON COLUMN "postgres_fields"."real_array" IS 'this is array of real numbers';""",
         )
@@ -1208,10 +1208,10 @@ COMMENT ON COLUMN "postgres_fields"."real_array" IS 'this is array of real numbe
             """CREATE TABLE IF NOT EXISTS "postgres_fields" (
     "id" SERIAL NOT NULL PRIMARY KEY,
     "tsvector" TSVECTOR NOT NULL,
-    "text_array" TEXT[] NOT NULL DEFAULT ('a','b','c'),
-    "varchar_array" VARCHAR(32)[] NOT NULL DEFAULT ('aa','bbb','cccc'),
-    "int_array" INT[] DEFAULT (1,2,3),
-    "real_array" REAL[] NOT NULL DEFAULT (1.1,2.2,3.3)
+    "text_array" TEXT[] NOT NULL DEFAULT '{"a","b","c"}',
+    "varchar_array" VARCHAR(32)[] NOT NULL DEFAULT '{"aa","bbb","cccc"}',
+    "int_array" INT[] DEFAULT '{1,2,3}',
+    "real_array" REAL[] NOT NULL DEFAULT '{1.1,2.2,3.3}'
 );
 COMMENT ON COLUMN "postgres_fields"."real_array" IS 'this is array of real numbers';""",
         )

--- a/tests/schema/test_generate_schema.py
+++ b/tests/schema/test_generate_schema.py
@@ -39,28 +39,28 @@ CREATE TABLE IF NOT EXISTS "sometable" (
 );
 CREATE INDEX IF NOT EXISTS "idx_sometable_some_ch_3d69eb" ON "sometable" ("some_chars_table");
 CREATE TABLE IF NOT EXISTS "team" (
-    "name" VARCHAR(50) NOT NULL  PRIMARY KEY /* The TEAM name (and PK) */,
+    "name" VARCHAR(50) NOT NULL PRIMARY KEY /* The TEAM name (and PK) */,
     "key" INT NOT NULL,
     "manager_id" VARCHAR(50) REFERENCES "team" ("name") ON DELETE CASCADE
 ) /* The TEAMS! */;
 CREATE INDEX IF NOT EXISTS "idx_team_manager_676134" ON "team" ("manager_id", "key");
 CREATE INDEX IF NOT EXISTS "idx_team_manager_ef8f69" ON "team" ("manager_id", "name");
 CREATE TABLE IF NOT EXISTS "teamaddress" (
-    "city" VARCHAR(50) NOT NULL  /* City */,
-    "country" VARCHAR(50) NOT NULL  /* Country */,
-    "street" VARCHAR(128) NOT NULL  /* Street Address */,
-    "team_id" VARCHAR(50) NOT NULL  PRIMARY KEY REFERENCES "team" ("name") ON DELETE CASCADE
+    "city" VARCHAR(50) NOT NULL /* City */,
+    "country" VARCHAR(50) NOT NULL /* Country */,
+    "street" VARCHAR(128) NOT NULL /* Street Address */,
+    "team_id" VARCHAR(50) NOT NULL PRIMARY KEY REFERENCES "team" ("name") ON DELETE CASCADE
 ) /* The Team's address */;
 CREATE TABLE IF NOT EXISTS "tournament" (
     "tid" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-    "name" VARCHAR(100) NOT NULL  /* Tournament name */,
-    "created" TIMESTAMP NOT NULL  DEFAULT CURRENT_TIMESTAMP /* Created *\\/'`\\/* datetime */
+    "name" VARCHAR(100) NOT NULL /* Tournament name */,
+    "created" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP /* Created *\\/'`\\/* datetime */
 ) /* What Tournaments *\\/'`\\/* we have */;
 CREATE INDEX IF NOT EXISTS "idx_tournament_name_6fe200" ON "tournament" ("name");
 CREATE TABLE IF NOT EXISTS "event" (
     "id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL /* Event ID */,
     "name" TEXT NOT NULL,
-    "modified" TIMESTAMP NOT NULL  DEFAULT CURRENT_TIMESTAMP,
+    "modified" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "prize" VARCHAR(40),
     "token" VARCHAR(100) NOT NULL UNIQUE /* Unique token */,
     "key" VARCHAR(100) NOT NULL,
@@ -71,9 +71,9 @@ CREATE TABLE IF NOT EXISTS "event" (
 CREATE TABLE IF NOT EXISTS "venueinformation" (
     "id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     "name" VARCHAR(128) NOT NULL,
-    "capacity" INT NOT NULL  /* No. of seats */,
+    "capacity" INT NOT NULL /* No. of seats */,
     "rent" REAL NOT NULL,
-    "team_id" VARCHAR(50)  UNIQUE REFERENCES "team" ("name") ON DELETE SET NULL
+    "team_id" VARCHAR(50) UNIQUE REFERENCES "team" ("name") ON DELETE SET NULL
 );
 CREATE TABLE IF NOT EXISTS "sometable_self" (
     "backward_sts" INT NOT NULL REFERENCES "sometable" ("sometable_id") ON DELETE CASCADE,
@@ -226,7 +226,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS "uidx_teamevents_event_i_664dbc" ON "teamevent
         self.assertEqual(
             sql.strip(),
             r"""CREATE TABLE "team" (
-    "name" VARCHAR(50) NOT NULL  PRIMARY KEY /* The TEAM name (and PK) */,
+    "name" VARCHAR(50) NOT NULL PRIMARY KEY /* The TEAM name (and PK) */,
     "key" INT NOT NULL,
     "manager_id" VARCHAR(50)
 ) /* The TEAMS! */;
@@ -234,18 +234,18 @@ CREATE INDEX "idx_team_manager_676134" ON "team" ("manager_id", "key");
 CREATE INDEX "idx_team_manager_ef8f69" ON "team" ("manager_id", "name");
 CREATE TABLE "tournament" (
     "tid" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-    "name" VARCHAR(100) NOT NULL  /* Tournament name */,
-    "created" TIMESTAMP NOT NULL  DEFAULT CURRENT_TIMESTAMP /* Created *\/'`\/* datetime */
+    "name" VARCHAR(100) NOT NULL /* Tournament name */,
+    "created" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP /* Created *\/'`\/* datetime */
 ) /* What Tournaments *\/'`\/* we have */;
 CREATE INDEX "idx_tournament_name_6fe200" ON "tournament" ("name");
 CREATE TABLE "event" (
     "id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL /* Event ID */,
     "name" TEXT NOT NULL,
-    "modified" TIMESTAMP NOT NULL  DEFAULT CURRENT_TIMESTAMP,
+    "modified" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "prize" VARCHAR(40),
     "token" VARCHAR(100) NOT NULL UNIQUE /* Unique token */,
     "key" VARCHAR(100) NOT NULL,
-    "tournament_id" SMALLINT NOT NULL  /* FK to tournament */,
+    "tournament_id" SMALLINT NOT NULL /* FK to tournament */,
     CONSTRAINT "uid_event_name_c6f89f" UNIQUE ("name", "prize"),
     CONSTRAINT "uid_event_tournam_a5b730" UNIQUE ("tournament_id", "key")
 ) /* This table contains a list of all the events */;
@@ -297,28 +297,28 @@ CREATE TABLE "sometable" (
 );
 CREATE INDEX "idx_sometable_some_ch_3d69eb" ON "sometable" ("some_chars_table");
 CREATE TABLE "team" (
-    "name" VARCHAR(50) NOT NULL  PRIMARY KEY /* The TEAM name (and PK) */,
+    "name" VARCHAR(50) NOT NULL PRIMARY KEY /* The TEAM name (and PK) */,
     "key" INT NOT NULL,
     "manager_id" VARCHAR(50) REFERENCES "team" ("name") ON DELETE CASCADE
 ) /* The TEAMS! */;
 CREATE INDEX "idx_team_manager_676134" ON "team" ("manager_id", "key");
 CREATE INDEX "idx_team_manager_ef8f69" ON "team" ("manager_id", "name");
 CREATE TABLE "teamaddress" (
-    "city" VARCHAR(50) NOT NULL  /* City */,
-    "country" VARCHAR(50) NOT NULL  /* Country */,
-    "street" VARCHAR(128) NOT NULL  /* Street Address */,
-    "team_id" VARCHAR(50) NOT NULL  PRIMARY KEY REFERENCES "team" ("name") ON DELETE CASCADE
+    "city" VARCHAR(50) NOT NULL /* City */,
+    "country" VARCHAR(50) NOT NULL /* Country */,
+    "street" VARCHAR(128) NOT NULL /* Street Address */,
+    "team_id" VARCHAR(50) NOT NULL PRIMARY KEY REFERENCES "team" ("name") ON DELETE CASCADE
 ) /* The Team's address */;
 CREATE TABLE "tournament" (
     "tid" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-    "name" VARCHAR(100) NOT NULL  /* Tournament name */,
-    "created" TIMESTAMP NOT NULL  DEFAULT CURRENT_TIMESTAMP /* Created *\\/'`\\/* datetime */
+    "name" VARCHAR(100) NOT NULL /* Tournament name */,
+    "created" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP /* Created *\\/'`\\/* datetime */
 ) /* What Tournaments *\\/'`\\/* we have */;
 CREATE INDEX "idx_tournament_name_6fe200" ON "tournament" ("name");
 CREATE TABLE "event" (
     "id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL /* Event ID */,
     "name" TEXT NOT NULL,
-    "modified" TIMESTAMP NOT NULL  DEFAULT CURRENT_TIMESTAMP,
+    "modified" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "prize" VARCHAR(40),
     "token" VARCHAR(100) NOT NULL UNIQUE /* Unique token */,
     "key" VARCHAR(100) NOT NULL,
@@ -329,9 +329,9 @@ CREATE TABLE "event" (
 CREATE TABLE "venueinformation" (
     "id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     "name" VARCHAR(128) NOT NULL,
-    "capacity" INT NOT NULL  /* No. of seats */,
+    "capacity" INT NOT NULL /* No. of seats */,
     "rent" REAL NOT NULL,
-    "team_id" VARCHAR(50)  UNIQUE REFERENCES "team" ("name") ON DELETE SET NULL
+    "team_id" VARCHAR(50) UNIQUE REFERENCES "team" ("name") ON DELETE SET NULL
 );
 CREATE TABLE "sometable_self" (
     "backward_sts" INT NOT NULL REFERENCES "sometable" ("sometable_id") ON DELETE CASCADE,
@@ -364,7 +364,7 @@ CREATE UNIQUE INDEX "uidx_teamevents_event_i_664dbc" ON "teamevents" ("event_id"
         self.assertEqual(
             sql.strip(),
             r"""CREATE TABLE "team" (
-    "name" VARCHAR(50) NOT NULL  PRIMARY KEY /* The TEAM name (and PK) */,
+    "name" VARCHAR(50) NOT NULL PRIMARY KEY /* The TEAM name (and PK) */,
     "key" INT NOT NULL,
     "manager_id" VARCHAR(50) REFERENCES "team" ("name") ON DELETE CASCADE
 ) /* The TEAMS! */;
@@ -372,14 +372,14 @@ CREATE INDEX "idx_team_manager_676134" ON "team" ("manager_id", "key");
 CREATE INDEX "idx_team_manager_ef8f69" ON "team" ("manager_id", "name");
 CREATE TABLE "tournament" (
     "tid" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-    "name" VARCHAR(100) NOT NULL  /* Tournament name */,
-    "created" TIMESTAMP NOT NULL  DEFAULT CURRENT_TIMESTAMP /* Created *\/'`\/* datetime */
+    "name" VARCHAR(100) NOT NULL /* Tournament name */,
+    "created" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP /* Created *\/'`\/* datetime */
 ) /* What Tournaments *\/'`\/* we have */;
 CREATE INDEX "idx_tournament_name_6fe200" ON "tournament" ("name");
 CREATE TABLE "event" (
     "id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL /* Event ID */,
     "name" TEXT NOT NULL,
-    "modified" TIMESTAMP NOT NULL  DEFAULT CURRENT_TIMESTAMP,
+    "modified" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "prize" VARCHAR(40),
     "token" VARCHAR(100) NOT NULL UNIQUE /* Unique token */,
     "key" VARCHAR(100) NOT NULL,
@@ -473,7 +473,7 @@ class TestGenerateSchemaMySQL(TestGenerateSchema):
         self.assertEqual(
             sql.strip(),
             r"""CREATE TABLE `team` (
-    `name` VARCHAR(50) NOT NULL  PRIMARY KEY COMMENT 'The TEAM name (and PK)',
+    `name` VARCHAR(50) NOT NULL PRIMARY KEY COMMENT 'The TEAM name (and PK)',
     `key` INT NOT NULL,
     `manager_id` VARCHAR(50),
     KEY `idx_team_manager_676134` (`manager_id`, `key`),
@@ -481,18 +481,18 @@ class TestGenerateSchemaMySQL(TestGenerateSchema):
 ) CHARACTER SET utf8mb4 COMMENT='The TEAMS!';
 CREATE TABLE `tournament` (
     `tid` SMALLINT NOT NULL PRIMARY KEY AUTO_INCREMENT,
-    `name` VARCHAR(100) NOT NULL  COMMENT 'Tournament name',
-    `created` DATETIME(6) NOT NULL  COMMENT 'Created */\'`/* datetime' DEFAULT CURRENT_TIMESTAMP(6),
+    `name` VARCHAR(100) NOT NULL COMMENT 'Tournament name',
+    `created` DATETIME(6) NOT NULL COMMENT 'Created */\'`/* datetime' DEFAULT CURRENT_TIMESTAMP(6),
     KEY `idx_tournament_name_6fe200` (`name`)
 ) CHARACTER SET utf8mb4 COMMENT='What Tournaments */\'`/* we have';
 CREATE TABLE `event` (
     `id` BIGINT NOT NULL PRIMARY KEY AUTO_INCREMENT COMMENT 'Event ID',
     `name` LONGTEXT NOT NULL,
-    `modified` DATETIME(6) NOT NULL  DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    `modified` DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
     `prize` DECIMAL(10,2),
     `token` VARCHAR(100) NOT NULL UNIQUE COMMENT 'Unique token',
     `key` VARCHAR(100) NOT NULL,
-    `tournament_id` SMALLINT NOT NULL  COMMENT 'FK to tournament',
+    `tournament_id` SMALLINT NOT NULL COMMENT 'FK to tournament',
     UNIQUE KEY `uid_event_name_c6f89f` (`name`, `prize`),
     UNIQUE KEY `uid_event_tournam_a5b730` (`tournament_id`, `key`)
 ) CHARACTER SET utf8mb4 COMMENT='This table contains a list of all the events';
@@ -546,7 +546,7 @@ CREATE TABLE `sometable` (
     KEY `idx_sometable_some_ch_3d69eb` (`some_chars_table`)
 ) CHARACTER SET utf8mb4;
 CREATE TABLE `team` (
-    `name` VARCHAR(50) NOT NULL  PRIMARY KEY COMMENT 'The TEAM name (and PK)',
+    `name` VARCHAR(50) NOT NULL PRIMARY KEY COMMENT 'The TEAM name (and PK)',
     `key` INT NOT NULL,
     `manager_id` VARCHAR(50),
     CONSTRAINT `fk_team_team_9c77cd8f` FOREIGN KEY (`manager_id`) REFERENCES `team` (`name`) ON DELETE CASCADE,
@@ -554,22 +554,22 @@ CREATE TABLE `team` (
     KEY `idx_team_manager_ef8f69` (`manager_id`, `name`)
 ) CHARACTER SET utf8mb4 COMMENT='The TEAMS!';
 CREATE TABLE `teamaddress` (
-    `city` VARCHAR(50) NOT NULL  COMMENT 'City',
-    `country` VARCHAR(50) NOT NULL  COMMENT 'Country',
-    `street` VARCHAR(128) NOT NULL  COMMENT 'Street Address',
-    `team_id` VARCHAR(50) NOT NULL  PRIMARY KEY,
+    `city` VARCHAR(50) NOT NULL COMMENT 'City',
+    `country` VARCHAR(50) NOT NULL COMMENT 'Country',
+    `street` VARCHAR(128) NOT NULL COMMENT 'Street Address',
+    `team_id` VARCHAR(50) NOT NULL PRIMARY KEY,
     CONSTRAINT `fk_teamaddr_team_1c78d737` FOREIGN KEY (`team_id`) REFERENCES `team` (`name`) ON DELETE CASCADE
 ) CHARACTER SET utf8mb4 COMMENT='The Team\\'s address';
 CREATE TABLE `tournament` (
     `tid` SMALLINT NOT NULL PRIMARY KEY AUTO_INCREMENT,
-    `name` VARCHAR(100) NOT NULL  COMMENT 'Tournament name',
-    `created` DATETIME(6) NOT NULL  COMMENT 'Created */\\'`/* datetime' DEFAULT CURRENT_TIMESTAMP(6),
+    `name` VARCHAR(100) NOT NULL COMMENT 'Tournament name',
+    `created` DATETIME(6) NOT NULL COMMENT 'Created */\\'`/* datetime' DEFAULT CURRENT_TIMESTAMP(6),
     KEY `idx_tournament_name_6fe200` (`name`)
 ) CHARACTER SET utf8mb4 COMMENT='What Tournaments */\\'`/* we have';
 CREATE TABLE `event` (
     `id` BIGINT NOT NULL PRIMARY KEY AUTO_INCREMENT COMMENT 'Event ID',
     `name` LONGTEXT NOT NULL,
-    `modified` DATETIME(6) NOT NULL  DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    `modified` DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
     `prize` DECIMAL(10,2),
     `token` VARCHAR(100) NOT NULL UNIQUE COMMENT 'Unique token',
     `key` VARCHAR(100) NOT NULL,
@@ -581,9 +581,9 @@ CREATE TABLE `event` (
 CREATE TABLE `venueinformation` (
     `id` INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
     `name` VARCHAR(128) NOT NULL,
-    `capacity` INT NOT NULL  COMMENT 'No. of seats',
+    `capacity` INT NOT NULL COMMENT 'No. of seats',
     `rent` DOUBLE NOT NULL,
-    `team_id` VARCHAR(50)  UNIQUE,
+    `team_id` VARCHAR(50) UNIQUE,
     CONSTRAINT `fk_venueinf_team_198af929` FOREIGN KEY (`team_id`) REFERENCES `team` (`name`) ON DELETE SET NULL
 ) CHARACTER SET utf8mb4;
 CREATE TABLE `sometable_self` (
@@ -652,7 +652,7 @@ CREATE TABLE IF NOT EXISTS `sometable` (
     KEY `idx_sometable_some_ch_3d69eb` (`some_chars_table`)
 ) CHARACTER SET utf8mb4;
 CREATE TABLE IF NOT EXISTS `team` (
-    `name` VARCHAR(50) NOT NULL  PRIMARY KEY COMMENT 'The TEAM name (and PK)',
+    `name` VARCHAR(50) NOT NULL PRIMARY KEY COMMENT 'The TEAM name (and PK)',
     `key` INT NOT NULL,
     `manager_id` VARCHAR(50),
     CONSTRAINT `fk_team_team_9c77cd8f` FOREIGN KEY (`manager_id`) REFERENCES `team` (`name`) ON DELETE CASCADE,
@@ -660,22 +660,22 @@ CREATE TABLE IF NOT EXISTS `team` (
     KEY `idx_team_manager_ef8f69` (`manager_id`, `name`)
 ) CHARACTER SET utf8mb4 COMMENT='The TEAMS!';
 CREATE TABLE IF NOT EXISTS `teamaddress` (
-    `city` VARCHAR(50) NOT NULL  COMMENT 'City',
-    `country` VARCHAR(50) NOT NULL  COMMENT 'Country',
-    `street` VARCHAR(128) NOT NULL  COMMENT 'Street Address',
-    `team_id` VARCHAR(50) NOT NULL  PRIMARY KEY,
+    `city` VARCHAR(50) NOT NULL COMMENT 'City',
+    `country` VARCHAR(50) NOT NULL COMMENT 'Country',
+    `street` VARCHAR(128) NOT NULL COMMENT 'Street Address',
+    `team_id` VARCHAR(50) NOT NULL PRIMARY KEY,
     CONSTRAINT `fk_teamaddr_team_1c78d737` FOREIGN KEY (`team_id`) REFERENCES `team` (`name`) ON DELETE CASCADE
 ) CHARACTER SET utf8mb4 COMMENT='The Team\\'s address';
 CREATE TABLE IF NOT EXISTS `tournament` (
     `tid` SMALLINT NOT NULL PRIMARY KEY AUTO_INCREMENT,
-    `name` VARCHAR(100) NOT NULL  COMMENT 'Tournament name',
-    `created` DATETIME(6) NOT NULL  COMMENT 'Created */\\'`/* datetime' DEFAULT CURRENT_TIMESTAMP(6),
+    `name` VARCHAR(100) NOT NULL COMMENT 'Tournament name',
+    `created` DATETIME(6) NOT NULL COMMENT 'Created */\\'`/* datetime' DEFAULT CURRENT_TIMESTAMP(6),
     KEY `idx_tournament_name_6fe200` (`name`)
 ) CHARACTER SET utf8mb4 COMMENT='What Tournaments */\\'`/* we have';
 CREATE TABLE IF NOT EXISTS `event` (
     `id` BIGINT NOT NULL PRIMARY KEY AUTO_INCREMENT COMMENT 'Event ID',
     `name` LONGTEXT NOT NULL,
-    `modified` DATETIME(6) NOT NULL  DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    `modified` DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
     `prize` DECIMAL(10,2),
     `token` VARCHAR(100) NOT NULL UNIQUE COMMENT 'Unique token',
     `key` VARCHAR(100) NOT NULL,
@@ -687,9 +687,9 @@ CREATE TABLE IF NOT EXISTS `event` (
 CREATE TABLE IF NOT EXISTS `venueinformation` (
     `id` INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
     `name` VARCHAR(128) NOT NULL,
-    `capacity` INT NOT NULL  COMMENT 'No. of seats',
+    `capacity` INT NOT NULL COMMENT 'No. of seats',
     `rent` DOUBLE NOT NULL,
-    `team_id` VARCHAR(50)  UNIQUE,
+    `team_id` VARCHAR(50) UNIQUE,
     CONSTRAINT `fk_venueinf_team_198af929` FOREIGN KEY (`team_id`) REFERENCES `team` (`name`) ON DELETE SET NULL
 ) CHARACTER SET utf8mb4;
 CREATE TABLE IF NOT EXISTS `sometable_self` (
@@ -751,7 +751,7 @@ CREATE SPATIAL INDEX `idx_index_geometr_0b4dfb` ON `index` (`geometry`);""",
         self.assertEqual(
             sql.strip(),
             r"""CREATE TABLE `team` (
-    `name` VARCHAR(50) NOT NULL  PRIMARY KEY COMMENT 'The TEAM name (and PK)',
+    `name` VARCHAR(50) NOT NULL PRIMARY KEY COMMENT 'The TEAM name (and PK)',
     `key` INT NOT NULL,
     `manager_id` VARCHAR(50),
     CONSTRAINT `fk_team_team_9c77cd8f` FOREIGN KEY (`manager_id`) REFERENCES `team` (`name`) ON DELETE CASCADE,
@@ -760,14 +760,14 @@ CREATE SPATIAL INDEX `idx_index_geometr_0b4dfb` ON `index` (`geometry`);""",
 ) CHARACTER SET utf8mb4 COMMENT='The TEAMS!';
 CREATE TABLE `tournament` (
     `tid` SMALLINT NOT NULL PRIMARY KEY AUTO_INCREMENT,
-    `name` VARCHAR(100) NOT NULL  COMMENT 'Tournament name',
-    `created` DATETIME(6) NOT NULL  COMMENT 'Created */\'`/* datetime' DEFAULT CURRENT_TIMESTAMP(6),
+    `name` VARCHAR(100) NOT NULL COMMENT 'Tournament name',
+    `created` DATETIME(6) NOT NULL COMMENT 'Created */\'`/* datetime' DEFAULT CURRENT_TIMESTAMP(6),
     KEY `idx_tournament_name_6fe200` (`name`)
 ) CHARACTER SET utf8mb4 COMMENT='What Tournaments */\'`/* we have';
 CREATE TABLE `event` (
     `id` BIGINT NOT NULL PRIMARY KEY AUTO_INCREMENT COMMENT 'Event ID',
     `name` LONGTEXT NOT NULL,
-    `modified` DATETIME(6) NOT NULL  DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    `modified` DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
     `prize` DECIMAL(10,2),
     `token` VARCHAR(100) NOT NULL UNIQUE COMMENT 'Unique token',
     `key` VARCHAR(100) NOT NULL,
@@ -826,7 +826,7 @@ class GenerateSchemaPostgresSQL(TestGenerateSchema):
         self.assertEqual(
             sql.strip(),
             r"""CREATE TABLE "team" (
-    "name" VARCHAR(50) NOT NULL  PRIMARY KEY,
+    "name" VARCHAR(50) NOT NULL PRIMARY KEY,
     "key" INT NOT NULL,
     "manager_id" VARCHAR(50)
 );
@@ -837,7 +837,7 @@ COMMENT ON TABLE "team" IS 'The TEAMS!';
 CREATE TABLE "tournament" (
     "tid" SMALLSERIAL NOT NULL PRIMARY KEY,
     "name" VARCHAR(100) NOT NULL,
-    "created" TIMESTAMPTZ NOT NULL  DEFAULT CURRENT_TIMESTAMP
+    "created" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX "idx_tournament_name_6fe200" ON "tournament" ("name");
 COMMENT ON COLUMN "tournament"."name" IS 'Tournament name';
@@ -846,7 +846,7 @@ COMMENT ON TABLE "tournament" IS 'What Tournaments */''`/* we have';
 CREATE TABLE "event" (
     "id" BIGSERIAL NOT NULL PRIMARY KEY,
     "name" TEXT NOT NULL,
-    "modified" TIMESTAMPTZ NOT NULL  DEFAULT CURRENT_TIMESTAMP,
+    "modified" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "prize" DECIMAL(10,2),
     "token" VARCHAR(100) NOT NULL UNIQUE,
     "key" VARCHAR(100) NOT NULL,
@@ -907,7 +907,7 @@ CREATE TABLE "sometable" (
 );
 CREATE INDEX "idx_sometable_some_ch_3d69eb" ON "sometable" ("some_chars_table");
 CREATE TABLE "team" (
-    "name" VARCHAR(50) NOT NULL  PRIMARY KEY,
+    "name" VARCHAR(50) NOT NULL PRIMARY KEY,
     "key" INT NOT NULL,
     "manager_id" VARCHAR(50) REFERENCES "team" ("name") ON DELETE CASCADE
 );
@@ -919,7 +919,7 @@ CREATE TABLE "teamaddress" (
     "city" VARCHAR(50) NOT NULL,
     "country" VARCHAR(50) NOT NULL,
     "street" VARCHAR(128) NOT NULL,
-    "team_id" VARCHAR(50) NOT NULL  PRIMARY KEY REFERENCES "team" ("name") ON DELETE CASCADE
+    "team_id" VARCHAR(50) NOT NULL PRIMARY KEY REFERENCES "team" ("name") ON DELETE CASCADE
 );
 COMMENT ON COLUMN "teamaddress"."city" IS 'City';
 COMMENT ON COLUMN "teamaddress"."country" IS 'Country';
@@ -928,7 +928,7 @@ COMMENT ON TABLE "teamaddress" IS 'The Team''s address';
 CREATE TABLE "tournament" (
     "tid" SMALLSERIAL NOT NULL PRIMARY KEY,
     "name" VARCHAR(100) NOT NULL,
-    "created" TIMESTAMPTZ NOT NULL  DEFAULT CURRENT_TIMESTAMP
+    "created" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX "idx_tournament_name_6fe200" ON "tournament" ("name");
 COMMENT ON COLUMN "tournament"."name" IS 'Tournament name';
@@ -937,7 +937,7 @@ COMMENT ON TABLE "tournament" IS 'What Tournaments */''`/* we have';
 CREATE TABLE "event" (
     "id" BIGSERIAL NOT NULL PRIMARY KEY,
     "name" TEXT NOT NULL,
-    "modified" TIMESTAMPTZ NOT NULL  DEFAULT CURRENT_TIMESTAMP,
+    "modified" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "prize" DECIMAL(10,2),
     "token" VARCHAR(100) NOT NULL UNIQUE,
     "key" VARCHAR(100) NOT NULL,
@@ -954,7 +954,7 @@ CREATE TABLE "venueinformation" (
     "name" VARCHAR(128) NOT NULL,
     "capacity" INT NOT NULL,
     "rent" DOUBLE PRECISION NOT NULL,
-    "team_id" VARCHAR(50)  UNIQUE REFERENCES "team" ("name") ON DELETE SET NULL
+    "team_id" VARCHAR(50) UNIQUE REFERENCES "team" ("name") ON DELETE SET NULL
 );
 COMMENT ON COLUMN "venueinformation"."capacity" IS 'No. of seats';
 CREATE TABLE "sometable_self" (
@@ -1012,7 +1012,7 @@ CREATE TABLE IF NOT EXISTS "sometable" (
 );
 CREATE INDEX IF NOT EXISTS "idx_sometable_some_ch_3d69eb" ON "sometable" ("some_chars_table");
 CREATE TABLE IF NOT EXISTS "team" (
-    "name" VARCHAR(50) NOT NULL  PRIMARY KEY,
+    "name" VARCHAR(50) NOT NULL PRIMARY KEY,
     "key" INT NOT NULL,
     "manager_id" VARCHAR(50) REFERENCES "team" ("name") ON DELETE CASCADE
 );
@@ -1024,7 +1024,7 @@ CREATE TABLE IF NOT EXISTS "teamaddress" (
     "city" VARCHAR(50) NOT NULL,
     "country" VARCHAR(50) NOT NULL,
     "street" VARCHAR(128) NOT NULL,
-    "team_id" VARCHAR(50) NOT NULL  PRIMARY KEY REFERENCES "team" ("name") ON DELETE CASCADE
+    "team_id" VARCHAR(50) NOT NULL PRIMARY KEY REFERENCES "team" ("name") ON DELETE CASCADE
 );
 COMMENT ON COLUMN "teamaddress"."city" IS 'City';
 COMMENT ON COLUMN "teamaddress"."country" IS 'Country';
@@ -1033,7 +1033,7 @@ COMMENT ON TABLE "teamaddress" IS 'The Team''s address';
 CREATE TABLE IF NOT EXISTS "tournament" (
     "tid" SMALLSERIAL NOT NULL PRIMARY KEY,
     "name" VARCHAR(100) NOT NULL,
-    "created" TIMESTAMPTZ NOT NULL  DEFAULT CURRENT_TIMESTAMP
+    "created" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS "idx_tournament_name_6fe200" ON "tournament" ("name");
 COMMENT ON COLUMN "tournament"."name" IS 'Tournament name';
@@ -1042,7 +1042,7 @@ COMMENT ON TABLE "tournament" IS 'What Tournaments */''`/* we have';
 CREATE TABLE IF NOT EXISTS "event" (
     "id" BIGSERIAL NOT NULL PRIMARY KEY,
     "name" TEXT NOT NULL,
-    "modified" TIMESTAMPTZ NOT NULL  DEFAULT CURRENT_TIMESTAMP,
+    "modified" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "prize" DECIMAL(10,2),
     "token" VARCHAR(100) NOT NULL UNIQUE,
     "key" VARCHAR(100) NOT NULL,
@@ -1059,7 +1059,7 @@ CREATE TABLE IF NOT EXISTS "venueinformation" (
     "name" VARCHAR(128) NOT NULL,
     "capacity" INT NOT NULL,
     "rent" DOUBLE PRECISION NOT NULL,
-    "team_id" VARCHAR(50)  UNIQUE REFERENCES "team" ("name") ON DELETE SET NULL
+    "team_id" VARCHAR(50) UNIQUE REFERENCES "team" ("name") ON DELETE SET NULL
 );
 COMMENT ON COLUMN "venueinformation"."capacity" IS 'No. of seats';
 CREATE TABLE IF NOT EXISTS "sometable_self" (
@@ -1136,7 +1136,7 @@ CREATE INDEX IF NOT EXISTS "idx_index_partial_c5be6a" ON "index" USING  ("partia
         self.assertEqual(
             sql.strip(),
             r"""CREATE TABLE "team" (
-    "name" VARCHAR(50) NOT NULL  PRIMARY KEY,
+    "name" VARCHAR(50) NOT NULL PRIMARY KEY,
     "key" INT NOT NULL,
     "manager_id" VARCHAR(50) REFERENCES "team" ("name") ON DELETE CASCADE
 );
@@ -1147,7 +1147,7 @@ COMMENT ON TABLE "team" IS 'The TEAMS!';
 CREATE TABLE "tournament" (
     "tid" SMALLSERIAL NOT NULL PRIMARY KEY,
     "name" VARCHAR(100) NOT NULL,
-    "created" TIMESTAMPTZ NOT NULL  DEFAULT CURRENT_TIMESTAMP
+    "created" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX "idx_tournament_name_6fe200" ON "tournament" ("name");
 COMMENT ON COLUMN "tournament"."name" IS 'Tournament name';
@@ -1156,7 +1156,7 @@ COMMENT ON TABLE "tournament" IS 'What Tournaments */''`/* we have';
 CREATE TABLE "event" (
     "id" BIGSERIAL NOT NULL PRIMARY KEY,
     "name" TEXT NOT NULL,
-    "modified" TIMESTAMPTZ NOT NULL  DEFAULT CURRENT_TIMESTAMP,
+    "modified" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "prize" DECIMAL(10,2),
     "token" VARCHAR(100) NOT NULL UNIQUE,
     "key" VARCHAR(100) NOT NULL,
@@ -1192,11 +1192,12 @@ CREATE UNIQUE INDEX "uidx_team_team_team_re_d994df" ON "team_team" ("team_rel_id
             """CREATE TABLE "postgres_fields" (
     "id" SERIAL NOT NULL PRIMARY KEY,
     "tsvector" TSVECTOR NOT NULL,
-    "text_array" TEXT[] NOT NULL  DEFAULT ('a','b','c'),
-    "varchar_array" VARCHAR(32)[] NOT NULL  DEFAULT ('aa','bbb','cccc'),
-    "int_array" INT[] NOT NULL  DEFAULT (1,2,3),
-    "real_array" REAL[] NOT NULL  DEFAULT (1.1,2.2,3.3)
-);""",
+    "text_array" TEXT[] NOT NULL DEFAULT ('a','b','c'),
+    "varchar_array" VARCHAR(32)[] NOT NULL DEFAULT ('aa','bbb','cccc'),
+    "int_array" INT[] DEFAULT (1,2,3),
+    "real_array" REAL[] NOT NULL DEFAULT (1.1,2.2,3.3)
+);
+COMMENT ON COLUMN "postgres_fields"."real_array" IS 'this is array of real numbers';""",
         )
 
     async def test_pgfields_safe(self):
@@ -1207,11 +1208,12 @@ CREATE UNIQUE INDEX "uidx_team_team_team_re_d994df" ON "team_team" ("team_rel_id
             """CREATE TABLE IF NOT EXISTS "postgres_fields" (
     "id" SERIAL NOT NULL PRIMARY KEY,
     "tsvector" TSVECTOR NOT NULL,
-    "text_array" TEXT[] NOT NULL  DEFAULT ('a','b','c'),
-    "varchar_array" VARCHAR(32)[] NOT NULL  DEFAULT ('aa','bbb','cccc'),
-    "int_array" INT[] NOT NULL  DEFAULT (1,2,3),
-    "real_array" REAL[] NOT NULL  DEFAULT (1.1,2.2,3.3)
-);""",
+    "text_array" TEXT[] NOT NULL DEFAULT ('a','b','c'),
+    "varchar_array" VARCHAR(32)[] NOT NULL DEFAULT ('aa','bbb','cccc'),
+    "int_array" INT[] DEFAULT (1,2,3),
+    "real_array" REAL[] NOT NULL DEFAULT (1.1,2.2,3.3)
+);
+COMMENT ON COLUMN "postgres_fields"."real_array" IS 'this is array of real numbers';""",
         )
 
 

--- a/tortoise/backends/base/schema_generator.py
+++ b/tortoise/backends/base/schema_generator.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:  # pragma: nocoverage
 class BaseSchemaGenerator:
     DIALECT = "sql"
     TABLE_CREATE_TEMPLATE = 'CREATE TABLE {exists}"{table_name}" ({fields}){extra}{comment};'
-    FIELD_TEMPLATE = '"{name}" {type} {nullable} {unique}{primary}{default}{comment}'
+    FIELD_TEMPLATE = '"{name}" {type}{nullable}{unique}{primary}{default}{comment}'
     INDEX_CREATE_TEMPLATE = 'CREATE INDEX {exists}"{index_name}" ON "{table_name}" ({fields});'
     UNIQUE_INDEX_CREATE_TEMPLATE = INDEX_CREATE_TEMPLATE.replace(" INDEX", " UNIQUE INDEX")
     UNIQUE_CONSTRAINT_CREATE_TEMPLATE = 'CONSTRAINT "{index_name}" UNIQUE ({fields})'
@@ -251,8 +251,8 @@ class BaseSchemaGenerator:
                         )
                         continue
 
-            nullable = "NOT NULL" if not field_object.null else ""
-            unique = "UNIQUE" if field_object.unique else ""
+            nullable = " NOT NULL" if not field_object.null else ""
+            unique = " UNIQUE" if field_object.unique else ""
 
             if getattr(field_object, "reference", None):
                 reference = cast("ForeignKeyFieldInstance", field_object.reference)

--- a/tortoise/backends/mssql/schema_generator.py
+++ b/tortoise/backends/mssql/schema_generator.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:  # pragma: nocoverage
 class MSSQLSchemaGenerator(BaseSchemaGenerator):
     DIALECT = "mssql"
     TABLE_CREATE_TEMPLATE = "CREATE TABLE [{table_name}] ({fields}){extra};"
-    FIELD_TEMPLATE = "[{name}] {type} {nullable} {unique}{primary}{default}"
+    FIELD_TEMPLATE = "[{name}] {type}{nullable}{unique}{primary}{default}"
     INDEX_CREATE_TEMPLATE = "CREATE INDEX [{index_name}] ON [{table_name}] ({fields});"
     GENERATED_PK_TEMPLATE = "[{field_name}] {generated_sql}"
     FK_TEMPLATE = (

--- a/tortoise/backends/mysql/schema_generator.py
+++ b/tortoise/backends/mysql/schema_generator.py
@@ -14,7 +14,7 @@ class MySQLSchemaGenerator(BaseSchemaGenerator):
     INDEX_CREATE_TEMPLATE = "KEY `{index_name}` ({fields})"
     UNIQUE_CONSTRAINT_CREATE_TEMPLATE = "UNIQUE KEY `{index_name}` ({fields})"
     UNIQUE_INDEX_CREATE_TEMPLATE = UNIQUE_CONSTRAINT_CREATE_TEMPLATE
-    FIELD_TEMPLATE = "`{name}` {type} {nullable} {unique}{primary}{comment}{default}"
+    FIELD_TEMPLATE = "`{name}` {type}{nullable}{unique}{primary}{comment}{default}"
     GENERATED_PK_TEMPLATE = "`{field_name}` {generated_sql}{comment}"
     FK_TEMPLATE = (
         "{constraint}FOREIGN KEY (`{db_column}`)"

--- a/tortoise/backends/oracle/schema_generator.py
+++ b/tortoise/backends/oracle/schema_generator.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:  # pragma: nocoverage
 class OracleSchemaGenerator(BaseSchemaGenerator):
     DIALECT = "oracle"
     TABLE_CREATE_TEMPLATE = 'CREATE TABLE "{table_name}" ({fields}){extra};'
-    FIELD_TEMPLATE = '"{name}" {type}{default} {nullable} {unique}{primary}'
+    FIELD_TEMPLATE = '"{name}" {type}{default}{nullable}{unique}{primary}'
     TABLE_COMMENT_TEMPLATE = "COMMENT ON TABLE \"{table}\" IS '{comment}';"
     COLUMN_COMMENT_TEMPLATE = 'COMMENT ON COLUMN "{table}"."{column}" IS \'{comment}\';'
     INDEX_CREATE_TEMPLATE = 'CREATE INDEX "{index_name}" ON "{table_name}" ({fields});'

--- a/tortoise/backends/sqlite/client.py
+++ b/tortoise/backends/sqlite/client.py
@@ -57,7 +57,12 @@ class SqliteClient(BaseDBAsyncClient):
     query_class = SQLLiteQuery
     schema_generator = SqliteSchemaGenerator
     capabilities = Capabilities(
-        "sqlite", daemon=False, requires_limit=True, inline_comment=True, support_for_update=False
+        "sqlite",
+        daemon=False,
+        requires_limit=True,
+        inline_comment=True,
+        support_for_update=False,
+        support_update_limit_order_by=False,
     )
 
     def __init__(self, file_path: str, **kwargs: Any) -> None:

--- a/tortoise/contrib/postgres/fields.py
+++ b/tortoise/contrib/postgres/fields.py
@@ -10,7 +10,7 @@ class TSVectorField(Field):
 class ArrayField(Field, list):  # type: ignore
     def __init__(self, element_type: str = "int", **kwargs: Any):
         super().__init__(**kwargs)
-        self.element_type = element_type
+        self.element_type = element_type.upper()
 
     @property
     def SQL_TYPE(self) -> str:  # type: ignore

--- a/tortoise/converters.py
+++ b/tortoise/converters.py
@@ -25,7 +25,7 @@ def _escape_unicode(value: str, mapping=None) -> str:
 escape_string = _escape_unicode
 
 
-def escape_item(val: Any, charset, mapping=None) -> str:
+def escape_item(val: Any, mapping=None) -> str:
     if mapping is None:
         mapping = encoders
     encoder = mapping.get(type(val))
@@ -37,31 +37,28 @@ def escape_item(val: Any, charset, mapping=None) -> str:
         except KeyError:
             raise TypeError("no default type converter defined")
 
-    if encoder in (escape_dict, escape_sequence):
-        val = encoder(val, charset, mapping)
-    else:
-        val = encoder(val, mapping)
+    val = encoder(val, mapping)
     return val
 
 
-def escape_dict(val: Dict, charset, mapping=None) -> dict:
+def escape_dict(val: Dict, mapping=None) -> dict:
     n = {}
     for k, v in val.items():
-        quoted = escape_item(v, charset, mapping)
+        quoted = escape_item(v, mapping)
         n[k] = quoted
     return n
 
 
-def escape_sequence(val: Sequence, charset, mapping=None) -> str:
+def escape_sequence(val: Sequence, mapping=None) -> str:
     n = []
     for item in val:
-        quoted = escape_item(item, charset, mapping)
+        quoted = escape_item(item, mapping)
         n.append(quoted)
     return "(" + ",".join(n) + ")"
 
 
-def escape_set(val: Set, charset, mapping=None) -> str:
-    return ",".join([escape_item(x, charset, mapping) for x in val])
+def escape_set(val: Set, mapping=None) -> str:
+    return ",".join([escape_item(x, mapping) for x in val])
 
 
 def escape_bool(value: bool, mapping=None) -> str:

--- a/tortoise/converters.py
+++ b/tortoise/converters.py
@@ -26,16 +26,20 @@ escape_string = _escape_unicode
 
 
 def escape_item(val: Any, mapping=None) -> str:
+    if isinstance(val, str):
+        return f'"{val}"'
+
     if mapping is None:
         mapping = encoders
+
     encoder = mapping.get(type(val))
 
     # Fallback to default when no encoder found
     if not encoder:
         try:
             encoder = mapping[str]
-        except KeyError:
-            raise TypeError("no default type converter defined")
+        except KeyError as exc:
+            raise TypeError("no default type converter defined") from exc
 
     val = encoder(val, mapping)
     return val
@@ -54,7 +58,7 @@ def escape_sequence(val: Sequence, mapping=None) -> str:
     for item in val:
         quoted = escape_item(item, mapping)
         n.append(quoted)
-    return "(" + ",".join(n) + ")"
+    return "'{" + ",".join(n) + "}'"
 
 
 def escape_set(val: Set, mapping=None) -> str:


### PR DESCRIPTION
Remove unused 'charset' in generate schema encoders

## Description

- remove unused 'charset' in generate schema encoders
- update element_type in ArrayField of postgres to be uppercase
- remove extra spaces when generate schema
- Fixes incorrect handling of default value `ArrayField` - use {} wrap in default value for postgres array field as in https://www.postgresql.org/docs/current/arrays.html#ARRAYS-INPUT
- add sqlite.capabilities support_update_limit_order_by=False because sqlite does not support it

## Motivation and Context

Error when using `get_schema_sql` on ArrayField with default value

```bash
self = <tortoise.backends.asyncpg.schema_generator.AsyncpgSchemaGenerator object at 0x106f28440>, default = [0, 0, 0, 0]

    def _escape_default_value(self, default: Any):
        if isinstance(default, bool):
            return default
>       return encoders.get(type(default))(default)  # type: ignore
E       TypeError: escape_sequence() missing 1 required positional argument: 'charset'
```

Encoders functions should accept the same number of arguments

## How Has This Been Tested?

Update `tests/schema/models_postgres_index.py`, `tests/schema/test_generate_schema.py` and run `make test`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

