### PR TITLE
Support multiple apps in testing initializer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,12 @@ Changelog
 0.24
 ====
 
+0.24.2
+------
+Added
+^^^^^
+- Allow mapping of modules for multiple apps to be provided to tortoise.contrib.test.initializer (#1895)
+
 0.24.1
 ------
 Added

--- a/docs/contrib/unittest.rst
+++ b/docs/contrib/unittest.rst
@@ -39,6 +39,8 @@ To get ``test.TestCase`` to work as expected, you need to configure your test en
     initializer(['module.a', 'module.b.c'])
     # With optional db_url, app_label and loop parameters
     initializer(['module.a', 'module.b.c'], db_url='...', app_label="someapp", loop=loop)
+    # With multiple apps
+    initializer({'app1': ['app1.models'], 'app2': ['app2.models']})
     # Or env-var driven → See Green test runner section below.
     env_initializer()
 

--- a/tortoise/contrib/test/__init__.py
+++ b/tortoise/contrib/test/__init__.py
@@ -53,20 +53,23 @@ On success it will be marked as unexpected success.
 _CONFIG: dict = {}
 _CONNECTIONS: dict = {}
 _LOOP: AbstractEventLoop = None  # type: ignore
-_MODULES: Iterable[str | ModuleType] = []
+_MODULES: Union[Iterable[str | ModuleType], dict[str, Iterable[Union[str, ModuleType]]]] = []
 _CONN_CONFIG: dict = {}
 
 
-def getDBConfig(app_label: str, modules: Iterable[str | ModuleType]) -> dict:
+def getDBConfig(app_label: str, modules: Union[Iterable[str | ModuleType], dict[str, Iterable[Union[str, ModuleType]]]]) -> dict:
     """
     DB Config factory, for use in testing.
 
-    :param app_label: Label of the app (must be distinct for multiple apps).
-    :param modules: List of modules to look for models in.
+    :param app_label: Default label of the app if modules is a list (must be distinct for multiple apps).
+    :param modules: List of modules to look for models in, or dictionary of apps and list of modules
     """
+
+    modules = {app_label: modules} if not isinstance(modules, dict) else modules
+
     return _generate_config(
         _TORTOISE_TEST_DB,
-        app_modules={app_label: modules},
+        app_modules=modules,
         testing=True,
         connection_label=app_label,
     )
@@ -104,7 +107,7 @@ async def truncate_all_models() -> None:
 
 
 def initializer(
-    modules: Iterable[str | ModuleType],
+    modules: Union[Iterable[str | ModuleType], dict[str, Iterable[Union[str, ModuleType]]]],
     db_url: str | None = None,
     app_label: str = "models",
     loop: AbstractEventLoop | None = None,
@@ -112,9 +115,9 @@ def initializer(
     """
     Sets up the DB for testing. Must be called as part of test environment setup.
 
-    :param modules: List of modules to look for models in.
+    :param modules: List of modules to look for models in, or a dict of app labels and module lists
     :param db_url: The db_url, defaults to ``sqlite://:memory``.
-    :param app_label: The name of the APP to initialise the modules in, defaults to "models"
+    :param app_label: The name of the APP to initialise the modules in if modules is a list, defaults to "models"
     :param loop: Optional event loop.
     """
     # pylint: disable=W0603
@@ -264,10 +267,10 @@ class IsolatedTestCase(SimpleTestCase):
     It will create and destroy a new DB instance for every test.
     This is obviously slow, but guarantees a fresh DB.
 
-    If you define a ``tortoise_test_modules`` list, it overrides the DB setup module for the tests.
+    If you define a ``tortoise_test_modules`` list or dict, it overrides the DB setup module for the tests.
     """
 
-    tortoise_test_modules: Iterable[str | ModuleType] = []
+    tortoise_test_modules: Union[Iterable[str | ModuleType], dict[str, Iterable[Union[str, ModuleType]]]] = []
 
     async def _setUpDB(self) -> None:
         await super()._setUpDB()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Allows the intializer to accept a mapping of app names to module list, allowing more flexibility when testing, and allowing tests to run on models across multiple apps. This would also allow models to work where they have a foreign key to a model in another app. The previous modules list and app label still works as normal so compatibility will not be affected. If a dict of app names to modules is provided, the app_label kw argument is not used.

## Motivation and Context
Particularly useful when integrating models from a third party library into your own application. 
Issue created a while back: https://github.com/tortoise/tortoise-orm/issues/1521

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This is something that needs to be discussed as at the moment intializer and finalizer is run as an autouse session fixture, so difficult to override for a single test. Coverage is not an issue as there are no new lines.

Possibilities include:
* Changing `initialize_tests` fixture to use the new apps/module dict format in which case the older single list format would not be tested.
* Create a completely separate tests directory which ignores the main conftest.py. Probably the main conftest.py would have to be moved into the current tests directory. The new tests directory would have it's own conftest.py using the new style initializer argument format

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

