### PR TITLE
Fix concurrent initialization of connection pool

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,12 @@ Changelog
 0.23
 ====
 
+0.23.1
+------
+Fixed
+^^^^^
+- Concurrent connection pool initialization (#1825)
+
 0.23.0
 ------
 Added

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -399,7 +399,9 @@ class Tortoise:
         table_name_generator: Callable[[Type["Model"]], str] | None = None,
     ) -> None:
         """
-        Sets up Tortoise-ORM.
+        Sets up Tortoise-ORM: loads apps and models, configures database connections but does not
+        connect to the database yet. The actual connection or connection pool is established
+        lazily on first query execution.
 
         You can configure using only one of ``config``, ``config_file``
         and ``(db_url, modules)``.

--- a/tortoise/backends/asyncpg/client.py
+++ b/tortoise/backends/asyncpg/client.py
@@ -100,10 +100,10 @@ class AsyncpgDBClient(BasePostgresClient):
         await self.close()
 
     def acquire_connection(self) -> Union["PoolConnectionWrapper", "ConnectionWrapper"]:
-        return PoolConnectionWrapper(self)
+        return PoolConnectionWrapper(self, self._pool_init_lock)
 
     def _in_transaction(self) -> "TransactionContext":
-        return TransactionContextPooled(TransactionWrapper(self))
+        return TransactionContextPooled(TransactionWrapper(self), self._pool_init_lock)
 
     @translate_exceptions
     async def execute_insert(self, query: str, values: list) -> Optional[asyncpg.Record]:

--- a/tortoise/backends/base_postgres/client.py
+++ b/tortoise/backends/base_postgres/client.py
@@ -1,4 +1,5 @@
 import abc
+import asyncio
 from asyncio.events import AbstractEventLoop
 from functools import wraps
 from typing import (
@@ -90,6 +91,7 @@ class BasePostgresClient(BaseDBAsyncClient, abc.ABC):
         self._template: dict = {}
         self._pool = None
         self._connection = None
+        self._pool_init_lock = asyncio.Lock()
 
     @abc.abstractmethod
     async def create_connection(self, with_db: bool) -> None:
@@ -128,7 +130,7 @@ class BasePostgresClient(BaseDBAsyncClient, abc.ABC):
             await self.close()
 
     def acquire_connection(self) -> Union["ConnectionWrapper", "PoolConnectionWrapper"]:
-        return PoolConnectionWrapper(self._pool)
+        return PoolConnectionWrapper(self._pool, self._pool_init_lock)
 
     @abc.abstractmethod
     def _in_transaction(self) -> "TransactionContext":

--- a/tortoise/backends/mssql/client.py
+++ b/tortoise/backends/mssql/client.py
@@ -41,7 +41,7 @@ class MSSQLClient(ODBCClient):
         self.dsn = f"DRIVER={driver};SERVER={host},{port};UID={user};PWD={password};"
 
     def _in_transaction(self) -> "TransactionContext":
-        return TransactionContextPooled(TransactionWrapper(self))
+        return TransactionContextPooled(TransactionWrapper(self), self._pool_init_lock)
 
     @translate_exceptions
     async def execute_insert(self, query: str, values: list) -> int:

--- a/tortoise/backends/odbc/client.py
+++ b/tortoise/backends/odbc/client.py
@@ -70,6 +70,7 @@ class ODBCClient(BaseDBAsyncClient, ABC):
         self._template: dict = {}
         self._pool: Optional[asyncodbc.Pool] = None
         self._connection = None
+        self._pool_init_lock = asyncio.Lock()
 
     async def create_connection(self, with_db: bool) -> None:
         self._template = {
@@ -114,7 +115,7 @@ class ODBCClient(BaseDBAsyncClient, ABC):
             self._pool = None
 
     def acquire_connection(self) -> ConnWrapperType:
-        return PoolConnectionWrapper(self)
+        return PoolConnectionWrapper(self, self._pool_init_lock)
 
     @translate_exceptions
     async def execute_many(self, query: str, values: list) -> None:

--- a/tortoise/backends/oracle/client.py
+++ b/tortoise/backends/oracle/client.py
@@ -57,10 +57,10 @@ class OracleClient(ODBCClient):
         self.dsn = f"DRIVER={driver};DBQ={dbq};UID={user};PWD={password};"
 
     def _in_transaction(self) -> "TransactionContext":
-        return TransactionContextPooled(TransactionWrapper(self))
+        return TransactionContextPooled(TransactionWrapper(self), self._pool_init_lock)
 
     def acquire_connection(self) -> Union["ConnectionWrapper", "PoolConnectionWrapper"]:
-        return OraclePoolConnectionWrapper(self)
+        return OraclePoolConnectionWrapper(self, self._pool_init_lock)
 
     async def db_create(self) -> None:
         await self.create_connection(with_db=False)

--- a/tortoise/backends/psycopg/client.py
+++ b/tortoise/backends/psycopg/client.py
@@ -193,10 +193,10 @@ class PsycopgClient(postgres_client.BasePostgresClient):
     def acquire_connection(
         self,
     ) -> typing.Union[base_client.ConnectionWrapper, PoolConnectionWrapper]:
-        return PoolConnectionWrapper(self)
+        return PoolConnectionWrapper(self, self._pool_init_lock)
 
     def _in_transaction(self) -> base_client.TransactionContext:
-        return base_client.TransactionContextPooled(TransactionWrapper(self))
+        return base_client.TransactionContextPooled(TransactionWrapper(self), self._pool_init_lock)
 
 
 class TransactionWrapper(PsycopgClient, base_client.BaseTransactionWrapper):

--- a/tortoise/backends/sqlite/client.py
+++ b/tortoise/backends/sqlite/client.py
@@ -190,8 +190,8 @@ class SqliteTransactionContext(TransactionContext):
             self.connection._connection = self.connection._parent._connection
 
     async def __aenter__(self) -> T_conn:
-        await self.ensure_connection()
         await self._trxlock.acquire()
+        await self.ensure_connection()
         self.token = connections.set(self.connection_name, self.connection)
         await self.connection.begin()
         return self.connection


### PR DESCRIPTION
## Description
This PR fixes the issue where when multiple concurrent tasks start queries or transactions, multiple connection pools are initialized that leads to
- Using more database connections than configured
- Running into the connections limit

The PR adds an extra lock that is used when the connection pool is initialized.

## Motivation and Context
This should fix https://github.com/tortoise/tortoise-orm/issues/1811.

## How Has This Been Tested?
`make ci`

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

