### PR TITLE
Fix index creation in Tortoise.generate_schemas() for MySQL and Postgres

### DIFF
--- a/tests/fields/test_db_index.py
+++ b/tests/fields/test_db_index.py
@@ -6,6 +6,7 @@ from tortoise import fields
 from tortoise.contrib import test
 from tortoise.exceptions import ConfigurationError
 from tortoise.indexes import Index
+from tests.testmodels import ModelWithIndexes
 
 
 class CustomIndex(Index):
@@ -14,7 +15,7 @@ class CustomIndex(Index):
         self._foo = ""
 
 
-class TestIndexHashEqualRepr(test.TestCase):
+class TestIndexHashEqualRepr(test.SimpleTestCase):
     def test_index_eq(self):
         assert Index(fields=("id",)) == Index(fields=("id",))
         assert CustomIndex(fields=("id",)) == CustomIndex(fields=("id",))
@@ -46,7 +47,7 @@ class TestIndexHashEqualRepr(test.TestCase):
         assert repr(Index(fields=("id",), name="MyIndex")) == "Index(fields=['id'], name='MyIndex')"
         assert repr(Index(Field("id"))) == f'Index({str(Field("id"))})'
         assert repr(Index(Field("a"), name="Id")) == f"Index({str(Field('a'))}, name='Id')"
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ConfigurationError):
             Index(Field("id"), fields=("name",))
 
 
@@ -94,3 +95,11 @@ class TestIndexAliasUUID(TestIndexAlias):
 class TestIndexAliasChar(TestIndexAlias):
     Field = fields.CharField
     init_kwargs = {"max_length": 10}
+
+
+class TestModelWithIndexes(test.TestCase):
+    def test_meta(self):
+        self.assertEqual(ModelWithIndexes._meta.indexes, [Index(fields=("f1", "f2"))])
+        self.assertTrue(ModelWithIndexes._meta.fields_map["id"].index)
+        self.assertTrue(ModelWithIndexes._meta.fields_map["indexed"].index)
+        self.assertTrue(ModelWithIndexes._meta.fields_map["unique_indexed"].unique)

--- a/tests/schema/test_generate_schema.py
+++ b/tests/schema/test_generate_schema.py
@@ -724,10 +724,10 @@ CREATE TABLE IF NOT EXISTS `teamevents` (
             """CREATE TABLE IF NOT EXISTS `index` (
     `id` INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
     `full_text` LONGTEXT NOT NULL,
-    `geometry` GEOMETRY NOT NULL
-) CHARACTER SET utf8mb4;
-CREATE FULLTEXT INDEX IF NOT EXISTS `idx_index_full_te_3caba4` ON `index` (`full_text`) WITH PARSER ngram;
-CREATE SPATIAL INDEX IF NOT EXISTS `idx_index_geometr_0b4dfb` ON `index` (`geometry`);""",
+    `geometry` GEOMETRY NOT NULL,
+    FULLTEXT KEY `idx_index_full_te_3caba4` (`full_text`) WITH PARSER ngram,
+    SPATIAL KEY `idx_index_geometr_0b4dfb` (`geometry`)
+) CHARACTER SET utf8mb4;""",
         )
 
     async def test_index_unsafe(self):
@@ -738,10 +738,10 @@ CREATE SPATIAL INDEX IF NOT EXISTS `idx_index_geometr_0b4dfb` ON `index` (`geome
             """CREATE TABLE `index` (
     `id` INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
     `full_text` LONGTEXT NOT NULL,
-    `geometry` GEOMETRY NOT NULL
-) CHARACTER SET utf8mb4;
-CREATE FULLTEXT INDEX `idx_index_full_te_3caba4` ON `index` (`full_text`) WITH PARSER ngram;
-CREATE SPATIAL INDEX `idx_index_geometr_0b4dfb` ON `index` (`geometry`);""",
+    `geometry` GEOMETRY NOT NULL,
+    FULLTEXT KEY `idx_index_full_te_3caba4` (`full_text`) WITH PARSER ngram,
+    SPATIAL KEY `idx_index_geometr_0b4dfb` (`geometry`)
+) CHARACTER SET utf8mb4;""",
         )
 
     async def test_m2m_no_auto_create(self):
