### PR TITLE
Add logic to handle `globalns` and `localns` in `pydantic_model_creator`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Changelog
 ------
 Fixed
 ^^^^^
+- Add support for globalns and localns in pydantic_model_creator (#1876)
 - Fixed asyncio "no current event loop" deprecation warning by replacing `asyncio.get_event_loop()` with modern event loop handling using `get_running_loop()` with fallback to `new_event_loop()` (#1865)
 
 Changed

--- a/tortoise/contrib/pydantic/creator.py
+++ b/tortoise/contrib/pydantic/creator.py
@@ -61,8 +61,8 @@ def _pydantic_recursion_protector(
     name=None,
     allow_cycles: bool = False,
     sort_alphabetically: Optional[bool] = None,
-    globalns: dict = None,
-    localns: dict = None,
+    globalns: Optional[dict] = None,
+    localns: Optional[dict] = None,
 ) -> Optional[type[PydanticModel]]:
     """
     It is an inner function to protect pydantic model creator against cyclic recursion
@@ -241,8 +241,8 @@ class PydanticModelCreator:
         model_config: Optional[ConfigDict] = None,
         validators: Optional[dict[str, Any]] = None,
         module: str = __name__,
-        globalns: dict = None,
-        localns: dict = None,
+        globalns: Optional[dict] = None,
+        localns: Optional[dict] = None,
         _stack: tuple = (),
         _as_submodel: bool = False,
     ) -> None:
@@ -532,7 +532,9 @@ class PydanticModelCreator:
         field: ComputedFieldDescription,
     ) -> Optional[Any]:
         func = field.function
-        annotation = get_annotations(self._cls, func, globalns=self.globalns, localns=self.localns).get("return", None)
+        annotation = get_annotations(
+            self._cls, func, globalns=self.globalns, localns=self.localns
+        ).get("return", None)
         comment = _cleandoc(func)
         if annotation is not None:
             c_f = computed_field(return_type=annotation, description=comment)
@@ -592,8 +594,8 @@ def pydantic_model_creator(
     model_config: Optional[ConfigDict] = None,
     validators: Optional[dict[str, Any]] = None,
     module: str = __name__,
-    globalns: dict = None,
-    localns: dict = None,
+    globalns: Optional[dict] = None,
+    localns: Optional[dict] = None,
 ) -> type[PydanticModel]:
     """
     Function to build `Pydantic Model <https://docs.pydantic.dev/latest/concepts/models/>`__ off Tortoise Model.

--- a/tortoise/contrib/pydantic/creator.py
+++ b/tortoise/contrib/pydantic/creator.py
@@ -61,6 +61,8 @@ def _pydantic_recursion_protector(
     name=None,
     allow_cycles: bool = False,
     sort_alphabetically: Optional[bool] = None,
+    globalns: dict = None,
+    localns: dict = None,
 ) -> Optional[type[PydanticModel]]:
     """
     It is an inner function to protect pydantic model creator against cyclic recursion
@@ -93,6 +95,8 @@ def _pydantic_recursion_protector(
         _stack=stack,
         allow_cycles=allow_cycles,
         sort_alphabetically=sort_alphabetically,
+        globalns=globalns,
+        localns=localns,
         _as_submodel=True,
     )
     return pmc.create_pydantic_model()
@@ -237,6 +241,8 @@ class PydanticModelCreator:
         model_config: Optional[ConfigDict] = None,
         validators: Optional[dict[str, Any]] = None,
         module: str = __name__,
+        globalns: dict = None,
+        localns: dict = None,
         _stack: tuple = (),
         _as_submodel: bool = False,
     ) -> None:
@@ -288,7 +294,7 @@ class PydanticModelCreator:
 
         self._as_submodel = _as_submodel
 
-        self._annotations = get_annotations(cls)
+        self._annotations = get_annotations(cls, globalns=globalns, localns=localns)
 
         self._pconfig: ConfigDict
 
@@ -304,6 +310,9 @@ class PydanticModelCreator:
 
         self._validators = validators
         self._module = module
+
+        self.globalns = globalns
+        self.localns = localns
 
         self._stack = _stack
 
@@ -523,7 +532,7 @@ class PydanticModelCreator:
         field: ComputedFieldDescription,
     ) -> Optional[Any]:
         func = field.function
-        annotation = get_annotations(self._cls, func).get("return", None)
+        annotation = get_annotations(self._cls, func, globalns=self.globalns, localns=self.localns).get("return", None)
         comment = _cleandoc(func)
         if annotation is not None:
             c_f = computed_field(return_type=annotation, description=comment)
@@ -555,6 +564,8 @@ class PydanticModelCreator:
                 stack=new_stack,
                 allow_cycles=self.meta.allow_cycles,
                 sort_alphabetically=self.meta.sort_alphabetically,
+                globalns=self.globalns,
+                localns=self.localns,
             )
         else:
             pmodel = None
@@ -581,6 +592,8 @@ def pydantic_model_creator(
     model_config: Optional[ConfigDict] = None,
     validators: Optional[dict[str, Any]] = None,
     module: str = __name__,
+    globalns: dict = None,
+    localns: dict = None,
 ) -> type[PydanticModel]:
     """
     Function to build `Pydantic Model <https://docs.pydantic.dev/latest/concepts/models/>`__ off Tortoise Model.
@@ -607,6 +620,8 @@ def pydantic_model_creator(
     :param model_config: A custom config to use as pydantic config.
     :param validators: A dictionary of methods that validate fields.
     :param module: The name of the module that the model belongs to.
+    :param globalns: If specified, use this dictionary as the globals map.
+    :param localns: If specified, use this dictionary as the locals map.
 
         Note: Created pydantic model uses config_class parameter and PydanticMeta's
             config_class as its Config class's bases(Only if provided!), but it
@@ -627,5 +642,7 @@ def pydantic_model_creator(
         model_config=model_config,
         validators=validators,
         module=module,
+        globalns=globalns,
+        localns=localns,
     )
     return pmc.create_pydantic_model()

--- a/tortoise/contrib/pydantic/utils.py
+++ b/tortoise/contrib/pydantic/utils.py
@@ -5,11 +5,13 @@ if TYPE_CHECKING:  # pragma: nocoverage
     from tortoise.models import Model
 
 
-def get_annotations(cls: "type[Model]", method: Optional[Callable] = None) -> dict[str, Any]:
+def get_annotations(cls: "type[Model]", method: Optional[Callable] = None, globalns: dict = None, localns: dict = None) -> dict[str, Any]:
     """
     Get all annotations including base classes
     :param cls: The model class we need annotations from
     :param method: If specified, we try to get the annotations for the callable
+    :param globalns: If specified, use this dictionary as the globals map
+    :param localns: If specified, use this dictionary as the locals map
     :return: The list of annotations
     """
-    return get_type_hints(method or cls)
+    return get_type_hints(method or cls, globalns, localns)

--- a/tortoise/contrib/pydantic/utils.py
+++ b/tortoise/contrib/pydantic/utils.py
@@ -5,7 +5,12 @@ if TYPE_CHECKING:  # pragma: nocoverage
     from tortoise.models import Model
 
 
-def get_annotations(cls: "type[Model]", method: Optional[Callable] = None, globalns: dict = None, localns: dict = None) -> dict[str, Any]:
+def get_annotations(
+    cls: "type[Model]",
+    method: Optional[Callable] = None,
+    globalns: Optional[dict] = None,
+    localns: Optional[dict] = None,
+) -> dict[str, Any]:
     """
     Get all annotations including base classes
     :param cls: The model class we need annotations from


### PR DESCRIPTION
## Description
When using typing.get_type_hints in Python 3.12, the get_type_hints method will not evaluate forward references unless the referenced objects are part of the objects module scope, or the references are specified in the globalns/localns argument of get_type_hints.

## Motivation and Context
When the models are not in the same module, forward references can't be evaluated.

My project structure resembles:
```python
# models/__init__.py
from .event import Event
from .tournament import Tournament

__all__ = [
    Event,
    Tournament,
]
```

```python
# models/event.py
from tortoise import Model, fields

from .tournament import Tournament


class Event(Model):
    id = fields.IntField(primary_key=True)
    name = fields.TextField()
    tournament: fields.ForeignKeyRelation[Tournament] = fields.ForeignKeyField(
        "models.Tournament", related_name="events"
    )

    def __str__(self):
        return self.name
```

```python
# models/tournament.py
from tortoise import Model, fields


class Tournament(Model):
    id = fields.IntField(primary_key=True)
    name = fields.TextField()

    events: fields.ReverseRelation["Event"]

    def __str__(self):
        return self.name
```

```python
# main.py
from models import Tournament

from tortoise.contrib.pydantic.creator import pydantic_model_creator

if __name__ == "__main__":
    a = pydantic_model_creator(Tournament)
```

Output:
```bash
NameError: name 'Event' is not defined
```

As a temporary fix, I've added this logic in `models/__init__.py`, which is not ideal:
```python
for m in __all__:
    m.__module__ = __name__
```

I propose a solution where users specify the globalns for typing.get_type_hints:
```python
# main.py
import models

from tortoise.contrib.pydantic.creator import pydantic_model_creator


globalns = {
    "Tournament": models.Tournament,
    "Event": models.Event,
}

if __name__ == "__main__":
    a = pydantic_model_creator(models.Tournament, globalns=globalns)
```

I might be missing something, or maybe there's a more elegant solution. I'm open to discussion and feedback.

## How Has This Been Tested?
I have been able to generate pydantic models by specifying globalns `Dict[str, Type[Model]]` when using `pydantic_model_creator` of my fork.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added the changelog accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
