### PR TITLE
filter datetime objects by date using __date

### DIFF
--- a/docs/query.rst
+++ b/docs/query.rst
@@ -221,6 +221,7 @@ The following lookup types are available:
 - ``iendswith`` - case insensitive ``endswith``
 - ``iexact`` - case insensitive equals
 - ``search`` - full text search
+- ``date`` - date search on datetime field e.g.; `await Team.filter(created_at__date=datetime.date(2020, 5, 20))`
 
 For PostgreSQL and MySQL, the following date related lookup types are available:
 

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -164,6 +164,15 @@ class TestFiltering(test.TestCase):
         self.assertEqual(len(tournaments), 2)
         self.assertSetEqual({t.name for t in tournaments}, {"0", "1"})
 
+    async def test_filter_date(self):
+        await DatetimeFields.create(
+            datetime=datetime.datetime(
+                year=2020, month=5, day=20, hour=0, minute=0, second=0, microsecond=0
+            )
+        )
+        date = datetime.date(2020, 5, 20)
+        self.assertEqual(await Tournament.filter(created__date=date).count(), 1)
+
     @test.requireCapability(dialect="mysql")
     @test.requireCapability(dialect="postgres")
     async def test_filter_exact(self):

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -171,7 +171,7 @@ class TestFiltering(test.TestCase):
             )
         )
         date = datetime.date(2020, 5, 20)
-        self.assertEqual(await Tournament.filter(created__date=date).count(), 1)
+        self.assertEqual(await DatetimeFields.filter(datetime__date=date).count(), 1)
 
     @test.requireCapability(dialect="mysql")
     @test.requireCapability(dialect="postgres")

--- a/tortoise/filters.py
+++ b/tortoise/filters.py
@@ -15,7 +15,7 @@ from typing import (
 
 from pypika_tortoise import SqlContext, Table
 from pypika_tortoise.enums import DatePart, Matching, SqlTypes
-from pypika_tortoise.functions import Cast, Extract, Upper
+from pypika_tortoise.functions import Cast, Date, Extract, Upper
 from pypika_tortoise.terms import (
     BasicCriterion,
     Criterion,
@@ -183,6 +183,10 @@ def insensitive_ends_with(field: Term, value: str) -> Criterion:
     return Like(
         Upper(Cast(field, SqlTypes.VARCHAR)), field.wrap_constant(Upper(f"%{escape_like(value)}"))
     )
+
+
+def date_equal(field: Term, value: str) -> Criterion:
+    return Date(field).eq(value)
 
 
 def extract_year_equal(field: Term, value: int) -> Criterion:
@@ -522,6 +526,11 @@ def get_filters_for_field(
             "source_field": source_field,
             "operator": insensitive_posix_regex,
             "value_encoder": string_encoder,
+        },
+        f"{field_name}__date": {
+            "field": actual_field_name,
+            "source_field": source_field,
+            "operator": date_equal,
         },
         f"{field_name}__year": {
             "field": actual_field_name,


### PR DESCRIPTION
Add functionality to allow filtering for `datetime` type fields by date using `{field_name}__date`

## Description
I have fields in my models/schema that are datetime objects, but I wish to be able to filter for them using only a date (e.g.; filter all entries on a particular date).

This PR adds `__date` operator that allows for such filtering.

## Motivation and Context
There does not appear to be a way to filter datetime fields by a date object. Perhaps it can be done using `lte` / `gte` but I would rather specify one filter.. it seems more obvious and less of a work around a missing filter type.

## How Has This Been Tested?
Added unit tests and used functionality in my use-case.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

