### PR TITLE
Fix annotation in ORDER BY of DISTINCT query

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Added
 Fixed
 ^^^^^
 - Fix update pk field raises unfriendly error (#1873)
+- Using `.distinct()` with an annotation and `.order_by()` produces invalid SQL for PostgreSQL (#1886)
 
 Changed
 ^^^^^^^

--- a/tests/test_order_by.py
+++ b/tests/test_order_by.py
@@ -95,7 +95,7 @@ class TestOrderBy(test.TestCase):
         )
         self.assertEqual([t.name for t in tournaments], ["1", "2"])
 
-    async def test_distinct_annotation_with_case(self):
+    async def test_distinct_values_with_annotation(self):
         await Tournament.create(name="3")
         await Tournament.create(name="1")
         await Tournament.create(name="2")
@@ -114,6 +114,25 @@ class TestOrderBy(test.TestCase):
             .values("name", "name_orderable", "created")
         )
         self.assertEqual([t["name"] for t in tournaments], ["1", "2", "3"])
+
+    async def test_distinct_all_withl_annotation(self):
+        await Tournament.create(name="3")
+        await Tournament.create(name="1")
+        await Tournament.create(name="2")
+
+        tournaments = (
+            await Tournament.annotate(
+                name_orderable=Case(
+                    When(Q(name="1"), then="1"),
+                    When(Q(name="2"), then="2"),
+                    When(Q(name="3"), then="3"),
+                    default="-1",
+                ),
+            )
+            .distinct()
+            .order_by("name_orderable", "-created")
+        )
+        self.assertEqual([t.name for t in tournaments], ["1", "2", "3"])
 
 
 class TestDefaultOrdering(test.TestCase):

--- a/tests/test_order_by.py
+++ b/tests/test_order_by.py
@@ -9,6 +9,7 @@ from tests.testmodels import (
 from tortoise.contrib import test
 from tortoise.contrib.test.condition import NotEQ
 from tortoise.exceptions import ConfigurationError, FieldError
+from tortoise.expressions import Q, Case, When
 from tortoise.functions import Count, Sum
 
 
@@ -93,6 +94,26 @@ class TestOrderBy(test.TestCase):
             "-events_count"
         )
         self.assertEqual([t.name for t in tournaments], ["1", "2"])
+
+    async def test_distinct_annotation_with_case(self):
+        await Tournament.create(name="3")
+        await Tournament.create(name="1")
+        await Tournament.create(name="2")
+
+        tournaments = (
+            await Tournament.annotate(
+                name_orderable=Case(
+                    When(Q(name="1"), then="1"),
+                    When(Q(name="2"), then="2"),
+                    When(Q(name="3"), then="3"),
+                    default="-1",
+                ),
+            )
+            .distinct()
+            .order_by("name_orderable", "-created")
+            .values("name", "name_orderable", "created")
+        )
+        self.assertEqual([t["name"] for t in tournaments], ["1", "2", "3"])
 
 
 class TestDefaultOrdering(test.TestCase):

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -190,8 +190,8 @@ class AwaitableQuery(Generic[MODEL]):
             (to allow self referential joins)
         :param orderings: What columns/order to order by
         :param annotations:  Annotations that may be ordered on
-        :param fields_for_select: Fields that are selected in the SELECT clause. It might be None
-            if not applicable or the default fields are selected.
+        :param fields_for_select: Contains fields that are selected in the SELECT clause if
+            .only(), .values() or .values_list() are used.
 
         :raises FieldError: If a field provided does not exist in model.
         """
@@ -218,11 +218,14 @@ class AwaitableQuery(Generic[MODEL]):
                 )
             elif field_name in annotations:
                 term: Term
-                if fields_for_select and field_name in fields_for_select:
-                    # the annotation is SELECTed, we can just reference it
+                if not fields_for_select or field_name in fields_for_select:
+                    # The annotation is SELECTed, we can just reference it in the following cases:
+                    # - Empty fields_for_select means that all columns and annotations are selected,
+                    #   hence we can reference the annotation.
+                    # - The annotation is in fields_for_select, hence we can reference it.
                     term = PseudoColumn(field_name)
                 else:
-                    # the annotation is not in SELECT, resolve it
+                    # The annotation is not in SELECT, resolve it
                     annotation = annotations[field_name]
                     if isinstance(annotation, Term):
                         term = annotation

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -190,6 +190,8 @@ class AwaitableQuery(Generic[MODEL]):
             (to allow self referential joins)
         :param orderings: What columns/order to order by
         :param annotations:  Annotations that may be ordered on
+        :param fields_for_select: Fields that are selected in the SELECT clause. It might be None
+            if not applicable or the default fields are selected.
 
         :raises FieldError: If a field provided does not exist in model.
         """

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import types
-from collections.abc import AsyncIterator, Callable, Generator, Iterable
+from collections.abc import AsyncIterator, Callable, Collection, Generator, Iterable
 from copy import copy
 from typing import TYPE_CHECKING, Any, Generic, Optional, TypeVar, cast, overload
 
