### PR TITLE
Enable tests for asyncmy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ test_mysql:
 
 test_mysql_asyncmy:
 	$(MAKE) deps_with_asyncmy
-	$(py_warn) TORTOISE_TEST_DB="mysql://root:$(TORTOISE_MYSQL_PASS)@127.0.0.1:3306/test_\{\}" pytest $(pytest_opts) --cov-append --cov-report=
+	$(MAKE) test_mysql
 	# Restore dependencies to the default
 	$(MAKE) deps
 

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ up:
 deps:
 	@poetry install -E asyncpg -E aiomysql -E accel -E psycopg -E asyncodbc
 
+deps_with_asyncmy:
+	@poetry install -E asyncpg -E asyncmy -E accel -E psycopg -E asyncodbc
+
 check: deps build _check
 _check:
 ifneq ($(shell which black),)
@@ -59,13 +62,20 @@ test_mysql_myisam:
 test_mysql:
 	$(py_warn) TORTOISE_TEST_DB="mysql://root:$(TORTOISE_MYSQL_PASS)@127.0.0.1:3306/test_\{\}" pytest $(pytest_opts) --cov-append --cov-report=
 
+test_mysql_asyncmy:
+	$(MAKE) deps_with_asyncmy
+	$(py_warn) TORTOISE_TEST_DB="mysql://root:$(TORTOISE_MYSQL_PASS)@127.0.0.1:3306/test_\{\}" pytest $(pytest_opts) --cov-append --cov-report=
+	# Restore dependencies to the default
+	$(MAKE) deps
+
 test_mssql:
 	$(py_warn) TORTOISE_TEST_DB="mssql://sa:$(TORTOISE_MSSQL_PASS)@127.0.0.1:1433/test_\{\}?driver=$(TORTOISE_MSSQL_DRIVER)&TrustServerCertificate=YES" pytest $(pytest_opts) --cov-append --cov-report=
 
 test_oracle:
 	$(py_warn) TORTOISE_TEST_DB="oracle://SYSTEM:$(TORTOISE_ORACLE_PASS)@127.0.0.1:1521/test_\{\}?driver=$(TORTOISE_ORACLE_DRIVER)" pytest $(pytest_opts) --cov-append --cov-report=
 
-_testall: test_sqlite test_postgres_asyncpg test_postgres_psycopg test_mysql_myisam test_mysql test_mssql
+_testall: test_sqlite test_postgres_asyncpg test_postgres_psycopg test_mysql_myisam test_mysql test_mysql_asyncmy test_mssql
+
 	coverage report
 
 testall: deps _testall

--- a/README.rst
+++ b/README.rst
@@ -152,7 +152,7 @@ Tortoise ORM currently supports the following databases:
 
 * `SQLite` (requires ``aiosqlite``)
 * `PostgreSQL` (requires ``asyncpg``)
-* `MySQL` (requires ``asyncmy``)
+* `MySQL` (requires ``asyncmy`` or ``aiomysql``)
 * `Microsoft SQL Server`/`Oracle` (requires ``asyncodbc``)
 
 ``generate_schema`` generates the schema on an empty database. Tortoise generates schemas in safe mode by default which

--- a/tests/backends/test_mysql.py
+++ b/tests/backends/test_mysql.py
@@ -28,8 +28,14 @@ class TestMySQL(test.SimpleTestCase):
 
     async def test_ssl_true(self):
         self.db_config["connections"]["models"]["credentials"]["ssl"] = True
-        # setting read_timeout for asyncmy. Otherwise, it will hang forever.
-        self.db_config["connections"]["models"]["credentials"]["read_timeout"] = 1
+        try:
+            import asyncmy  # noqa pylint: disable=unused-import
+
+            # setting read_timeout for asyncmy. Otherwise, it will hang forever.
+            self.db_config["connections"]["models"]["credentials"]["read_timeout"] = 1
+        except ImportError:
+            pass
+
         with self.assertRaises(ConnectionError):
             await Tortoise.init(self.db_config, _create_db=True)
 

--- a/tests/backends/test_mysql.py
+++ b/tests/backends/test_mysql.py
@@ -28,12 +28,10 @@ class TestMySQL(test.SimpleTestCase):
 
     async def test_ssl_true(self):
         self.db_config["connections"]["models"]["credentials"]["ssl"] = True
-        try:
+        # setting read_timeout for asyncmy. Otherwise, it will hang forever.
+        self.db_config["connections"]["models"]["credentials"]["read_timeout"] = 1
+        with self.assertRaises(ConnectionError):
             await Tortoise.init(self.db_config, _create_db=True)
-        except (ConnectionError, ssl.SSLError):
-            pass
-        else:
-            self.assertFalse(True, "Expected ConnectionError or SSLError")
 
     async def test_ssl_custom(self):
         # Expect connectionerror or pass


### PR DESCRIPTION
## Description
Enables tests with `asyncmy`. At the moment we are only running tests with `aiomysql`, however, we list `asyncmy` as the default client for MySQL

## Motivation and Context
This should close https://github.com/tortoise/tortoise-orm/issues/1814

## How Has This Been Tested?
`make ci`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