@@ -1102,7 +1102,7 @@ CREATE INDEX "idx_index_gin_a403ee" ON "index" USING GIN ("gin");
 CREATE INDEX "idx_index_gist_c807bf" ON "index" USING GIST ("gist");
 CREATE INDEX "idx_index_sp_gist_2c0bad" ON "index" USING SPGIST ("sp_gist");
 CREATE INDEX "idx_index_hash_cfe6b5" ON "index" USING HASH ("hash");
-CREATE INDEX "idx_index_partial_c5be6a" ON "index" USING  ("partial") WHERE id = 1;""",
+CREATE INDEX "idx_index_partial_c5be6a" ON "index" ("partial") WHERE id = 1;""",
         )
 
     async def test_index_safe(self):
@@ -1126,7 +1126,7 @@ CREATE INDEX IF NOT EXISTS "idx_index_gin_a403ee" ON "index" USING GIN ("gin");
 CREATE INDEX IF NOT EXISTS "idx_index_gist_c807bf" ON "index" USING GIST ("gist");
 CREATE INDEX IF NOT EXISTS "idx_index_sp_gist_2c0bad" ON "index" USING SPGIST ("sp_gist");
 CREATE INDEX IF NOT EXISTS "idx_index_hash_cfe6b5" ON "index" USING HASH ("hash");
-CREATE INDEX IF NOT EXISTS "idx_index_partial_c5be6a" ON "index" USING  ("partial") WHERE id = 1;""",
+CREATE INDEX IF NOT EXISTS "idx_index_partial_c5be6a" ON "index" ("partial") WHERE id = 1;""",
         )
 
     async def test_m2m_no_auto_create(self):

--- a/tests/testmodels.py
+++ b/tests/testmodels.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel, ConfigDict
 from tortoise import fields
 from tortoise.exceptions import ValidationError
 from tortoise.fields import NO_ACTION
+from tortoise.indexes import Index
 from tortoise.manager import Manager
 from tortoise.models import Model
 from tortoise.queryset import QuerySet
@@ -1050,3 +1051,19 @@ class BenchmarkManyFields(Model):
     col_text4 = fields.TextField(null=True)
     col_decimal4 = fields.DecimalField(12, 8, null=True)
     col_json4 = fields.JSONField[dict](null=True)
+
+
+class ModelWithIndexes(Model):
+    id = fields.IntField(primary_key=True)
+    indexed = fields.CharField(max_length=255, index=True)
+    unique_indexed = fields.CharField(max_length=255, unique=True)
+    f1 = fields.CharField(max_length=255)
+    f2 = fields.CharField(max_length=255)
+    u1 = fields.IntField()
+    u2 = fields.IntField()
+
+    class Meta:
+        indexes = [
+            Index(fields=["f1", "f2"]),
+        ]
+        unique_together = [("u1", "u2")]

--- a/tests/testmodels.py
+++ b/tests/testmodels.py
@@ -1055,10 +1055,10 @@ class BenchmarkManyFields(Model):
 
 class ModelWithIndexes(Model):
     id = fields.IntField(primary_key=True)
-    indexed = fields.CharField(max_length=255, index=True)
-    unique_indexed = fields.CharField(max_length=255, unique=True)
-    f1 = fields.CharField(max_length=255)
-    f2 = fields.CharField(max_length=255)
+    indexed = fields.CharField(max_length=16, index=True)
+    unique_indexed = fields.CharField(max_length=16, unique=True)
+    f1 = fields.CharField(max_length=16)
+    f2 = fields.CharField(max_length=16)
     u1 = fields.IntField()
     u2 = fields.IntField()
 

--- a/tests/utils/test_describe_model.py
+++ b/tests/utils/test_describe_model.py
@@ -5,6 +5,7 @@ from typing import Union
 from tests.testmodels import (
     Event,
     JSONFields,
+    ModelWithIndexes,
     Reporter,
     SourceFields,
     StraightFields,
@@ -1560,4 +1561,20 @@ class TestDescribeModel(test.SimpleTestCase):
                 "backward_o2o_fields": [],
                 "m2m_fields": [],
             },
+        )
+
+    def test_describe_indexes_serializable(self):
+        val = ModelWithIndexes.describe()
+
+        self.assertEqual(
+            val["indexes"],
+            [{"fields": ["f1", "f2"], "expressions": [], "name": None, "type": "", "extra": ""}],
+        )
+
+    def test_describe_indexes_not_serializable(self):
+        val = ModelWithIndexes.describe(serializable=False)
+
+        self.assertEqual(
+            val["indexes"],
+            ModelWithIndexes._meta.indexes,
         )

