### PR TITLE
fraoustin 1565 Meta indexes are created safely

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -63,6 +63,7 @@ Contributors
 * Rui Catarino ``@ruitcatarino``
 * Lance Moe ``@lancemoe``
 * Markus Beckschulte ``@markus-96``
+* Frederic Aoustin ``@fraoustin``
 
 Special Thanks
 ==============

--- a/tests/schema/test_generate_schema.py
+++ b/tests/schema/test_generate_schema.py
@@ -726,8 +726,8 @@ CREATE TABLE IF NOT EXISTS `teamevents` (
     `full_text` LONGTEXT NOT NULL,
     `geometry` GEOMETRY NOT NULL
 ) CHARACTER SET utf8mb4;
-CREATE FULLTEXT INDEX `idx_index_full_te_3caba4` ON `index` (`full_text`) WITH PARSER ngram;
-CREATE SPATIAL INDEX `idx_index_geometr_0b4dfb` ON `index` (`geometry`);""",
+CREATE FULLTEXT INDEX IF NOT EXISTS `idx_index_full_te_3caba4` ON `index` (`full_text`) WITH PARSER ngram;
+CREATE SPATIAL INDEX IF NOT EXISTS `idx_index_geometr_0b4dfb` ON `index` (`geometry`);""",
         )
 
     async def test_index_unsafe(self):

--- a/tortoise/indexes.py
+++ b/tortoise/indexes.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 class Index:
     INDEX_TYPE = ""
     INDEX_CREATE_TEMPLATE = (
-        "CREATE{index_type}INDEX {index_name} ON {table_name} ({fields}){extra};"
+        "CREATE{index_type}INDEX {exists}{index_name} ON {table_name} ({fields}){extra};"
     )
 
     def __init__(


### PR DESCRIPTION
The index should be created safely using IF NOT EXISTS in the migration and generate_schemas shouldn't fail either when safe is set to True.


## Description
Add the exist format in template index create

## Motivation and Context
Issue #1565: When creating a PartialIndex with Meta, the index is not created safely nor in the migration file neither with Tortoise.generate_schemas(safe=True). This results a failure when generating schemas.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

