### PR TITLE
add real enum support for mysql/mariadb

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,10 @@ Changelog
 
 0.25.0 (unreleased)
 ------
+Added
+^^^^^
+- Added MySQL-specific ENUM type support for CharEnumField (#1883)
+
 Fixed
 ^^^^^
 - Fixed asyncio "no current event loop" deprecation warning by replacing `asyncio.get_event_loop()` with modern event loop handling using `get_running_loop()` with fallback to `new_event_loop()` (#1865)

--- a/tortoise/fields/data.py
+++ b/tortoise/fields/data.py
@@ -764,7 +764,6 @@ class CharEnumFieldInstance(CharField):
 
     class _db_mysql:
         def __init__(self, field: "CharEnumFieldInstance") -> None:
-            field.description = None
             self.field = field
 
         @property

--- a/tortoise/fields/data.py
+++ b/tortoise/fields/data.py
@@ -13,6 +13,7 @@ from pypika_tortoise.enums import SqlTypes
 from pypika_tortoise.terms import Term
 
 from tortoise import timezone
+from tortoise.converters import escape_str
 from tortoise.exceptions import ConfigurationError, FieldError
 from tortoise.fields.base import Field
 from tortoise.timezone import get_default_timezone, get_timezone, get_use_tz, localtime
@@ -760,6 +761,16 @@ class CharEnumFieldInstance(CharField):
 
         super().__init__(description=description, max_length=max_length, **kwargs)
         self.enum_type = enum_type
+
+    class _db_mysql:
+        def __init__(self, field: "CharEnumFieldInstance") -> None:
+            field.description = None
+            self.field = field
+
+        @property
+        def SQL_TYPE(self) -> str:
+            enum_values = ", ".join(escape_str(e.value) for e in self.field.enum_type)
+            return f"ENUM({enum_values})"
 
     def to_python_value(self, value: Union[str, None]) -> Union[Enum, None]:
         return self.enum_type(value) if value is not None else None


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Added MySQL-specific implementation for CharEnumField to properly support native ENUM types in MySQL databases. This implementation:
- Introduces a new `db_mysql` class for CharEnumFieldInstance
- Converts enum values to MySQL ENUM type definition
- Properly escapes enum values to prevent SQL injection
- Maintains type safety between Python Enum and MySQL ENUM

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, CharEnumField doesn't utilize MySQL's native ENUM type, instead storing enum values as regular VARCHAR fields. This change improves:
- Data integrity by enforcing enum constraints at the database level
- Query performance by using MySQL's optimized ENUM type
- Schema clarity by explicitly showing valid enum values in database structure

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`make test`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.