--- a/tortoise/backends/base/schema_generator.py
+++ b/tortoise/backends/base/schema_generator.py
@@ -1,6 +1,6 @@
 import re
 from hashlib import sha256
-from typing import TYPE_CHECKING, Any, List, Set, Type, Union, cast
+from typing import TYPE_CHECKING, Any, List, Optional, Set, Type, Union, cast
 
 from tortoise.exceptions import ConfigurationError
 from tortoise.fields import JSONField, TextField, UUIDField
@@ -23,8 +23,10 @@ class BaseSchemaGenerator:
     DIALECT = "sql"
     TABLE_CREATE_TEMPLATE = 'CREATE TABLE {exists}"{table_name}" ({fields}){extra}{comment};'
     FIELD_TEMPLATE = '"{name}" {type}{nullable}{unique}{primary}{default}{comment}'
-    INDEX_CREATE_TEMPLATE = 'CREATE INDEX {exists}"{index_name}" ON "{table_name}" ({fields});'
-    UNIQUE_INDEX_CREATE_TEMPLATE = INDEX_CREATE_TEMPLATE.replace(" INDEX", " UNIQUE INDEX")
+    INDEX_CREATE_TEMPLATE = (
+        'CREATE {index_type}INDEX {exists}"{index_name}" ON "{table_name}" ({fields}){extra};'
+    )
+    UNIQUE_INDEX_CREATE_TEMPLATE = INDEX_CREATE_TEMPLATE.replace("INDEX", "UNIQUE INDEX")
     UNIQUE_CONSTRAINT_CREATE_TEMPLATE = 'CONSTRAINT "{index_name}" UNIQUE ({fields})'
     GENERATED_PK_TEMPLATE = '"{field_name}" {generated_sql}{comment}'
     FK_TEMPLATE = ' REFERENCES "{table}" ("{field}") ON DELETE {on_delete}{comment}'
@@ -167,12 +169,22 @@ class BaseSchemaGenerator:
         )
         return index_name
 
-    def _get_index_sql(self, model: "Type[Model]", field_names: List[str], safe: bool) -> str:
+    def _get_index_sql(
+        self,
+        model: "Type[Model]",
+        field_names: List[str],
+        safe: bool,
+        index_name: Optional[str] = None,
+        index_type: Optional[str] = None,
+        extra: Optional[str] = None,
+    ) -> str:
         return self.INDEX_CREATE_TEMPLATE.format(
             exists="IF NOT EXISTS " if safe else "",
-            index_name=self._generate_index_name("idx", model, field_names),
+            index_name=index_name or self._generate_index_name("idx", model, field_names),
+            index_type=f"{index_type} " if index_type else "",
             table_name=model._meta.db_table,
             fields=", ".join([self.quote(f) for f in field_names]),
+            extra=f"{extra}" if extra else "",
         )
 
     def _get_unique_index_sql(self, exists: str, table_name: str, field_names: List[str]) -> str:
@@ -180,8 +192,10 @@ class BaseSchemaGenerator:
         return self.UNIQUE_INDEX_CREATE_TEMPLATE.format(
             exists=exists,
             index_name=index_name,
+            index_type="",
             table_name=table_name,
             fields=", ".join([self.quote(f) for f in field_names]),
+            extra="",
         )
 
     def _get_unique_constraint_sql(self, model: "Type[Model]", field_names: List[str]) -> str:
@@ -324,22 +338,30 @@ class BaseSchemaGenerator:
                     self._get_unique_constraint_sql(model, unique_together_to_create)
                 )
 
-        # Indexes.
         _indexes = [
             self._get_index_sql(model, [field_name], safe=safe) for field_name in fields_with_index
         ]
 
         if model._meta.indexes:
-            for indexes_list in model._meta.indexes:
-                if not isinstance(indexes_list, Index):
-                    indexes_to_create = []
-                    for field in indexes_list:
+            for index in model._meta.indexes:
+                if not isinstance(index, Index):
+                    fields = []
+                    for field in index:
                         field_object = model._meta.fields_map[field]
-                        indexes_to_create.append(field_object.source_field or field)
+                        fields.append(field_object.source_field or field)
 
-                    _indexes.append(self._get_index_sql(model, indexes_to_create, safe=safe))
+                    _indexes.append(self._get_index_sql(model, fields, safe=safe))
                 else:
