### PR TITLE
chore: add `__repr__` to Index class

### DIFF
--- a/tests/contrib/test_pydantic.py
+++ b/tests/contrib/test_pydantic.py
@@ -9,10 +9,10 @@ from tests.testmodels import (
     Employee,
     EnumFields,
     Event,
-    ModelTestPydanticMetaBackwardRelations1,
-    ModelTestPydanticMetaBackwardRelations2,
     IntFields,
     JSONFields,
+    ModelTestPydanticMetaBackwardRelations1,
+    ModelTestPydanticMetaBackwardRelations2,
     Reporter,
     Team,
     Tournament,
@@ -70,11 +70,17 @@ class TestPydantic(test.TestCase):
         self.assertTrue("address" in event_schema["properties"])
         self.assertFalse("address" in event_non_backward_schema_by_override["properties"])
         del event_schema["properties"]["address"]
-        self.assertEqual(event_schema["properties"], event_non_backward_schema_by_override["properties"])
+        self.assertEqual(
+            event_schema["properties"], event_non_backward_schema_by_override["properties"]
+        )
 
     async def test_backward_relations_with_pydantic_meta(self):
-        test_model1_schema = self.ModelTestPydanticMetaBackwardRelations1_Pydantic.model_json_schema()
-        test_model2_schema = self.ModelTestPydanticMetaBackwardRelations2_Pydantic.model_json_schema()
+        test_model1_schema = (
+            self.ModelTestPydanticMetaBackwardRelations1_Pydantic.model_json_schema()
+        )
+        test_model2_schema = (
+            self.ModelTestPydanticMetaBackwardRelations2_Pydantic.model_json_schema()
+        )
         self.assertTrue("threes" in test_model2_schema["properties"])
         self.assertFalse("threes" in test_model1_schema["properties"])
         del test_model2_schema["properties"]["threes"]

--- a/tests/fields/test_db_index.py
+++ b/tests/fields/test_db_index.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+from pypika.terms import Field
+
 from tortoise import fields
 from tortoise.contrib import test
 from tortoise.exceptions import ConfigurationError
@@ -12,7 +14,7 @@ class CustomIndex(Index):
         self._foo = ""
 
 
-class TestIndexHashEqual(test.TestCase):
+class TestIndexHashEqualRepr(test.TestCase):
     def test_index_eq(self):
         assert Index(fields=("id",)) == Index(fields=("id",))
         assert CustomIndex(fields=("id",)) == CustomIndex(fields=("id",))
@@ -37,6 +39,15 @@ class TestIndexHashEqual(test.TestCase):
         assert len(indexes) == 2
         indexes.add(Index(fields=("name",)))
         assert len(indexes) == 3
+
+    def test_index_repr(self):
+        assert repr(Index(fields=("id",))) == "Index(fields=['id'])"
+        assert repr(Index(fields=("id", "name"))) == "Index(fields=['id', 'name'])"
+        assert repr(Index(fields=("id",), name="MyIndex")) == "Index(fields=['id'], name='MyIndex')"
+        assert repr(Index(Field("id"))) == f'Index({str(Field("id"))})'
+        assert repr(Index(Field("a"), name="Id")) == f"Index({str(Field('a'))}, name='Id')"
+        with self.assertRaises(ValueError):
+            Index(Field("id"), fields=("name",))
 
 
 class TestIndexAlias(test.TestCase):

--- a/tests/testmodels.py
+++ b/tests/testmodels.py
@@ -131,16 +131,19 @@ class ModelTestPydanticMetaBackwardRelations1(Model):
         backward_relations = False
 
 
-class ModelTestPydanticMetaBackwardRelations2(Model):
-    ...
+class ModelTestPydanticMetaBackwardRelations2(Model): ...
 
 
 class ModelTestPydanticMetaBackwardRelations3(Model):
-    one: fields.ForeignKeyRelation[ModelTestPydanticMetaBackwardRelations1] = fields.ForeignKeyField(
-        "models.ModelTestPydanticMetaBackwardRelations1", related_name="threes"
+    one: fields.ForeignKeyRelation[ModelTestPydanticMetaBackwardRelations1] = (
+        fields.ForeignKeyField(
+            "models.ModelTestPydanticMetaBackwardRelations1", related_name="threes"
+        )
     )
-    two: fields.ForeignKeyRelation[ModelTestPydanticMetaBackwardRelations2] = fields.ForeignKeyField(
-        "models.ModelTestPydanticMetaBackwardRelations2", related_name="threes"
+    two: fields.ForeignKeyRelation[ModelTestPydanticMetaBackwardRelations2] = (
+        fields.ForeignKeyField(
+            "models.ModelTestPydanticMetaBackwardRelations2", related_name="threes"
+        )
     )
 
 

--- a/tortoise/indexes.py
+++ b/tortoise/indexes.py
@@ -1,4 +1,6 @@
-from typing import TYPE_CHECKING, Any, Optional, Tuple, Type
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Type
 
 from pypika.terms import Term, ValueWrapper
 
@@ -16,8 +18,8 @@ class Index:
     def __init__(
         self,
         *expressions: Term,
-        fields: Optional[Tuple[str, ...]] = None,
-        name: Optional[str] = None,
+        fields: tuple[str, ...] | list[str] | None = None,
+        name: str | None = None,
     ) -> None:
         """
         All kinds of index parent class, default is BTreeIndex.
@@ -37,6 +39,16 @@ class Index:
         self.name = name
         self.expressions = expressions
         self.extra = ""
+
+    def __repr__(self) -> str:
+        argument = ""
+        if self.expressions:
+            argument += ", ".join(map(str, self.expressions))
+        if fields := self.fields:
+            argument += f"{fields=}"
+        if name := self.name:
+            argument += f", {name=}"
+        return self.__class__.__name__ + "(" + argument + ")"
 
     def get_sql(
         self, schema_generator: "BaseSchemaGenerator", model: "Type[Model]", safe: bool
@@ -70,9 +82,9 @@ class PartialIndex(Index):
     def __init__(
         self,
         *expressions: Term,
-        fields: Optional[Tuple[str, ...]] = None,
-        name: Optional[str] = None,
-        condition: Optional[dict] = None,
+        fields: tuple[str, ...] | list[str] | None = None,
+        name: str | None = None,
+        condition: dict | None = None,
     ) -> None:
         super().__init__(*expressions, fields=fields, name=name)
         if condition:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
1. Add `__repr__` to the Index class
2. Update type hint for the `fields` argument in Index `__init__` to support both `tuple[str, ...]` and `list[str]` instead of only `tuple[str, ...]`
3. `tests/contrib/test_pydantic.py` and `tests/testmodels.py` was auto changed by `make style`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Without the custom `__repr__`, Index class display like this:
```ipython
--> python -m IPython
Python 3.10.12 (main, Nov  6 2024, 20:22:13) [GCC 11.4.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.30.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from tortoise.indexes import Index

In [2]: Index(fields=('id',))
Out[2]: <tortoise.indexes.Index at 0x7ff40999ed40>
```
After it added:
```py
In [1]: from tortoise.indexes import Index

In [2]: Index(fields=('id',))
Out[2]: Index(fields=['id'])

In [3]: idx = Index(fields=('id', 'name'))

In [4]: f'{idx = }'
Out[4]: "idx = Index(fields=['id', 'name'])"
```
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