@@ -9,7 +9,7 @@ from pypika_tortoise import JoinType, Order, Table
 from pypika_tortoise.analytics import Count
 from pypika_tortoise.functions import Cast
 from pypika_tortoise.queries import QueryBuilder
-from pypika_tortoise.terms import Case, Field, Star, Term, ValueWrapper
+from pypika_tortoise.terms import Case, Field, Star, Term, ValueWrapper, PseudoColumn
 from typing_extensions import Literal, Protocol
 
 from tortoise.backends.base.client import BaseDBAsyncClient, Capabilities
@@ -179,7 +179,8 @@ class AwaitableQuery(Generic[MODEL]):
         model: type[Model],
         table: Table,
         orderings: Iterable[tuple[str, str | Order]],
-        annotations: dict[str, Any],
+        annotations: dict[str, Term | Expression],
+        fields_for_select: Collection[str] | None = None,
     ) -> None:
         """
         Applies standard ordering to QuerySet.
@@ -214,18 +215,24 @@ class AwaitableQuery(Generic[MODEL]):
                     {},
                 )
             elif field_name in annotations:
-                if isinstance(annotation := annotations[field_name], Term):
-                    term: Term = annotation
+                term: Term
+                if fields_for_select and field_name in fields_for_select:
+                    # the annotation is SELECTed, we can just reference it
+                    term = PseudoColumn(field_name)
                 else:
-                    annotation_info = annotation.resolve(
-                        ResolveContext(
-                            model=self.model,
-                            table=table,
-                            annotations=annotations,
-                            custom_filters={},
-                        )
-                    )
-                    term = annotation_info.term
+                    # the annotation is not in SELECT, resolve it
+                    annotation = annotations[field_name]
+                    if isinstance(annotation, Term):
+                        term = annotation
+                    else:
+                        term = annotation.resolve(
+                            ResolveContext(
+                                model=self.model,
+                                table=table,
+                                annotations=annotations,
+                                custom_filters={},
+                            )
+                        ).term
                 self.query = self.query.orderby(term, order=ordering[1])
             else:
                 field_object = model._meta.fields_map.get(field_name)
@@ -1078,7 +1085,11 @@ class QuerySet(AwaitableQuery[MODEL]):
             if append_item not in self._select_related_idx:
                 self._select_related_idx.append(append_item)
         self.resolve_ordering(
-            self.model, self.model._meta.basetable, self._orderings, self._annotations
+            self.model,
+            self.model._meta.basetable,
+            self._orderings,
+            self._annotations,
+            self._fields_for_select,
         )
         self.resolve_filters()
         if self._limit is not None:
@@ -1562,6 +1573,7 @@ class ValuesListQuery(FieldSelectQuery, Generic[SINGLE]):
             table=self.model._meta.basetable,
             orderings=self._orderings,
             annotations=self._annotations,
+            fields_for_select=self._fields_for_select_list,
         )
         self.resolve_filters()
         if self._limit:
@@ -1683,6 +1695,7 @@ class ValuesQuery(FieldSelectQuery, Generic[SINGLE]):
             table=self.model._meta.basetable,
             orderings=self._orderings,
             annotations=self._annotations,
+            fields_for_select=self._fields_for_select.keys(),
         )
         self.resolve_filters()
 


### PR DESCRIPTION
## Description
Fixes the issue where using `.distinct()` with an annotation and `.order_by()` produces invalid SQL for PostgreSQL. Before the change the produced SQL looked as below:

```sql
SELECT DISTINCT "name","grade","datetime","id",CASE WHEN "grade"=%s THEN %s WHEN "grade"=%s THEN %s WHEN "grade"=%s THEN %s WHEN "grade"=%s THEN %s WHEN "grade"=%s THEN %s WHEN "grade" IS NULL THEN %s ELSE NULL END "grade_orderable" 
FROM "event" 
ORDER BY CASE WHEN "grade"=%s THEN %s WHEN "grade"=%s THEN %s WHEN "grade"=%s THEN %s WHEN "grade"=%s THEN %s WHEN "grade"=%s THEN %s WHEN "grade" IS NULL THEN %s ELSE NULL END ASC,"datetime" DESC
```

CASE-WHEN in SELECT is the same as CASE-WHEN in the ORDER BY, however, Postgres struggles to see it because of query parametrization. The SQL after the change references `grade_orderable`, hence solving the issue:

```sql
SELECT DISTINCT "grade","name","datetime","id",CASE WHEN "grade"=%s THEN %s WHEN "grade"=%s THEN %s WHEN "grade"=%s THEN %s WHEN "grade"=%s THEN %s WHEN "grade"=%s THEN %s WHEN "grade" IS NULL THEN %s ELSE NULL END "grade_orderable" 
FROM "event" 
ORDER BY grade_orderable ASC,"datetime" DESC
```

## Motivation and Context
Should fix https://github.com/tortoise/tortoise-orm/issues/1878

## How Has This Been Tested?
`make ci`

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