-                    _indexes.append(indexes_list.get_sql(self, model, safe))
+                    if index.fields:
+                        fields = [f for f in index.fields]
+                    else:
+                        fields = [f"({expression.get_sql()})" for expression in index.expressions]
+
+                    _indexes.append(
+                        self._get_index_sql(
+                            model, fields, safe=safe, index_type=index.INDEX_TYPE, extra=index.extra
+                        )
+                    )
 
         field_indexes_sqls = [val for val in list(dict.fromkeys(_indexes)) if val]
 

--- a/tortoise/backends/base/schema_generator.py
+++ b/tortoise/backends/base/schema_generator.py
@@ -2,6 +2,8 @@ import re
 from hashlib import sha256
 from typing import TYPE_CHECKING, Any, List, Optional, Set, Type, Union, cast
 
+from pypika_tortoise.context import DEFAULT_SQL_CONTEXT
+
 from tortoise.exceptions import ConfigurationError
 from tortoise.fields import JSONField, TextField, UUIDField
 from tortoise.fields.relational import OneToOneFieldInstance
@@ -354,8 +356,15 @@ class BaseSchemaGenerator:
                 else:
                     if index.fields:
                         fields = [f for f in index.fields]
+                    elif index.expressions:
+                        fields = [
+                            f"({expression.get_sql(DEFAULT_SQL_CONTEXT)})"
+                            for expression in index.expressions
+                        ]
                     else:
