### PR TITLE
Optimize field conversion to database format

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,15 +6,18 @@ Changelog
 
 .. rst-class:: emphasize-children
 
-0.23
+0.24
 ====
 
-0.23.1
+0.24.0 (unreleased)
 ------
 Fixed
 ^^^^^
 - Rename pypika to pypika_tortoise for fixing package name conflict (#1829)
 - Concurrent connection pool initialization (#1825)
+Changed
+^^^^^^^
+- Optimize field conversion to database format to speed up `create` and `bulk_create` (#1840)
 
 0.23.0
 ------

--- a/tests/fields/test_time.py
+++ b/tests/fields/test_time.py
@@ -26,6 +26,14 @@ class TestEmpty(test.TestCase):
 
 
 class TestDatetimeFields(TestEmpty):
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
+        timezone._reset_timezone_cache()
+
+    async def asyncTearDown(self):
+        await super().asyncTearDown()
+        timezone._reset_timezone_cache()
+
     def test_both_auto_bad(self):
         with self.assertRaisesRegex(
             ConfigurationError, "You can choose only 'auto_now' or 'auto_now_add'"

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -28,8 +28,8 @@ from tortoise.fields.relational import (
 from tortoise.filters import get_m2m_filters
 from tortoise.log import logger
 from tortoise.models import Model, ModelMeta
-from tortoise.utils import generate_schema_for_client
 from tortoise.timezone import _reset_timezone_cache
+from tortoise.utils import generate_schema_for_client
 
 
 class Tortoise:

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -29,6 +29,7 @@ from tortoise.filters import get_m2m_filters
 from tortoise.log import logger
 from tortoise.models import Model, ModelMeta
 from tortoise.utils import generate_schema_for_client
+from tortoise.timezone import _reset_timezone_cache
 
 
 class Tortoise:
@@ -614,6 +615,7 @@ class Tortoise:
     def _init_timezone(cls, use_tz: bool, timezone: str) -> None:
         os.environ["USE_TZ"] = str(use_tz)
         os.environ["TIMEZONE"] = timezone
+        _reset_timezone_cache()
 
 
 def run_async(coro: Coroutine) -> None:

--- a/tortoise/backends/base/executor.py
+++ b/tortoise/backends/base/executor.py
@@ -2,7 +2,6 @@ import asyncio
 import datetime
 import decimal
 from copy import copy
-from functools import partial
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -24,7 +23,6 @@ from pypika_tortoise.queries import QueryBuilder
 
 from tortoise.exceptions import OperationalError
 from tortoise.expressions import Expression, ResolveContext
-from tortoise.fields.base import Field
 from tortoise.fields.relational import (
     BackwardFKRelation,
     BackwardOneToOneRelation,
@@ -47,7 +45,6 @@ EXECUTOR_CACHE: Dict[
 
 
 class BaseExecutor:
-    TO_DB_OVERRIDE: Dict[Type[Field], Callable] = {}
     FILTER_FUNC_OVERRIDE: Dict[Callable, Callable] = {}
     EXPLAIN_PREFIX: str = "EXPLAIN"
     DB_NATIVE = {bytes, str, int, float, decimal.Decimal, datetime.datetime, datetime.date}
@@ -84,12 +81,7 @@ class BaseExecutor:
             self.column_map: Dict[str, Callable[[Any, Any], Any]] = {}
             for column in self.regular_columns_all:
                 field_object = self.model._meta.fields_map[column]
-                if field_object.__class__ in self.TO_DB_OVERRIDE:
-                    self.column_map[column] = partial(
-                        self.TO_DB_OVERRIDE[field_object.__class__], field_object
-                    )
-                else:
-                    self.column_map[column] = field_object.to_db_value
+                self.column_map[column] = field_object.to_db_value
 
             table = self.model._meta.basetable
             basequery = cast(QueryBuilder, self.model._meta.basequery)

--- a/tortoise/backends/base/executor.py
+++ b/tortoise/backends/base/executor.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:  # pragma: nocoverage
 
 EXECUTOR_CACHE: Dict[
     Tuple[str, Optional[str], str],
-    Tuple[list, str, list, str, Dict[str, Callable], str, Dict[str, str]],
+    Tuple[list, str, list, str, str, Dict[str, str]],
 ] = {}
 
 
@@ -78,11 +78,6 @@ class BaseExecutor:
                     self._prepare_insert_statement(columns_all, has_generated=False)
                 )
 
-            self.column_map: Dict[str, Callable[[Any, Any], Any]] = {}
-            for column in self.regular_columns_all:
-                field_object = self.model._meta.fields_map[column]
-                self.column_map[column] = field_object.to_db_value
-
             table = self.model._meta.basetable
             basequery = cast(QueryBuilder, self.model._meta.basequery)
             self.delete_query = str(
@@ -95,7 +90,6 @@ class BaseExecutor:
                 self.insert_query,
                 self.regular_columns_all,
                 self.insert_query_all,
-                self.column_map,
                 self.delete_query,
                 self.update_cache,
             )
@@ -106,7 +100,6 @@ class BaseExecutor:
                 self.insert_query,
                 self.regular_columns_all,
                 self.insert_query_all,
-                self.column_map,
                 self.delete_query,
                 self.update_cache,
             ) = EXECUTOR_CACHE[key]
@@ -186,7 +179,9 @@ class BaseExecutor:
     async def execute_insert(self, instance: "Model") -> None:
         if not instance._custom_generated_pk:
             values = [
-                self.column_map[field_name](getattr(instance, field_name), instance)
+                self.model._meta.fields_map[field_name].to_db_value(
+                    getattr(instance, field_name), instance
+                )
                 for field_name in self.regular_columns
             ]
             insert_result = await self.db.execute_insert(self.insert_query, values)
@@ -194,7 +189,9 @@ class BaseExecutor:
 
         else:
             values = [
-                self.column_map[field_name](getattr(instance, field_name), instance)
+                self.model._meta.fields_map[field_name].to_db_value(
+                    getattr(instance, field_name), instance
+                )
                 for field_name in self.regular_columns_all
             ]
             await self.db.execute_insert(self.insert_query_all, values)
@@ -211,14 +208,18 @@ class BaseExecutor:
                 if instance._custom_generated_pk:
                     values_lists_all.append(
                         [
-                            self.column_map[field_name](getattr(instance, field_name), instance)
+                            self.model._meta.fields_map[field_name].to_db_value(
+                                getattr(instance, field_name), instance
+                            )
                             for field_name in self.regular_columns_all
                         ]
                     )
                 else:
                     values_lists.append(
                         [
-                            self.column_map[field_name](getattr(instance, field_name), instance)
+                            self.model._meta.fields_map[field_name].to_db_value(
+                                getattr(instance, field_name), instance
+                            )
                             for field_name in self.regular_columns
                         ]
                     )
@@ -284,7 +285,7 @@ class BaseExecutor:
                 if isinstance(instance_field, Expression):
                     expressions[field] = instance_field
                 else:
-                    value = self.column_map[field](instance_field, instance)
+                    value = self.model._meta.fields_map[field].to_db_value(instance_field, instance)
                     values.append(value)
         values.append(self.model._meta.pk.to_db_value(instance.pk, instance))
         return (

--- a/tortoise/backends/mssql/executor.py
+++ b/tortoise/backends/mssql/executor.py
@@ -1,6 +1,6 @@
 from typing import Any, Optional, Type, Union
 
-from tortoise import Model, fields
+from tortoise import Model
 from tortoise.backends.odbc.executor import ODBCExecutor
 from tortoise.exceptions import UnSupportedError
 from tortoise.fields import BooleanField
@@ -16,9 +16,5 @@ def to_db_bool(
 
 
 class MSSQLExecutor(ODBCExecutor):
-    TO_DB_OVERRIDE = {
-        fields.BooleanField: to_db_bool,
-    }
-
     async def execute_explain(self, sql: str) -> Any:
         raise UnSupportedError("MSSQL does not support explain")

--- a/tortoise/backends/mssql/executor.py
+++ b/tortoise/backends/mssql/executor.py
@@ -1,18 +1,7 @@
-from typing import Any, Optional, Type, Union
+from typing import Any
 
-from tortoise import Model
 from tortoise.backends.odbc.executor import ODBCExecutor
 from tortoise.exceptions import UnSupportedError
-from tortoise.fields import BooleanField
-
-
-def to_db_bool(
-    self: BooleanField, value: Optional[Union[bool, int]], instance: Union[Type[Model], Model]
-) -> Optional[int]:
-    self.validate(value)
-    if value is None:
-        return None
-    return int(bool(value))
 
 
 class MSSQLExecutor(ODBCExecutor):

--- a/tortoise/backends/sqlite/executor.py
+++ b/tortoise/backends/sqlite/executor.py
@@ -5,7 +5,7 @@ from typing import Optional, Type, Union
 
 import pytz
 
-from tortoise import Model, fields, timezone
+from tortoise import Model, timezone
 from tortoise.backends.base.executor import BaseExecutor
 from tortoise.contrib.sqlite.regex import (
     insensitive_posix_sqlite_regexp,
@@ -88,12 +88,6 @@ sqlite3.register_adapter(Decimal, str)
 
 
 class SqliteExecutor(BaseExecutor):
-    TO_DB_OVERRIDE = {
-        fields.BooleanField: to_db_bool,
-        fields.DecimalField: to_db_decimal,
-        fields.DatetimeField: to_db_datetime,
-        fields.TimeField: to_db_time,
-    }
     EXPLAIN_PREFIX = "EXPLAIN QUERY PLAN"
     DB_NATIVE = {bytes, str, int, float}
     FILTER_FUNC_OVERRIDE = {

--- a/tortoise/backends/sqlite/executor.py
+++ b/tortoise/backends/sqlite/executor.py
@@ -8,13 +8,8 @@ from tortoise.contrib.sqlite.regex import (
     insensitive_posix_sqlite_regexp,
     posix_sqlite_regexp,
 )
-from tortoise.fields import (
-    BigIntField,
-    IntField,
-    SmallIntField,
-)
+from tortoise.fields import BigIntField, IntField, SmallIntField
 from tortoise.filters import insensitive_posix_regex, posix_regex
-
 
 # Conversion for the cases where it's hard to know the
 # related field, e.g. in raw queries, math or annotations.

--- a/tortoise/backends/sqlite/executor.py
+++ b/tortoise/backends/sqlite/executor.py
@@ -1,11 +1,8 @@
 import datetime
 import sqlite3
 from decimal import Decimal
-from typing import Optional, Type, Union
 
-import pytz
-
-from tortoise import Model, timezone
+from tortoise import Model
 from tortoise.backends.base.executor import BaseExecutor
 from tortoise.contrib.sqlite.regex import (
     insensitive_posix_sqlite_regexp,
@@ -13,78 +10,17 @@ from tortoise.contrib.sqlite.regex import (
 )
 from tortoise.fields import (
     BigIntField,
-    BooleanField,
-    DatetimeField,
-    DecimalField,
     IntField,
     SmallIntField,
-    TimeField,
 )
 from tortoise.filters import insensitive_posix_regex, posix_regex
 
 
-def to_db_bool(
-    self: BooleanField, value: Optional[Union[bool, int]], instance: Union[Type[Model], Model]
-) -> Optional[int]:
-    self.validate(value)
-    if value is None:
-        return None
-    return int(bool(value))
-
-
-def to_db_decimal(
-    self: DecimalField,
-    value: Optional[Union[str, float, int, Decimal]],
-    instance: Union[Type[Model], Model],
-) -> Optional[str]:
-    self.validate(value)
-    if value is None:
-        return None
-    return str(Decimal(value).quantize(self.quant).normalize())
-
-
-def to_db_datetime(
-    self: DatetimeField, value: Optional[datetime.datetime], instance: Union[Type[Model], Model]
-) -> Optional[str]:
-    self.validate(value)
-    # Only do this if it is a Model instance, not class. Test for guaranteed instance var
-    if hasattr(instance, "_saved_in_db") and (
-        self.auto_now
-        or (self.auto_now_add and getattr(instance, self.model_field_name, None) is None)
-    ):
-        if timezone.get_use_tz():
-            value = datetime.datetime.now(tz=pytz.utc)
-        else:
-            value = datetime.datetime.now(tz=timezone.get_default_timezone())
-        setattr(instance, self.model_field_name, value)
-        return value.isoformat(" ")
-    if isinstance(value, datetime.datetime):
-        return value.isoformat(" ")
-    return None
-
-
-def to_db_time(
-    self: TimeField, value: Optional[datetime.time], instance: Union[Type[Model], Model]
-) -> Optional[str]:
-    self.validate(value)
-    if hasattr(instance, "_saved_in_db") and (
-        self.auto_now
-        or (self.auto_now_add and getattr(instance, self.model_field_name, None) is None)
-    ):
-        if timezone.get_use_tz():
-            value = datetime.datetime.now(tz=pytz.utc).time()
-        else:
-            value = datetime.datetime.now(tz=timezone.get_default_timezone()).time()
-        setattr(instance, self.model_field_name, value)
-        return value.isoformat()
-    if isinstance(value, datetime.time):
-        return value.isoformat()
-    return None
-
-
-# Converts Decimal to string for sqlite in cases where it's hard to know the
+# Conversion for the cases where it's hard to know the
 # related field, e.g. in raw queries, math or annotations.
 sqlite3.register_adapter(Decimal, str)
+sqlite3.register_adapter(datetime.date, lambda val: val.isoformat())
+sqlite3.register_adapter(datetime.datetime, lambda val: val.isoformat(" "))
 
 
 class SqliteExecutor(BaseExecutor):

--- a/tortoise/fields/base.py
+++ b/tortoise/fields/base.py
@@ -259,11 +259,6 @@ class Field(Generic[VALUE], metaclass=_FieldMeta):
         if value is not None and not isinstance(value, self.field_type):
             value = self.field_type(value)  # pylint: disable=E1102
 
-        if self.__class__ in self.model._meta.db.executor_class.TO_DB_OVERRIDE:
-            value = self.model._meta.db.executor_class.TO_DB_OVERRIDE[self.__class__](
-                self, value, instance
-            )
-
         self.validate(value)
         return value
 

--- a/tortoise/timezone.py
+++ b/tortoise/timezone.py
@@ -1,3 +1,4 @@
+from functools import lru_cache
 import os
 from datetime import datetime, time, tzinfo
 from typing import Optional, Union
@@ -5,6 +6,7 @@ from typing import Optional, Union
 import pytz
 
 
+@lru_cache(maxsize=None)
 def get_use_tz() -> bool:
     """
     Get use_tz from env set in Tortoise config.
@@ -12,6 +14,7 @@ def get_use_tz() -> bool:
     return os.environ.get("USE_TZ") == "True"
 
 
+@lru_cache(maxsize=None)
 def get_timezone() -> str:
     """
     Get timezone from env set in Tortoise config.
@@ -29,6 +32,7 @@ def now() -> datetime:
         return datetime.now(get_default_timezone())
 
 
+@lru_cache(maxsize=None)
 def get_default_timezone() -> tzinfo:
     """
     Return the default time zone as a tzinfo instance.
@@ -36,6 +40,13 @@ def get_default_timezone() -> tzinfo:
     This is the time zone defined by Tortoise config.
     """
     return pytz.timezone(get_timezone())
+
+
+def _reset_timezone_cache() -> None:
+    """Reset timezone cache. For internal use only."""
+    get_default_timezone.cache_clear()
+    get_use_tz.cache_clear()
+    get_timezone.cache_clear()
 
 
 def localtime(value: Optional[datetime] = None, timezone: Optional[str] = None) -> datetime:

--- a/tortoise/timezone.py
+++ b/tortoise/timezone.py
@@ -1,6 +1,6 @@
-from functools import lru_cache
 import os
 from datetime import datetime, time, tzinfo
+from functools import lru_cache
 from typing import Optional, Union
 
 import pytz


### PR DESCRIPTION
## Description
- Remove `TO_DB_OVERRIDE` that is no longer needed after parametrization changes. The only exception is SQLite for which `sqlite3.register_adapter` was added - this is the same approach used by Django.
- Get rid of `BaseExecutor.column_map`. It was only required because of `TO_DB_OVERRIDE`.
- Cache `timezone.get_use_tz`, `timezone.get_timezone` and `timezone.get_default_timezone`. Since these are called for each field with `auto_now` or `auto_now_add`, it provides a significant speedup.

## Motivation and Context
This PR improves the performance of field value conversion to the DB format (see the detailed report in the comments):
- 52% improvement in the `test_bulk_create_many_fields` benchmark
- 13% improvement in `test_bulk_create_few_fields`
- 9% improvement in `test_create_many_fields`

The speedup is primarily achieved by the removal of `self.model._meta.db` from the `Field. to_db_value` code. The `db` property gets the current connection from `ContextVar` and it was a relatively slow operation to do it for each field for each object in `bulk_create`.

## How Has This Been Tested?
`make ci`

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

