### PR TITLE
Release 0.24.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ Changelog
 0.24
 ====
 
-0.24.0 (unreleased)
+0.24.0
 ------
 Fixed
 ^^^^^

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tortoise-orm"
-version = "0.23.0"
+version = "0.24.0"
 description = "Easy async ORM for python, built with relations in mind"
 authors = ["Andrey Bondar <andrey@bondar.ru>", "Nickolas Grigoriadis <nagrigoriadis@gmail.com>", "long2ice <long2ice@gmail.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
0.24.0
------
Fixed
^^^^^
- Rename pypika to pypika_tortoise for fixing package name conflict (#1829)
- Concurrent connection pool initialization (#1825)

Changed
^^^^^^^
- Drop support for Python3.8 (#1848)
- Optimize field conversion to database format to speed up `create` and `bulk_create` (#1840)
- Improved query performance by optimizing SQL generation (#1837)