-                        fields = [f"({expression.get_sql()})" for expression in index.expressions]
+                        raise ConfigurationError(
+                            "At least one field or expression is required to define an index."
+                        )
 
                     _indexes.append(
                         self._get_index_sql(

--- a/tortoise/backends/base_postgres/schema_generator.py
+++ b/tortoise/backends/base_postgres/schema_generator.py
@@ -1,7 +1,8 @@
-from typing import TYPE_CHECKING, Any, List
+from typing import TYPE_CHECKING, Any, List, Optional, Type
 
 from tortoise.backends.base.schema_generator import BaseSchemaGenerator
 from tortoise.converters import encoders
+from tortoise.models import Model
 
 if TYPE_CHECKING:  # pragma: nocoverage
     from .client import BasePostgresClient
@@ -9,6 +10,10 @@ if TYPE_CHECKING:  # pragma: nocoverage
 
 class BasePostgresSchemaGenerator(BaseSchemaGenerator):
     DIALECT = "postgres"
+    INDEX_CREATE_TEMPLATE = (
+        'CREATE INDEX {exists}"{index_name}" ON "{table_name}" {index_type}({fields}){extra};'
+    )
+    UNIQUE_INDEX_CREATE_TEMPLATE = INDEX_CREATE_TEMPLATE.replace("INDEX", "UNIQUE INDEX")
     TABLE_COMMENT_TEMPLATE = "COMMENT ON TABLE \"{table}\" IS '{comment}';"
     COLUMN_COMMENT_TEMPLATE = 'COMMENT ON COLUMN "{table}"."{column}" IS \'{comment}\';'
     GENERATED_PK_TEMPLATE = '"{field_name}" {generated_sql}'
@@ -61,3 +66,19 @@ class BasePostgresSchemaGenerator(BaseSchemaGenerator):
         if isinstance(default, bool):
             return default
         return encoders.get(type(default))(default)  # type: ignore
+
+    def _get_index_sql(
+        self,
+        model: "Type[Model]",
+        field_names: List[str],
+        safe: bool,
+        index_name: Optional[str] = None,
+        index_type: Optional[str] = None,
+        extra: Optional[str] = None,
+    ) -> str:
+        if index_type:
+            index_type = f"USING {index_type}"
+
+        return super()._get_index_sql(
+            model, field_names, safe, index_name=index_name, index_type=index_type, extra=extra
+        )

--- a/tortoise/backends/mssql/schema_generator.py
+++ b/tortoise/backends/mssql/schema_generator.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, List, Type
+from typing import TYPE_CHECKING, Any, List, Optional, Type
 
 from tortoise.backends.base.schema_generator import BaseSchemaGenerator
 from tortoise.converters import encoders
@@ -59,8 +59,18 @@ class MSSQLSchemaGenerator(BaseSchemaGenerator):
     def _escape_default_value(self, default: Any):
         return encoders.get(type(default))(default)  # type: ignore
 
-    def _get_index_sql(self, model: "Type[Model]", field_names: List[str], safe: bool) -> str:
-        return super(MSSQLSchemaGenerator, self)._get_index_sql(model, field_names, False)
+    def _get_index_sql(
+        self,
+        model: "Type[Model]",
+        field_names: List[str],
+        safe: bool,
+        index_name: Optional[str] = None,
+        index_type: Optional[str] = None,
+        extra: Optional[str] = None,
+    ) -> str:
+        return super(MSSQLSchemaGenerator, self)._get_index_sql(
+            model, field_names, False, index_name=index_name, index_type=index_type, extra=extra
+        )
 
     def _get_table_sql(self, model: "Type[Model]", safe: bool = True) -> dict:
         return super(MSSQLSchemaGenerator, self)._get_table_sql(model, False)

--- a/tortoise/backends/mysql/schema_generator.py
+++ b/tortoise/backends/mysql/schema_generator.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, List, Type
+from typing import TYPE_CHECKING, Any, List, Optional, Type
 
 from tortoise.backends.base.schema_generator import BaseSchemaGenerator
 from tortoise.converters import encoders
@@ -11,7 +11,7 @@ if TYPE_CHECKING:  # pragma: nocoverage
 class MySQLSchemaGenerator(BaseSchemaGenerator):
     DIALECT = "mysql"
     TABLE_CREATE_TEMPLATE = "CREATE TABLE {exists}`{table_name}` ({fields}){extra}{comment};"
-    INDEX_CREATE_TEMPLATE = "KEY `{index_name}` ({fields})"
+    INDEX_CREATE_TEMPLATE = "{index_type}KEY `{index_name}` ({fields}){extra}"
     UNIQUE_CONSTRAINT_CREATE_TEMPLATE = "UNIQUE KEY `{index_name}` ({fields})"
     UNIQUE_INDEX_CREATE_TEMPLATE = UNIQUE_CONSTRAINT_CREATE_TEMPLATE
     FIELD_TEMPLATE = "`{name}` {type}{nullable}{unique}{primary}{comment}{default}"
@@ -68,9 +68,19 @@ class MySQLSchemaGenerator(BaseSchemaGenerator):
     def _escape_default_value(self, default: Any):
         return encoders.get(type(default))(default)  # type: ignore
 
-    def _get_index_sql(self, model: "Type[Model]", field_names: List[str], safe: bool) -> str:
+    def _get_index_sql(
+        self,
+        model: "Type[Model]",
+        field_names: List[str],
+        safe: bool,
+        index_name: Optional[str] = None,
+        index_type: Optional[str] = None,
+        extra: Optional[str] = None,
+    ) -> str:
         """Get index SQLs, but keep them for ourselves"""
-        index_create_sql = super()._get_index_sql(model, field_names, safe)
+        index_create_sql = super()._get_index_sql(
+            model, field_names, safe, index_name=index_name, index_type=index_type, extra=extra
+        )
         self._field_indexes.append(index_create_sql)
         return ""
 

--- a/tortoise/backends/oracle/schema_generator.py
+++ b/tortoise/backends/oracle/schema_generator.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, List, Type
+from typing import TYPE_CHECKING, Any, List, Optional, Type
 
 from tortoise.backends.base.schema_generator import BaseSchemaGenerator
 from tortoise.converters import encoders
@@ -85,8 +85,18 @@ class OracleSchemaGenerator(BaseSchemaGenerator):
     def _escape_default_value(self, default: Any):
         return encoders.get(type(default))(default)  # type: ignore
 
-    def _get_index_sql(self, model: "Type[Model]", field_names: List[str], safe: bool) -> str:
-        return super(OracleSchemaGenerator, self)._get_index_sql(model, field_names, False)
+    def _get_index_sql(
+        self,
+        model: "Type[Model]",
+        field_names: List[str],
+        safe: bool,
+        index_name: Optional[str] = None,
+        index_type: Optional[str] = None,
+        extra: Optional[str] = None,
+    ) -> str:
+        return super(OracleSchemaGenerator, self)._get_index_sql(
+            model, field_names, False, index_name=index_name, index_type=index_type, extra=extra
+        )
 
     def _get_table_sql(self, model: "Type[Model]", safe: bool = True) -> dict:
         return super(OracleSchemaGenerator, self)._get_table_sql(model, False)

--- a/tortoise/contrib/postgres/indexes.py
+++ b/tortoise/contrib/postgres/indexes.py
@@ -2,9 +2,7 @@ from tortoise.indexes import PartialIndex
 
 
 class PostgreSQLIndex(PartialIndex):
-    INDEX_CREATE_TEMPLATE = (
-        "CREATE INDEX {exists}{index_name} ON {table_name} USING{index_type}({fields}){extra};"
-    )
+    pass
 
 
 class BloomIndex(PostgreSQLIndex):

--- a/tortoise/indexes.py
+++ b/tortoise/indexes.py
@@ -1,19 +1,12 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Type
+from typing import Any
 
 from pypika_tortoise.terms import Term, ValueWrapper
-
-if TYPE_CHECKING:
-    from tortoise import Model
-    from tortoise.backends.base.schema_generator import BaseSchemaGenerator
 
 
 class Index:
     INDEX_TYPE = ""
-    INDEX_CREATE_TEMPLATE = (
-        "CREATE{index_type}INDEX {exists}{index_name} ON {table_name} ({fields}){extra};"
-    )
 
     def __init__(
         self,
@@ -49,28 +42,6 @@ class Index:
         if name := self.name:
             argument += f", {name=}"
         return self.__class__.__name__ + "(" + argument + ")"
-
-    def get_sql(
-        self, schema_generator: "BaseSchemaGenerator", model: "Type[Model]", safe: bool
-    ) -> str:
-        if self.fields:
-            fields = ", ".join(schema_generator.quote(f) for f in self.fields)
-        else:
-            ctx = schema_generator.client.query_class.SQL_CONTEXT
-            expressions = [f"({expression.get_sql(ctx)})" for expression in self.expressions]
-            fields = ", ".join(expressions)
-
-        return self.INDEX_CREATE_TEMPLATE.format(
-            exists="IF NOT EXISTS " if safe else "",
-            index_name=schema_generator.quote(self.index_name(schema_generator, model)),
-            index_type=f" {self.INDEX_TYPE} ",
-            table_name=schema_generator.quote(model._meta.db_table),
-            fields=fields,
-            extra=self.extra,
-        )
-
-    def index_name(self, schema_generator: "BaseSchemaGenerator", model: "Type[Model]") -> str:
-        return self.name or schema_generator._generate_index_name("idx", model, self.fields)
 
     def __hash__(self) -> int:
         return hash((tuple(self.fields), self.name, tuple(self.expressions)))

--- a/tortoise/indexes.py
+++ b/tortoise/indexes.py
@@ -4,6 +4,8 @@ from typing import Any
 
 from pypika_tortoise.terms import Term, ValueWrapper
 
+from tortoise.exceptions import ConfigurationError
+
 
 class Index:
     INDEX_TYPE = ""
@@ -24,14 +26,25 @@ class Index:
         """
         self.fields = list(fields or [])
         if not expressions and not fields:
-            raise ValueError("At least one field or expression is required to define an " "index.")
+            raise ConfigurationError(
+                "At least one field or expression is required to define an " "index."
+            )
         if expressions and fields:
-            raise ValueError(
+            raise ConfigurationError(
                 "Index.fields and expressions are mutually exclusive.",
             )
         self.name = name
         self.expressions = expressions
         self.extra = ""
+
+    def describe(self) -> dict:
+        return {
+            "fields": self.fields,
+            "expressions": [str(expression) for expression in self.expressions],
+            "name": self.name,
+            "type": self.INDEX_TYPE,
+            "extra": self.extra,
+        }
 
     def __repr__(self) -> str:
         argument = ""


### PR DESCRIPTION
## Description
- Replace `CREATE INDEX IF NOT EXISTS` queries with indexes defined inside the table definition for MySQL
- Fix partial index creation for Postgres - `CREATE INDEX "idx_index_partial_c5be6a" ON "index" USING  ("partial") WHERE id = 1;` isn't correct syntax because `USING` should be followed by the index type.
- Replace the logic for index creation from `Index` and its subclasses with `schema_generator`, hence making `schema_generator` a single place to have schema generation logic. This also also makes the `Index` and `schema_generator` relation one directional.
- Fix the issue with using `Model.describe` when `Index` is in `Model.Meta.indexes`

## Motivation and Context
This should fix https://github.com/tortoise/tortoise-orm/issues/1836.

## How Has This Been Tested?
`make ci`

I also tested the generated SQLs against corresponding databases.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

