### PR TITLE
fix: fastapi exception handlers not work

### DIFF
--- a/examples/fastapi/_tests.py
+++ b/examples/fastapi/_tests.py
@@ -96,6 +96,23 @@ class TestUser(UserTester):
         await self.user_list(client)
 
 
+@pytest.mark.anyio
+async def test_404(client: AsyncClient) -> None:
+    response = await client.get("/404")
+    assert response.status_code == 404, response.text
+    data = response.json()
+    assert isinstance(data["detail"], str)
+
+
+@pytest.mark.anyio
+async def test_422(client: AsyncClient) -> None:
+    response = await client.get("/422")
+    assert response.status_code == 422, response.text
+    data = response.json()
+    assert isinstance(data["detail"], list)
+    assert isinstance(data["detail"][0], dict)
+
+
 class TestUserEast(UserTester):
     timezone = "Asia/Shanghai"
     delta_hours = 8
@@ -121,6 +138,23 @@ class TestUserEast(UserTester):
         created_at = user_obj.created_at
         assert (created_at.hour - time.hour) in [self.delta_hours, self.delta_hours - 24]
         assert item.model_dump()["created_at"].hour == created_at.hour
+
+
+@pytest.mark.anyio
+async def test_404_east(client_east: AsyncClient) -> None:
+    response = await client_east.get("/404")
+    assert response.status_code == 404, response.text
+    data = response.json()
+    assert isinstance(data["detail"], str)
+
+
+@pytest.mark.anyio
+async def test_422_east(client_east: AsyncClient) -> None:
+    response = await client_east.get("/422")
+    assert response.status_code == 422, response.text
+    data = response.json()
+    assert isinstance(data["detail"], list)
+    assert isinstance(data["detail"][0], dict)
 
 
 def query_without_app(pk: int) -> int:

--- a/examples/fastapi/config.py
+++ b/examples/fastapi/config.py
@@ -8,5 +8,4 @@ register_orm = partial(
     db_url=os.getenv("DB_URL", "sqlite://db.sqlite3"),
     modules={"models": ["models"]},
     generate_schemas=True,
-    add_exception_handlers=True,
 )

--- a/examples/fastapi/main.py
+++ b/examples/fastapi/main.py
@@ -8,7 +8,7 @@ from routers import router as users_router
 
 from examples.fastapi.config import register_orm
 from tortoise import Tortoise, generate_config
-from tortoise.contrib.fastapi import RegisterTortoise
+from tortoise.contrib.fastapi import RegisterTortoise, tortoise_exception_handlers
 
 
 @asynccontextmanager
@@ -23,7 +23,6 @@ async def lifespan_test(app: FastAPI) -> AsyncGenerator[None, None]:
         app=app,
         config=config,
         generate_schemas=True,
-        add_exception_handlers=True,
         _create_db=True,
     ):
         # db connected
@@ -47,5 +46,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         # db connections closed
 
 
-app = FastAPI(title="Tortoise ORM FastAPI example", lifespan=lifespan)
+app = FastAPI(
+    title="Tortoise ORM FastAPI example",
+    lifespan=lifespan,
+    exception_handlers=tortoise_exception_handlers(),
+)
 app.include_router(users_router, prefix="")

--- a/examples/fastapi/main_custom_timezone.py
+++ b/examples/fastapi/main_custom_timezone.py
@@ -14,6 +14,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         app,
         use_tz=False,
         timezone="Asia/Shanghai",
+        add_exception_handlers=True,
     ):
         # db connected
         yield

--- a/examples/fastapi/routers.py
+++ b/examples/fastapi/routers.py
@@ -33,3 +33,14 @@ async def delete_user(user_id: int):
     if not deleted_count:
         raise HTTPException(status_code=404, detail=f"User {user_id} not found")
     return Status(message=f"Deleted user {user_id}")
+
+
+@router.get("/404")
+async def get_404():
+    await Users.get(id=0)
+
+
+@router.get("/422")
+async def get_422():
+    obj = await Users.create(username="foo")
+    await Users.create(username=obj.username)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes #1874 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
starlette (used by fastapi) added a DeprecationWarning for `@app.exception_handler`:
https://github.com/encode/starlette/blob/a7d0b14c7378aa2e95b0b13583fe0dadace363be/starlette/applications.py#L166

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
PYTHONPATH=examples/fastapi pytest examples/fastapi/_tests.py

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


