### PR TITLE
Release 0.24.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ Changelog
 0.24
 ====
 
-0.24.1 (unreleased)
+0.24.1
 ------
 Added
 ^^^^^
@@ -20,8 +20,6 @@ Fixed
 - Fix update pk field raises unfriendly error (#1873)
 - Using `.distinct()` with an annotation and `.order_by()` produces invalid SQL for PostgreSQL (#1886)
 
-Changed
-^^^^^^^
 
 0.24.0
 ------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tortoise-orm"
-version = "0.24.0"
+version = "0.24.1"
 description = "Easy async ORM for python, built with relations in mind"
 authors = ["Andrey Bondar <andrey@bondar.ru>", "Nickolas Grigoriadis <nagrigoriadis@gmail.com>", "long2ice <long2ice@gmail.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
0.24.1
------
Added
^^^^^
- Implement __contains, __contained_by, __overlap and __len for ArrayField (#1877)

Fixed
^^^^^
- Fix update pk field raises unfriendly error (#1873)
- Using `.distinct()` with an annotation and `.order_by()` produces invalid SQL for PostgreSQL (#1886)