### PR TITLE
Implement __contains, __contained_by, __overlap and __len for ArrayField

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,14 +11,16 @@ Changelog
 
 0.24.1 (unreleased)
 ------
+Added
+^^^^^
+- Implement __contains, __contained_by, __overlap and __len for ArrayField (#1877)
+
 Fixed
 ^^^^^
 - Fix update pk field raises unfriendly error (#1873)
-- Fixed asyncio "no current event loop" deprecation warning by replacing `asyncio.get_event_loop()` with modern event loop handling using `get_running_loop()` with fallback to `new_event_loop()` (#1865)
 
 Changed
 ^^^^^^^
-- add benchmarks for `get_for_dialect` (#1862)
 
 0.24.0
 ------

--- a/docs/query.rst
+++ b/docs/query.rst
@@ -285,7 +285,7 @@ PostgreSQL and SQLite also support ``iposix_regex``, which makes case insensive 
     obj = await DemoModel.filter(demo_text__iposix_regex="^hello world$").first()
 
 
-In PostgreSQL, ``filter`` supports additional lookup types:
+In PostgreSQL, for ``JSONField``, ``filter`` supports additional lookup types:
 
 - ``in`` - ``await JSONModel.filter(data__filter={"breed__in": ["labrador", "poodle"]}).first()``
 - ``not_in``
@@ -300,6 +300,13 @@ In PostgreSQL, ``filter`` supports additional lookup types:
 - ``icontains``
 - ``istartswith``
 - ``iendswith``
+
+In PostgreSQL, for ``ArrayField``, the following lookup types are available:
+
+- ``contains`` - ``await ArrayFields.filter(array__contains=[1, 2, 3]).first()`` which will use the ``@>`` operator
+- ``contained_by`` - will use the ``<@`` operator
+- ``overlap`` - will use the ``&&`` operator
+- ``len`` - will use the ``array_length`` function, e.g. ``await ArrayFields.filter(array__len=3).first()``
 
 
 Complex prefetch

--- a/docs/query.rst
+++ b/docs/query.rst
@@ -285,7 +285,7 @@ PostgreSQL and SQLite also support ``iposix_regex``, which makes case insensive 
     obj = await DemoModel.filter(demo_text__iposix_regex="^hello world$").first()
 
 
-In PostgreSQL, for ``JSONField``, ``filter`` supports additional lookup types:
+With PostgreSQL, for ``JSONField``, ``filter`` supports additional lookup types:
 
 - ``in`` - ``await JSONModel.filter(data__filter={"breed__in": ["labrador", "poodle"]}).first()``
 - ``not_in``
@@ -301,7 +301,7 @@ In PostgreSQL, for ``JSONField``, ``filter`` supports additional lookup types:
 - ``istartswith``
 - ``iendswith``
 
-In PostgreSQL, for ``ArrayField``, the following lookup types are available:
+With PostgreSQL, ``ArrayField`` can be used with the following lookup types:
 
 - ``contains`` - ``await ArrayFields.filter(array__contains=[1, 2, 3]).first()`` which will use the ``@>`` operator
 - ``contained_by`` - will use the ``<@`` operator

--- a/tests/fields/test_array.py
+++ b/tests/fields/test_array.py
@@ -135,3 +135,17 @@ class TestArrayFields(test.IsolatedTestCase):
             "array", flat=True
         )
         self.assertEqual(sorted(list(found)), [[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+
+    async def test_array_length(self):
+        await testmodels.ArrayFields.create(array=[1, 2, 3])
+        await testmodels.ArrayFields.create(array=[1])
+        await testmodels.ArrayFields.create(array=[1, 2])
+
+        found = await testmodels.ArrayFields.filter(array__len=3).values_list("array", flat=True)
+        self.assertEqual(list(found), [[1, 2, 3]])
+
+        found = await testmodels.ArrayFields.filter(array__len=1).values_list("array", flat=True)
+        self.assertEqual(list(found), [[1]])
+
+        found = await testmodels.ArrayFields.filter(array__len=0).values_list("array", flat=True)
+        self.assertEqual(list(found), [])

--- a/tests/fields/test_array.py
+++ b/tests/fields/test_array.py
@@ -44,120 +44,92 @@ class TestArrayFields(test.IsolatedTestCase):
         self.assertEqual(values, [0])
 
     async def test_eq_filter(self):
-        o1 = await testmodels.ArrayFields.create(array=[1, 2, 3])
-        o2 = await testmodels.ArrayFields.create(array=[1, 2])
+        obj1 = await testmodels.ArrayFields.create(array=[1, 2, 3])
+        obj2 = await testmodels.ArrayFields.create(array=[1, 2])
 
         found = await testmodels.ArrayFields.filter(array=[1, 2, 3]).first()
-        self.assertEqual(found, o1)
+        self.assertEqual(found, obj1)
 
         found = await testmodels.ArrayFields.filter(array=[1, 2]).first()
-        self.assertEqual(found, o2)
+        self.assertEqual(found, obj2)
 
     async def test_not_filter(self):
         await testmodels.ArrayFields.create(array=[1, 2, 3])
-        o2 = await testmodels.ArrayFields.create(array=[1, 2])
+        obj2 = await testmodels.ArrayFields.create(array=[1, 2])
 
         found = await testmodels.ArrayFields.filter(array__not=[1, 2, 3]).first()
-        self.assertEqual(found, o2)
+        self.assertEqual(found, obj2)
 
     async def test_contains_ints(self):
-        await testmodels.ArrayFields.create(array=[1, 2, 3])
-        await testmodels.ArrayFields.create(array=[2, 3])
+        obj1 = await testmodels.ArrayFields.create(array=[1, 2, 3])
+        obj2 = await testmodels.ArrayFields.create(array=[2, 3])
         await testmodels.ArrayFields.create(array=[4, 5, 6])
 
-        found = await testmodels.ArrayFields.filter(array__contains=[2]).values_list(
-            "array", flat=True
-        )
-        self.assertEqual(list(found), [[1, 2, 3], [2, 3]])
+        found = await testmodels.ArrayFields.filter(array__contains=[2])
+        self.assertEqual(found, [obj1, obj2])
 
-        found = await testmodels.ArrayFields.filter(array__contains=[10]).values_list(
-            "array", flat=True
-        )
-        self.assertEqual(list(found), [])
+        found = await testmodels.ArrayFields.filter(array__contains=[10])
+        self.assertEqual(found, [])
 
     async def test_contains_smallints(self):
-        o1 = await testmodels.ArrayFields.create(array=[], array_smallint=[1, 2, 3])
+        obj1 = await testmodels.ArrayFields.create(array=[], array_smallint=[1, 2, 3])
 
         found = await testmodels.ArrayFields.filter(array_smallint__contains=[2]).first()
-        self.assertEqual(found, o1)
+        self.assertEqual(found, obj1)
 
     async def test_contains_strs(self):
-        await testmodels.ArrayFields.create(array_str=["a", "b", "c"], array=[])
+        obj1 = await testmodels.ArrayFields.create(array_str=["a", "b", "c"], array=[])
 
-        found = await testmodels.ArrayFields.filter(
-            array_str__contains=["a", "b", "c"]
-        ).values_list("array_str", flat=True)
-        self.assertEqual(list(found), [["a", "b", "c"]])
+        found = await testmodels.ArrayFields.filter(array_str__contains=["a", "b", "c"])
+        self.assertEqual(found, [obj1])
 
-        found = await testmodels.ArrayFields.filter(array_str__contains=["a", "b"]).values_list(
-            "array_str", flat=True
-        )
-        self.assertEqual(list(found), [["a", "b", "c"]])
+        found = await testmodels.ArrayFields.filter(array_str__contains=["a", "b"])
+        self.assertEqual(found, [obj1])
 
-        found = await testmodels.ArrayFields.filter(
-            array_str__contains=["a", "b", "c", "d"]
-        ).values_list("array_str", flat=True)
-        self.assertEqual(list(found), [])
+        found = await testmodels.ArrayFields.filter(array_str__contains=["a", "b", "c", "d"])
+        self.assertEqual(found, [])
 
     async def test_contained_by_ints(self):
-        await testmodels.ArrayFields.create(array=[1])
-        await testmodels.ArrayFields.create(array=[1, 2])
-        await testmodels.ArrayFields.create(array=[1, 2, 3])
+        obj1 = await testmodels.ArrayFields.create(array=[1])
+        obj2 = await testmodels.ArrayFields.create(array=[1, 2])
+        obj3 = await testmodels.ArrayFields.create(array=[1, 2, 3])
 
-        found = await testmodels.ArrayFields.filter(array__contained_by=[1, 2, 3]).values_list(
-            "array", flat=True
-        )
-        self.assertEqual(sorted(list(found)), [[1], [1, 2], [1, 2, 3]])
+        found = await testmodels.ArrayFields.filter(array__contained_by=[1, 2, 3])
+        self.assertEqual(found, [obj1, obj2, obj3])
 
-        found = await testmodels.ArrayFields.filter(array__contained_by=[1, 2]).values_list(
-            "array", flat=True
-        )
-        self.assertEqual(sorted(list(found)), [[1], [1, 2]])
+        found = await testmodels.ArrayFields.filter(array__contained_by=[1, 2])
+        self.assertEqual(found, [obj1, obj2])
 
-        found = await testmodels.ArrayFields.filter(array__contained_by=[1]).values_list(
-            "array", flat=True
-        )
-        self.assertEqual(list(found), [[1]])
+        found = await testmodels.ArrayFields.filter(array__contained_by=[1])
+        self.assertEqual(found, [obj1])
 
     async def test_contained_by_strs(self):
-        await testmodels.ArrayFields.create(array_str=["a"], array=[])
-        await testmodels.ArrayFields.create(array_str=["a", "b"], array=[])
-        await testmodels.ArrayFields.create(array_str=["a", "b", "c"], array=[])
+        obj1 = await testmodels.ArrayFields.create(array_str=["a"], array=[])
+        obj2 = await testmodels.ArrayFields.create(array_str=["a", "b"], array=[])
+        obj3 = await testmodels.ArrayFields.create(array_str=["a", "b", "c"], array=[])
 
-        found = await testmodels.ArrayFields.filter(
-            array_str__contained_by=["a", "b", "c", "d"]
-        ).values_list("array_str", flat=True)
-        self.assertEqual(sorted(list(found)), [["a"], ["a", "b"], ["a", "b", "c"]])
+        found = await testmodels.ArrayFields.filter(array_str__contained_by=["a", "b", "c", "d"])
+        self.assertEqual(found, [obj1, obj2, obj3])
 
-        found = await testmodels.ArrayFields.filter(array_str__contained_by=["a", "b"]).values_list(
-            "array_str", flat=True
-        )
-        self.assertEqual(sorted(list(found)), [["a"], ["a", "b"]])
+        found = await testmodels.ArrayFields.filter(array_str__contained_by=["a", "b"])
+        self.assertEqual(found, [obj1, obj2])
 
-        found = await testmodels.ArrayFields.filter(
-            array_str__contained_by=["x", "y", "z"]
-        ).values_list("array_str", flat=True)
-        self.assertEqual(list(found), [])
+        found = await testmodels.ArrayFields.filter(array_str__contained_by=["x", "y", "z"])
+        self.assertEqual(found, [])
 
     async def test_overlap_ints(self):
-        await testmodels.ArrayFields.create(array=[1, 2, 3])
-        await testmodels.ArrayFields.create(array=[2, 3, 4])
-        await testmodels.ArrayFields.create(array=[3, 4, 5])
+        obj1 = await testmodels.ArrayFields.create(array=[1, 2, 3])
+        obj2 = await testmodels.ArrayFields.create(array=[2, 3, 4])
+        obj3 = await testmodels.ArrayFields.create(array=[3, 4, 5])
 
-        found = await testmodels.ArrayFields.filter(array__overlap=[1, 2]).values_list(
-            "array", flat=True
-        )
-        self.assertEqual(sorted(list(found)), [[1, 2, 3], [2, 3, 4]])
+        found = await testmodels.ArrayFields.filter(array__overlap=[1, 2])
+        self.assertEqual(found, [obj1, obj2])
 
-        found = await testmodels.ArrayFields.filter(array__overlap=[4]).values_list(
-            "array", flat=True
-        )
-        self.assertEqual(sorted(list(found)), [[2, 3, 4], [3, 4, 5]])
+        found = await testmodels.ArrayFields.filter(array__overlap=[4])
+        self.assertEqual(found, [obj2, obj3])
 
-        found = await testmodels.ArrayFields.filter(array__overlap=[1, 2, 3, 4, 5]).values_list(
-            "array", flat=True
-        )
-        self.assertEqual(sorted(list(found)), [[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+        found = await testmodels.ArrayFields.filter(array__overlap=[1, 2, 3, 4, 5])
+        self.assertEqual(found, [obj1, obj2, obj3])
 
     async def test_array_length(self):
         await testmodels.ArrayFields.create(array=[1, 2, 3])

--- a/tests/fields/test_array.py
+++ b/tests/fields/test_array.py
@@ -43,6 +43,23 @@ class TestArrayFields(test.IsolatedTestCase):
         values = await testmodels.ArrayFields.get(id=obj0.id).values_list("array", flat=True)
         self.assertEqual(values, [0])
 
+    async def test_eq_filter(self):
+        o1 = await testmodels.ArrayFields.create(array=[1, 2, 3])
+        o2 = await testmodels.ArrayFields.create(array=[1, 2])
+
+        found = await testmodels.ArrayFields.filter(array=[1, 2, 3]).first()
+        self.assertEqual(found, o1)
+
+        found = await testmodels.ArrayFields.filter(array=[1, 2]).first()
+        self.assertEqual(found, o2)
+
+    async def test_not_filter(self):
+        await testmodels.ArrayFields.create(array=[1, 2, 3])
+        o2 = await testmodels.ArrayFields.create(array=[1, 2])
+
+        found = await testmodels.ArrayFields.filter(array__not=[1, 2, 3]).first()
+        self.assertEqual(found, o2)
+
     async def test_contains_ints(self):
         await testmodels.ArrayFields.create(array=[1, 2, 3])
         await testmodels.ArrayFields.create(array=[2, 3])
@@ -57,6 +74,12 @@ class TestArrayFields(test.IsolatedTestCase):
             "array", flat=True
         )
         self.assertEqual(list(found), [])
+
+    async def test_contains_smallints(self):
+        o1 = await testmodels.ArrayFields.create(array=[], array_smallint=[1, 2, 3])
+
+        found = await testmodels.ArrayFields.filter(array_smallint__contains=[2]).first()
+        self.assertEqual(found, o1)
 
     async def test_contains_strs(self):
         await testmodels.ArrayFields.create(array_str=["a", "b", "c"], array=[])

--- a/tests/fields/test_array.py
+++ b/tests/fields/test_array.py
@@ -42,3 +42,36 @@ class TestArrayFields(test.IsolatedTestCase):
         obj0 = await testmodels.ArrayFields.create(array=[0])
         values = await testmodels.ArrayFields.get(id=obj0.id).values_list("array", flat=True)
         self.assertEqual(values, [0])
+
+    async def test_contains_single_value(self):
+        await testmodels.ArrayFields.create(array=[1, 2, 3])
+        await testmodels.ArrayFields.create(array=[4, 5, 6])
+        await testmodels.ArrayFields.create(array=[7, 8, 9])
+
+        found = await testmodels.ArrayFields.filter(array__contains=[2]).values_list(
+            "array", flat=True
+        )
+        self.assertEqual(list(found), [[1, 2, 3]])
+
+        found = await testmodels.ArrayFields.filter(array__contains=[10]).values_list(
+            "array", flat=True
+        )
+        self.assertEqual(list(found), [])
+
+    async def test_contains_multiple_values(self):
+        await testmodels.ArrayFields.create(array_str=["a", "b", "c"], array=[])
+
+        found = await testmodels.ArrayFields.filter(
+            array_str__contains=["a", "b", "c"]
+        ).values_list("array_str", flat=True)
+        self.assertEqual(list(found), [["a", "b", "c"]])
+
+        found = await testmodels.ArrayFields.filter(array_str__contains=["a", "b"]).values_list(
+            "array_str", flat=True
+        )
+        self.assertEqual(list(found), [["a", "b", "c"]])
+
+        found = await testmodels.ArrayFields.filter(
+            array_str__contains=["a", "b", "c", "d"]
+        ).values_list("array_str", flat=True)
+        self.assertEqual(list(found), [])

--- a/tests/fields/test_array.py
+++ b/tests/fields/test_array.py
@@ -43,22 +43,22 @@ class TestArrayFields(test.IsolatedTestCase):
         values = await testmodels.ArrayFields.get(id=obj0.id).values_list("array", flat=True)
         self.assertEqual(values, [0])
 
-    async def test_contains_single_value(self):
+    async def test_contains_ints(self):
         await testmodels.ArrayFields.create(array=[1, 2, 3])
+        await testmodels.ArrayFields.create(array=[2, 3])
         await testmodels.ArrayFields.create(array=[4, 5, 6])
-        await testmodels.ArrayFields.create(array=[7, 8, 9])
 
         found = await testmodels.ArrayFields.filter(array__contains=[2]).values_list(
             "array", flat=True
         )
-        self.assertEqual(list(found), [[1, 2, 3]])
+        self.assertEqual(list(found), [[1, 2, 3], [2, 3]])
 
         found = await testmodels.ArrayFields.filter(array__contains=[10]).values_list(
             "array", flat=True
         )
         self.assertEqual(list(found), [])
 
-    async def test_contains_multiple_values(self):
+    async def test_contains_strs(self):
         await testmodels.ArrayFields.create(array_str=["a", "b", "c"], array=[])
 
         found = await testmodels.ArrayFields.filter(
@@ -73,5 +73,45 @@ class TestArrayFields(test.IsolatedTestCase):
 
         found = await testmodels.ArrayFields.filter(
             array_str__contains=["a", "b", "c", "d"]
+        ).values_list("array_str", flat=True)
+        self.assertEqual(list(found), [])
+
+    async def test_contained_by_ints(self):
+        await testmodels.ArrayFields.create(array=[1])
+        await testmodels.ArrayFields.create(array=[1, 2])
+        await testmodels.ArrayFields.create(array=[1, 2, 3])
+
+        found = await testmodels.ArrayFields.filter(array__contained_by=[1, 2, 3]).values_list(
+            "array", flat=True
+        )
+        self.assertEqual(sorted(list(found)), [[1], [1, 2], [1, 2, 3]])
+
+        found = await testmodels.ArrayFields.filter(array__contained_by=[1, 2]).values_list(
+            "array", flat=True
+        )
+        self.assertEqual(sorted(list(found)), [[1], [1, 2]])
+
+        found = await testmodels.ArrayFields.filter(array__contained_by=[1]).values_list(
+            "array", flat=True
+        )
+        self.assertEqual(list(found), [[1]])
+
+    async def test_contained_by_strs(self):
+        await testmodels.ArrayFields.create(array_str=["a"], array=[])
+        await testmodels.ArrayFields.create(array_str=["a", "b"], array=[])
+        await testmodels.ArrayFields.create(array_str=["a", "b", "c"], array=[])
+
+        found = await testmodels.ArrayFields.filter(
+            array_str__contained_by=["a", "b", "c", "d"]
+        ).values_list("array_str", flat=True)
+        self.assertEqual(sorted(list(found)), [["a"], ["a", "b"], ["a", "b", "c"]])
+
+        found = await testmodels.ArrayFields.filter(array_str__contained_by=["a", "b"]).values_list(
+            "array_str", flat=True
+        )
+        self.assertEqual(sorted(list(found)), [["a"], ["a", "b"]])
+
+        found = await testmodels.ArrayFields.filter(
+            array_str__contained_by=["x", "y", "z"]
         ).values_list("array_str", flat=True)
         self.assertEqual(list(found), [])

--- a/tests/fields/test_array.py
+++ b/tests/fields/test_array.py
@@ -115,3 +115,23 @@ class TestArrayFields(test.IsolatedTestCase):
             array_str__contained_by=["x", "y", "z"]
         ).values_list("array_str", flat=True)
         self.assertEqual(list(found), [])
+
+    async def test_overlap_ints(self):
+        await testmodels.ArrayFields.create(array=[1, 2, 3])
+        await testmodels.ArrayFields.create(array=[2, 3, 4])
+        await testmodels.ArrayFields.create(array=[3, 4, 5])
+
+        found = await testmodels.ArrayFields.filter(array__overlap=[1, 2]).values_list(
+            "array", flat=True
+        )
+        self.assertEqual(sorted(list(found)), [[1, 2, 3], [2, 3, 4]])
+
+        found = await testmodels.ArrayFields.filter(array__overlap=[4]).values_list(
+            "array", flat=True
+        )
+        self.assertEqual(sorted(list(found)), [[2, 3, 4], [3, 4, 5]])
+
+        found = await testmodels.ArrayFields.filter(array__overlap=[1, 2, 3, 4, 5]).values_list(
+            "array", flat=True
+        )
+        self.assertEqual(sorted(list(found)), [[1, 2, 3], [2, 3, 4], [3, 4, 5]])

--- a/tests/testmodels_postgres.py
+++ b/tests/testmodels_postgres.py
@@ -7,3 +7,4 @@ class ArrayFields(Model):
     array = ArrayField()
     array_null = ArrayField(null=True)
     array_str = ArrayField(element_type="varchar(1)", null=True)
+    array_smallint = ArrayField(element_type="smallint", null=True)

--- a/tests/testmodels_postgres.py
+++ b/tests/testmodels_postgres.py
@@ -6,3 +6,4 @@ class ArrayFields(Model):
     id = fields.IntField(primary_key=True)
     array = ArrayField()
     array_null = ArrayField(null=True)
+    array_str = ArrayField(element_type="varchar(1)", null=True)

--- a/tortoise/backends/base_postgres/executor.py
+++ b/tortoise/backends/base_postgres/executor.py
@@ -10,6 +10,7 @@ from tortoise.backends.base.executor import BaseExecutor
 from tortoise.contrib.postgres.array_functions import (
     postgres_array_contains,
     postgres_array_contained_by,
+    postgres_array_overlap,
 )
 from tortoise.contrib.postgres.json_functions import (
     postgres_json_contained_by,
@@ -24,6 +25,7 @@ from tortoise.contrib.postgres.search import SearchCriterion
 from tortoise.filters import (
     array_contains,
     array_contained_by,
+    array_overlap,
     insensitive_posix_regex,
     json_contained_by,
     json_contains,
@@ -44,6 +46,7 @@ class BasePostgresExecutor(BaseExecutor):
         search: postgres_search,
         array_contains: postgres_array_contains,
         array_contained_by: postgres_array_contained_by,
+        array_overlap: postgres_array_overlap,
         json_contains: postgres_json_contains,
         json_contained_by: postgres_json_contained_by,
         json_filter: postgres_json_filter,

--- a/tortoise/backends/base_postgres/executor.py
+++ b/tortoise/backends/base_postgres/executor.py
@@ -11,6 +11,7 @@ from tortoise.contrib.postgres.array_functions import (
     postgres_array_contains,
     postgres_array_contained_by,
     postgres_array_overlap,
+    postgres_array_length,
 )
 from tortoise.contrib.postgres.json_functions import (
     postgres_json_contained_by,
@@ -32,6 +33,7 @@ from tortoise.filters import (
     json_filter,
     posix_regex,
     search,
+    array_length,
 )
 
 
@@ -52,6 +54,7 @@ class BasePostgresExecutor(BaseExecutor):
         json_filter: postgres_json_filter,
         posix_regex: postgres_posix_regex,
         insensitive_posix_regex: postgres_insensitive_posix_regex,
+        array_length: postgres_array_length,
     }
 
     def _prepare_insert_statement(

--- a/tortoise/backends/base_postgres/executor.py
+++ b/tortoise/backends/base_postgres/executor.py
@@ -7,6 +7,7 @@ from pypika_tortoise.terms import Term
 
 from tortoise import Model
 from tortoise.backends.base.executor import BaseExecutor
+from tortoise.contrib.postgres.array_functions import postgres_array_contains
 from tortoise.contrib.postgres.json_functions import (
     postgres_json_contained_by,
     postgres_json_contains,
@@ -18,6 +19,7 @@ from tortoise.contrib.postgres.regex import (
 )
 from tortoise.contrib.postgres.search import SearchCriterion
 from tortoise.filters import (
+    array_contains,
     insensitive_posix_regex,
     json_contained_by,
     json_contains,
@@ -36,6 +38,7 @@ class BasePostgresExecutor(BaseExecutor):
     DB_NATIVE = BaseExecutor.DB_NATIVE | {bool, uuid.UUID}
     FILTER_FUNC_OVERRIDE = {
         search: postgres_search,
+        array_contains: postgres_array_contains,
         json_contains: postgres_json_contains,
         json_contained_by: postgres_json_contained_by,
         json_filter: postgres_json_filter,

--- a/tortoise/backends/base_postgres/executor.py
+++ b/tortoise/backends/base_postgres/executor.py
@@ -7,7 +7,10 @@ from pypika_tortoise.terms import Term
 
 from tortoise import Model
 from tortoise.backends.base.executor import BaseExecutor
-from tortoise.contrib.postgres.array_functions import postgres_array_contains
+from tortoise.contrib.postgres.array_functions import (
+    postgres_array_contains,
+    postgres_array_contained_by,
+)
 from tortoise.contrib.postgres.json_functions import (
     postgres_json_contained_by,
     postgres_json_contains,
@@ -20,6 +23,7 @@ from tortoise.contrib.postgres.regex import (
 from tortoise.contrib.postgres.search import SearchCriterion
 from tortoise.filters import (
     array_contains,
+    array_contained_by,
     insensitive_posix_regex,
     json_contained_by,
     json_contains,
@@ -39,6 +43,7 @@ class BasePostgresExecutor(BaseExecutor):
     FILTER_FUNC_OVERRIDE = {
         search: postgres_search,
         array_contains: postgres_array_contains,
+        array_contained_by: postgres_array_contained_by,
         json_contains: postgres_json_contains,
         json_contained_by: postgres_json_contained_by,
         json_filter: postgres_json_filter,

--- a/tortoise/backends/base_postgres/executor.py
+++ b/tortoise/backends/base_postgres/executor.py
@@ -8,10 +8,10 @@ from pypika_tortoise.terms import Term
 from tortoise import Model
 from tortoise.backends.base.executor import BaseExecutor
 from tortoise.contrib.postgres.array_functions import (
-    postgres_array_contains,
     postgres_array_contained_by,
-    postgres_array_overlap,
+    postgres_array_contains,
     postgres_array_length,
+    postgres_array_overlap,
 )
 from tortoise.contrib.postgres.json_functions import (
     postgres_json_contained_by,
@@ -24,8 +24,9 @@ from tortoise.contrib.postgres.regex import (
 )
 from tortoise.contrib.postgres.search import SearchCriterion
 from tortoise.filters import (
-    array_contains,
     array_contained_by,
+    array_contains,
+    array_length,
     array_overlap,
     insensitive_posix_regex,
     json_contained_by,
@@ -33,7 +34,6 @@ from tortoise.filters import (
     json_filter,
     posix_regex,
     search,
-    array_length,
 )
 
 

--- a/tortoise/contrib/postgres/array_functions.py
+++ b/tortoise/contrib/postgres/array_functions.py
@@ -1,0 +1,15 @@
+from enum import Enum
+from typing import Any, Sequence, Union
+
+from pypika_tortoise.terms import Array, BasicCriterion, Criterion, Term
+
+
+class PostgresArrayOperators(str, Enum):
+    CONTAINS = "@>"
+
+
+def postgres_array_contains(field: Term, value: Union[Any, Sequence[Any]]) -> Criterion:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        value = (value,)
+
+    return BasicCriterion(PostgresArrayOperators.CONTAINS, field, Array(*value))

--- a/tortoise/contrib/postgres/array_functions.py
+++ b/tortoise/contrib/postgres/array_functions.py
@@ -6,6 +6,7 @@ from pypika_tortoise.terms import Array, BasicCriterion, Criterion, Term
 
 class PostgresArrayOperators(str, Enum):
     CONTAINS = "@>"
+    CONTAINED_BY = "<@"
 
 
 def postgres_array_contains(field: Term, value: Union[Any, Sequence[Any]]) -> Criterion:
@@ -13,3 +14,7 @@ def postgres_array_contains(field: Term, value: Union[Any, Sequence[Any]]) -> Cr
         value = (value,)
 
     return BasicCriterion(PostgresArrayOperators.CONTAINS, field, Array(*value))
+
+
+def postgres_array_contained_by(field: Term, value: Sequence[Any]) -> Criterion:
+    return BasicCriterion(PostgresArrayOperators.CONTAINED_BY, field, Array(*value))

--- a/tortoise/contrib/postgres/array_functions.py
+++ b/tortoise/contrib/postgres/array_functions.py
@@ -7,6 +7,7 @@ from pypika_tortoise.terms import Array, BasicCriterion, Criterion, Term
 class PostgresArrayOperators(str, Enum):
     CONTAINS = "@>"
     CONTAINED_BY = "<@"
+    OVERLAP = "&&"
 
 
 def postgres_array_contains(field: Term, value: Union[Any, Sequence[Any]]) -> Criterion:
@@ -18,3 +19,7 @@ def postgres_array_contains(field: Term, value: Union[Any, Sequence[Any]]) -> Cr
 
 def postgres_array_contained_by(field: Term, value: Sequence[Any]) -> Criterion:
     return BasicCriterion(PostgresArrayOperators.CONTAINED_BY, field, Array(*value))
+
+
+def postgres_array_overlap(field: Term, value: Sequence[Any]) -> Criterion:
+    return BasicCriterion(PostgresArrayOperators.OVERLAP, field, Array(*value))

--- a/tortoise/contrib/postgres/array_functions.py
+++ b/tortoise/contrib/postgres/array_functions.py
@@ -1,8 +1,6 @@
 from enum import Enum
-from typing import Any, Sequence, Union
 
-from pypika_tortoise.terms import Array, BasicCriterion, Criterion, Term
-from pypika_tortoise.functions import Function
+from pypika_tortoise.terms import BasicCriterion, Criterion, Function, Term
 
 
 class PostgresArrayOperators(str, Enum):
@@ -11,19 +9,21 @@ class PostgresArrayOperators(str, Enum):
     OVERLAP = "&&"
 
 
-def postgres_array_contains(field: Term, value: Union[Any, Sequence[Any]]) -> Criterion:
-    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
-        value = (value,)
-
-    return BasicCriterion(PostgresArrayOperators.CONTAINS, field, Array(*value))
+# The value in the functions below is casted to the exact type of the field with value_encoder
+# to avoid issues with psycopg that tries to use the smallest possible type which can lead to errors,
+# e.g. {1,2} will be casted to smallint[] instead of integer[].
 
 
-def postgres_array_contained_by(field: Term, value: Sequence[Any]) -> Criterion:
-    return BasicCriterion(PostgresArrayOperators.CONTAINED_BY, field, Array(*value))
+def postgres_array_contains(field: Term, value: Term) -> Criterion:
+    return BasicCriterion(PostgresArrayOperators.CONTAINS, field, value)
 
 
-def postgres_array_overlap(field: Term, value: Sequence[Any]) -> Criterion:
-    return BasicCriterion(PostgresArrayOperators.OVERLAP, field, Array(*value))
+def postgres_array_contained_by(field: Term, value: Term) -> Criterion:
+    return BasicCriterion(PostgresArrayOperators.CONTAINED_BY, field, value)
+
+
+def postgres_array_overlap(field: Term, value: Term) -> Criterion:
+    return BasicCriterion(PostgresArrayOperators.OVERLAP, field, value)
 
 
 def postgres_array_length(field: Term, value: int) -> Criterion:

--- a/tortoise/contrib/postgres/array_functions.py
+++ b/tortoise/contrib/postgres/array_functions.py
@@ -2,6 +2,7 @@ from enum import Enum
 from typing import Any, Sequence, Union
 
 from pypika_tortoise.terms import Array, BasicCriterion, Criterion, Term
+from pypika_tortoise.functions import Function
 
 
 class PostgresArrayOperators(str, Enum):
@@ -23,3 +24,8 @@ def postgres_array_contained_by(field: Term, value: Sequence[Any]) -> Criterion:
 
 def postgres_array_overlap(field: Term, value: Sequence[Any]) -> Criterion:
     return BasicCriterion(PostgresArrayOperators.OVERLAP, field, Array(*value))
+
+
+def postgres_array_length(field: Term, value: int) -> Criterion:
+    """Returns a criterion that checks if array length equals the given value"""
+    return Function("array_length", field, 1).eq(value)

--- a/tortoise/expressions.py
+++ b/tortoise/expressions.py
@@ -355,29 +355,30 @@ class Q:
         join = None
 
         if value is None and f"{key}__isnull" in model._meta.filters:
-            filter = model._meta.get_filter(f"{key}__isnull")
+            filter_info = model._meta.get_filter(f"{key}__isnull")
             value = True
         else:
-            filter = model._meta.get_filter(key)
+            filter_info = model._meta.get_filter(key)
 
-        if "table" in filter:
+        if "table" in filter_info:
             # join the table
             join = (
-                filter["table"],
-                table[model._meta.db_pk_column] == filter["table"][filter["backward_key"]],
+                filter_info["table"],
+                table[model._meta.db_pk_column]
+                == filter_info["table"][filter_info["backward_key"]],
             )
-            if "value_encoder" in filter:
-                value = filter["value_encoder"](value, model)
-            table = filter["table"]
+            if "value_encoder" in filter_info:
+                value = filter_info["value_encoder"](value, model)
+            table = filter_info["table"]
         elif not isinstance(value, Term):
-            field_object = model._meta.fields_map[filter["field"]]
+            field_object = model._meta.fields_map[filter_info["field"]]
             value = (
-                filter["value_encoder"](value, model, field_object)
-                if "value_encoder" in filter
+                filter_info["value_encoder"](value, model, field_object)
+                if "value_encoder" in filter_info
                 else field_object.to_db_value(value, model)
             )
-        op = filter["operator"]
-        criterion = op(table[filter.get("source_field", filter["field"])], value)
+        op = filter_info["operator"]
+        criterion = op(table[filter_info.get("source_field", filter_info["field"])], value)
         return criterion, join
 
     def _resolve_regular_kwarg(

--- a/tortoise/expressions.py
+++ b/tortoise/expressions.py
@@ -355,33 +355,29 @@ class Q:
         join = None
 
         if value is None and f"{key}__isnull" in model._meta.filters:
-            param = model._meta.get_filter(f"{key}__isnull")
+            filter = model._meta.get_filter(f"{key}__isnull")
             value = True
         else:
-            param = model._meta.get_filter(key)
+            filter = model._meta.get_filter(key)
 
-        pk_db_field = model._meta.db_pk_column
-        if param.get("table"):
+        if "table" in filter:
+            # join the table
             join = (
-                param["table"],
-                table[pk_db_field] == param["table"][param["backward_key"]],
+                filter["table"],
+                table[model._meta.db_pk_column] == filter["table"][filter["backward_key"]],
             )
-            if param.get("value_encoder"):
-                value = param["value_encoder"](value, model)
-            op = param["operator"]
-            criterion = op(param["table"][param["field"]], value)
-        else:
-            if isinstance(value, Term):
-                encoded_value = value
-            else:
-                field_object = model._meta.fields_map[param["field"]]
-                encoded_value = (
-                    param["value_encoder"](value, model, field_object)
-                    if param.get("value_encoder")
-                    else field_object.to_db_value(value, model)
-                )
-            op = param["operator"]
-            criterion = op(table[param["source_field"]], encoded_value)
+            if "value_encoder" in filter:
+                value = filter["value_encoder"](value, model)
+            table = filter["table"]
+        elif not isinstance(value, Term):
+            field_object = model._meta.fields_map[filter["field"]]
+            value = (
+                filter["value_encoder"](value, model, field_object)
+                if "value_encoder" in filter
+                else field_object.to_db_value(value, model)
+            )
+        op = filter["operator"]
+        criterion = op(table[filter.get("source_field", filter["field"])], value)
         return criterion, join
 
     def _resolve_regular_kwarg(

--- a/tortoise/fields/base.py
+++ b/tortoise/fields/base.py
@@ -317,6 +317,13 @@ class Field(Generic[VALUE], metaclass=_FieldMeta):
 
         return ret
 
+    def get_db_field_type(self) -> str:
+        """
+        Returns the DB field type for this field for the current dialect.
+        """
+        dialect = self.model._meta.db.capabilities.dialect
+        return self.get_for_dialect(dialect, "SQL_TYPE")
+
     def get_db_field_types(self) -> Optional[dict[str, str]]:
         """
         Returns the DB types for this field.

--- a/tortoise/filters.py
+++ b/tortoise/filters.py
@@ -234,6 +234,10 @@ def array_contained_by(field: Term, value: Union[Any, Sequence[Any]]) -> Criteri
     raise NotImplementedError("must be overridden in each executor")
 
 
+def array_overlap(field: Term, value: Union[Any, Sequence[Any]]) -> Criterion:
+    raise NotImplementedError("must be overridden in each executor")
+
+
 ##############################################################################
 # Filter resolvers
 ##############################################################################
@@ -420,6 +424,11 @@ def get_array_filter(field_name: str, source_field: str) -> dict[str, FilterInfo
             "field": field_name,
             "source_field": source_field,
             "operator": array_contained_by,
+        },
+        f"{field_name}__overlap": {
+            "field": field_name,
+            "source_field": source_field,
+            "operator": array_overlap,
         },
     }
 

--- a/tortoise/filters.py
+++ b/tortoise/filters.py
@@ -214,22 +214,23 @@ def extract_microsecond_equal(field: Term, value: int) -> Criterion:
     return Extract(DatePart.microsecond, field).eq(value)
 
 
-def json_contains(field: Term, value: str) -> Criterion:  # type:ignore[empty-body]
-    # will be override in each executor
-    pass
+def json_contains(field: Term, value: str) -> Criterion:
+    raise NotImplementedError("must be overridden in each executor")
 
 
-def json_contained_by(field: Term, value: str) -> Criterion:  # type:ignore[empty-body]
-    # will be override in each executor
-    pass
+def json_contained_by(field: Term, value: str) -> Criterion:
+    raise NotImplementedError("must be overridden in each executor")
 
 
-def json_filter(field: Term, value: dict) -> Criterion:  # type:ignore[empty-body]
-    # will be override in each executor
-    pass
+def json_filter(field: Term, value: dict) -> Criterion:
+    raise NotImplementedError("must be overridden in each xecutor")
 
 
 def array_contains(field: Term, value: Union[Any, Sequence[Any]]) -> Criterion:
+    raise NotImplementedError("must be overridden in each executor")
+
+
+def array_contained_by(field: Term, value: Union[Any, Sequence[Any]]) -> Criterion:
     raise NotImplementedError("must be overridden in each executor")
 
 
@@ -414,6 +415,11 @@ def get_array_filter(field_name: str, source_field: str) -> dict[str, FilterInfo
             "field": field_name,
             "source_field": source_field,
             "operator": array_contains,
+        },
+        f"{field_name}__contained_by": {
+            "field": field_name,
+            "source_field": source_field,
+            "operator": array_contained_by,
         },
     }
 

--- a/tortoise/filters.py
+++ b/tortoise/filters.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import operator
 from collections.abc import Callable, Iterable
 from functools import partial
-from typing import TYPE_CHECKING, Any, Optional, TypedDict
+from typing import TYPE_CHECKING, Any, Optional, Sequence, TypedDict, Union
 
 from pypika_tortoise import SqlContext, Table
 from pypika_tortoise.enums import DatePart, Matching, SqlTypes
@@ -17,6 +17,7 @@ from pypika_tortoise.terms import (
 )
 from typing_extensions import NotRequired
 
+from tortoise.contrib.postgres.fields import ArrayField
 from tortoise.fields import Field, JSONField
 from tortoise.fields.relational import BackwardFKRelation, ManyToManyFieldInstance
 
@@ -228,6 +229,10 @@ def json_filter(field: Term, value: dict) -> Criterion:  # type:ignore[empty-bod
     pass
 
 
+def array_contains(field: Term, value: Union[Any, Sequence[Any]]) -> Criterion:
+    raise NotImplementedError("must be overridden in each executor")
+
+
 ##############################################################################
 # Filter resolvers
 ##############################################################################
@@ -381,15 +386,50 @@ def get_json_filter_operator(
     return key_parts, filter_value, operator_
 
 
+def get_array_filter(field_name: str, source_field: str) -> dict[str, FilterInfoDict]:
+    return {
+        field_name: {
+            "field": field_name,
+            "source_field": source_field,
+            "operator": operator.eq,
+        },
+        f"{field_name}__not": {
+            "field": field_name,
+            "source_field": source_field,
+            "operator": not_equal,
+        },
+        f"{field_name}__isnull": {
+            "field": field_name,
+            "source_field": source_field,
+            "operator": is_null,
+            "value_encoder": bool_encoder,
+        },
+        f"{field_name}__not_isnull": {
+            "field": field_name,
+            "source_field": source_field,
+            "operator": not_null,
+            "value_encoder": bool_encoder,
+        },
+        f"{field_name}__contains": {
+            "field": field_name,
+            "source_field": source_field,
+            "operator": array_contains,
+        },
+    }
+
+
 def get_filters_for_field(
     field_name: str, field: Optional[Field], source_field: str
 ) -> dict[str, FilterInfoDict]:
-    if isinstance(field, ManyToManyFieldInstance):
-        return get_m2m_filters(field_name, field)
-    if isinstance(field, BackwardFKRelation):
-        return get_backward_fk_filters(field_name, field)
-    if isinstance(field, JSONField):
-        return get_json_filter(field_name, source_field)
+    if field:
+        if isinstance(field, ManyToManyFieldInstance):
+            return get_m2m_filters(field_name, field)
+        if isinstance(field, BackwardFKRelation):
+            return get_backward_fk_filters(field_name, field)
+        if isinstance(field, JSONField):
+            return get_json_filter(field_name, source_field)
+        if isinstance(field, ArrayField):
+            return get_array_filter(field_name, source_field)
 
     actual_field_name = field_name
     if field_name == "pk" and field:

--- a/tortoise/filters.py
+++ b/tortoise/filters.py
@@ -9,6 +9,7 @@ from pypika_tortoise import SqlContext, Table
 from pypika_tortoise.enums import DatePart, Matching, SqlTypes
 from pypika_tortoise.functions import Cast, Extract, Upper
 from pypika_tortoise.terms import (
+    Array,
     BasicCriterion,
     Criterion,
     Equality,
@@ -79,6 +80,13 @@ def int_encoder(value: Any, instance: "Model", field: Field) -> int:
 
 def json_encoder(value: Any, instance: "Model", field: Field) -> dict:
     return value
+
+
+def array_encoder(value: Union[Any, Sequence[Any]], instance: "Model", field: Field) -> Any:
+    # Casting to the exact type of the field to avoid issues with psycopg that tries
+    # to use the smallest possible type which can lead to errors,
+    # e.g. {1,2} will be casted to smallint[] instead of integer[].
+    return Cast(Array(*value), field.get_db_field_type())
 
 
 ##############################################################################
@@ -343,42 +351,41 @@ def get_backward_fk_filters(
 
 
 def get_json_filter(field_name: str, source_field: str) -> dict[str, FilterInfoDict]:
-    actual_field_name = field_name
     return {
         field_name: {
-            "field": actual_field_name,
+            "field": field_name,
             "source_field": source_field,
             "operator": operator.eq,
         },
         f"{field_name}__not": {
-            "field": actual_field_name,
+            "field": field_name,
             "source_field": source_field,
             "operator": not_equal,
         },
         f"{field_name}__isnull": {
-            "field": actual_field_name,
+            "field": field_name,
             "source_field": source_field,
             "operator": is_null,
             "value_encoder": bool_encoder,
         },
         f"{field_name}__not_isnull": {
-            "field": actual_field_name,
+            "field": field_name,
             "source_field": source_field,
             "operator": not_null,
             "value_encoder": bool_encoder,
         },
         f"{field_name}__contains": {
-            "field": actual_field_name,
+            "field": field_name,
             "source_field": source_field,
             "operator": json_contains,
         },
         f"{field_name}__contained_by": {
-            "field": actual_field_name,
+            "field": field_name,
             "source_field": source_field,
             "operator": json_contained_by,
         },
         f"{field_name}__filter": {
-            "field": actual_field_name,
+            "field": field_name,
             "source_field": source_field,
             "operator": json_filter,
             "value_encoder": json_encoder,
@@ -399,17 +406,21 @@ def get_json_filter_operator(
     return key_parts, filter_value, operator_
 
 
-def get_array_filter(field_name: str, source_field: str) -> dict[str, FilterInfoDict]:
+def get_array_filter(
+    field_name: str, source_field: str, field: ArrayField
+) -> dict[str, FilterInfoDict]:
     return {
         field_name: {
             "field": field_name,
             "source_field": source_field,
             "operator": operator.eq,
+            "value_encoder": array_encoder,
         },
         f"{field_name}__not": {
             "field": field_name,
             "source_field": source_field,
             "operator": not_equal,
+            "value_encoder": array_encoder,
         },
         f"{field_name}__isnull": {
             "field": field_name,
@@ -427,16 +438,19 @@ def get_array_filter(field_name: str, source_field: str) -> dict[str, FilterInfo
             "field": field_name,
             "source_field": source_field,
             "operator": array_contains,
+            "value_encoder": array_encoder,
         },
         f"{field_name}__contained_by": {
             "field": field_name,
             "source_field": source_field,
             "operator": array_contained_by,
+            "value_encoder": array_encoder,
         },
         f"{field_name}__overlap": {
             "field": field_name,
             "source_field": source_field,
             "operator": array_overlap,
+            "value_encoder": array_encoder,
         },
         f"{field_name}__len": {
             "field": field_name,
@@ -458,7 +472,7 @@ def get_filters_for_field(
         if isinstance(field, JSONField):
             return get_json_filter(field_name, source_field)
         if isinstance(field, ArrayField):
-            return get_array_filter(field_name, source_field)
+            return get_array_filter(field_name, source_field, field)
 
     actual_field_name = field_name
     if field_name == "pk" and field:

--- a/tortoise/filters.py
+++ b/tortoise/filters.py
@@ -464,7 +464,7 @@ def get_array_filter(
 def get_filters_for_field(
     field_name: str, field: Optional[Field], source_field: str
 ) -> dict[str, FilterInfoDict]:
-    if field:
+    if field is not None:
         if isinstance(field, ManyToManyFieldInstance):
             return get_m2m_filters(field_name, field)
         if isinstance(field, BackwardFKRelation):

--- a/tortoise/filters.py
+++ b/tortoise/filters.py
@@ -73,6 +73,10 @@ def string_encoder(value: Any, instance: "Model", field: Field) -> str:
     return str(value)
 
 
+def int_encoder(value: Any, instance: "Model", field: Field) -> int:
+    return int(value)
+
+
 def json_encoder(value: Any, instance: "Model", field: Field) -> dict:
     return value
 
@@ -235,6 +239,10 @@ def array_contained_by(field: Term, value: Union[Any, Sequence[Any]]) -> Criteri
 
 
 def array_overlap(field: Term, value: Union[Any, Sequence[Any]]) -> Criterion:
+    raise NotImplementedError("must be overridden in each executor")
+
+
+def array_length(field: Term, value: int) -> Criterion:
     raise NotImplementedError("must be overridden in each executor")
 
 
@@ -429,6 +437,12 @@ def get_array_filter(field_name: str, source_field: str) -> dict[str, FilterInfo
             "field": field_name,
             "source_field": source_field,
             "operator": array_overlap,
+        },
+        f"{field_name}__len": {
+            "field": field_name,
+            "source_field": source_field,
+            "operator": array_length,
+            "value_encoder": int_encoder,
         },
     }
 


### PR DESCRIPTION
## Description
Implements the following lookup types for `ArrayField`:
- `contains` - `await ArrayFields.filter(array__contains=[1, 2, 3]).first()` which will use the `@>` operator
- `contained_by` - will use the `<@` operator
- `overlap` - will use the `&&` operator
- `len` - will use the `array_length` function, e.g. `await ArrayFields.filter(array__len=3).first()`


## Motivation and Context
This should close https://github.com/tortoise/tortoise-orm/issues/1857 and https://github.com/tortoise/tortoise-orm/issues/370.

The filters are modeled after [Django's counterparts](https://docs.djangoproject.com/en/5.1/ref/contrib/postgres/fields/#contains).

## How Has This Been Tested?
`make ci`

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

