### PR TITLE
refactor: only replace password by star when logging level is debug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,11 @@ checkfiles = tortoise/ examples/ tests/ conftest.py
 py_warn = PYTHONDEVMODE=1
 pytest_opts = -n auto --cov=tortoise --cov-append --tb=native -q
 
+TORTOISE_MYSQL_PASS ?= 123456
+TORTOISE_POSTGRES_PASS ?= 123456
+TORTOISE_MSSQL_PASS ?= 123456
+TORTOISE_ORACLE_PASS ?= 123456
+
 help:
 	@echo  "Tortoise ORM development makefile"
 	@echo
@@ -76,10 +81,10 @@ docs: deps
 	rm -fR ./build
 	sphinx-build -M html docs build
 
+style: deps _style
 _style:
 	isort -src $(checkfiles)
 	black $(checkfiles)
-style: _style deps
 
 build: deps
 	rm -fR dist/

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -11,7 +11,6 @@ from copy import deepcopy
 from inspect import isclass
 from types import ModuleType
 from typing import Any, Callable, Coroutine, Iterable, Type, cast
-from urllib.parse import quote_plus
 
 from pypika import Query, Table
 
@@ -500,24 +499,7 @@ class Tortoise:
         cls.table_name_generator = table_name_generator
 
         if logger.isEnabledFor(logging.DEBUG):
-            # Mask passwords in logs output
-            passwords = []
-            for name, info in connections_config.items():
-                if isinstance(info, str):
-                    info = expand_db_url(info)
-                if password := info.get("credentials", {}).get("password"):
-                    passwords.append(password)
-
-            str_connection_config = str(connections_config)
-            for password in passwords:
-                # Show one third of the password at beginning (may be better for debugging purposes)
-                star_passwd = f"{password[0:len(password) // 3]}***"
-                if (quoted_passwd := quote_plus(password)) in str_connection_config:
-                    str_connection_config = str_connection_config.replace(
-                        quoted_passwd, star_passwd
-                    )
-                else:
-                    str_connection_config = str_connection_config.replace(password, star_passwd)
+            str_connection_config = cls.star_password(connections_config)
             logger.debug(
                 "Tortoise-ORM startup\n    connections: %s\n    apps: %s",
                 str_connection_config,
@@ -530,6 +512,25 @@ class Tortoise:
         cls._init_routers(routers)
 
         cls._inited = True
+
+    @staticmethod
+    def star_password(connections_config) -> str:
+        # Mask passwords to hide sensitive information in logs output
+        passwords = []
+        for name, info in connections_config.items():
+            if isinstance(info, str):
+                info = expand_db_url(info)
+            if password := info.get("credentials", {}).get("password"):
+                passwords.append(password)
+
+        str_connection_config = str(connections_config)
+        for password in passwords:
+            str_connection_config = str_connection_config.replace(
+                password,
+                # Show one third of the password at beginning (may be better for debugging purposes)
+                f"{password[0:len(password) // 3]}***",
+            )
+        return str_connection_config
 
     @classmethod
     def _init_routers(cls, routers: list[str | type] | None = None) -> None:

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -4,12 +4,14 @@ import asyncio
 import importlib
 import importlib.metadata as importlib_metadata
 import json
+import logging
 import os
 import warnings
 from copy import deepcopy
 from inspect import isclass
 from types import ModuleType
 from typing import Any, Callable, Coroutine, Iterable, Type, cast
+from urllib.parse import quote_plus
 
 from pypika import Query, Table
 
@@ -497,27 +499,30 @@ class Tortoise:
 
         cls.table_name_generator = table_name_generator
 
-        # Mask passwords in logs output
-        passwords = []
-        for name, info in connections_config.items():
-            if isinstance(info, str):
-                info = expand_db_url(info)
-            if password := info.get("credentials", {}).get("password"):
-                passwords.append(password)
+        if logger.isEnabledFor(logging.DEBUG):
+            # Mask passwords in logs output
+            passwords = []
+            for name, info in connections_config.items():
+                if isinstance(info, str):
+                    info = expand_db_url(info)
+                if password := info.get("credentials", {}).get("password"):
+                    passwords.append(password)
 
-        str_connection_config = str(connections_config)
-        for password in passwords:
-            str_connection_config = str_connection_config.replace(
-                password,
+            str_connection_config = str(connections_config)
+            for password in passwords:
                 # Show one third of the password at beginning (may be better for debugging purposes)
-                f"{password[0:len(password) // 3]}***",
+                star_passwd = f"{password[0:len(password) // 3]}***"
+                if (quoted_passwd := quote_plus(password)) in str_connection_config:
+                    str_connection_config = str_connection_config.replace(
+                        quoted_passwd, star_passwd
+                    )
+                else:
+                    str_connection_config = str_connection_config.replace(password, star_passwd)
+            logger.debug(
+                "Tortoise-ORM startup\n    connections: %s\n    apps: %s",
+                str_connection_config,
+                str(apps_config),
             )
-
-        logger.debug(
-            "Tortoise-ORM startup\n    connections: %s\n    apps: %s",
-            str_connection_config,
-            str(apps_config),
-        )
 
         cls._init_timezone(use_tz, timezone)
         await connections._init(connections_config, _create_db)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
There are 20 lines about the logger.debug(...) in `tortoise.Tortoise.init`
This wasting my time to understand the logic of this function.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
1. Move password padding logic to a staticmethod
2. Indent the logger.debug to be under a `if logger.isEnabledFor(logging.DEBUG):`, so that people who don't care the logger can ignore it

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

