### PR TITLE
fix: model with multi m2m fields generates wrong references name

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,13 @@ Changelog
 0.24
 ====
 
+0.24.2 (Unreleased)
+------
+
+Fixed
+^^^^^
+- Fix model with multi m2m fields generates wrong references name (#1897)
+
 0.24.1
 ------
 Added

--- a/tests/schema/models_m2m_2.py
+++ b/tests/schema/models_m2m_2.py
@@ -1,0 +1,20 @@
+"""
+This is the testing Models — Multi ManyToMany fields
+"""
+
+from __future__ import annotations
+
+from tortoise import Model, fields
+
+
+class One(Model):
+    threes: fields.ManyToManyRelation[Three]
+
+
+class Two(Model):
+    threes: fields.ManyToManyRelation[Three]
+
+
+class Three(Model):
+    ones: fields.ManyToManyRelation[One] = fields.ManyToManyField("models.One")
+    twos: fields.ManyToManyRelation[Two] = fields.ManyToManyField("models.Two")

--- a/tests/schema/test_generate_schema.py
+++ b/tests/schema/test_generate_schema.py
@@ -217,6 +217,13 @@ CREATE UNIQUE INDEX IF NOT EXISTS "uidx_teamevents_event_i_664dbc" ON "teamevent
         ):
             await self.init_for("tests.schema.models_m2m_1")
 
+    async def test_multi_m2m_fields_in_a_model(self):
+        await self.init_for("tests.schema.models_m2m_2")
+        sql = self.get_sql("CASCADE")
+        self.assertNotRegex(sql, r'REFERENCES [`"]three_one[`"]')
+        self.assertNotRegex(sql, r'REFERENCES [`"]three_two[`"]')
+        self.assertRegex(sql, r'REFERENCES [`"](one|two|three)[`"]')
+
     async def test_table_and_row_comment_generation(self):
         await self.init_for("tests.testmodels")
         sql = self.get_sql("comments")

--- a/tests/test_order_by.py
+++ b/tests/test_order_by.py
@@ -9,7 +9,7 @@ from tests.testmodels import (
 from tortoise.contrib import test
 from tortoise.contrib.test.condition import NotEQ
 from tortoise.exceptions import ConfigurationError, FieldError
-from tortoise.expressions import Q, Case, When
+from tortoise.expressions import Case, Q, When
 from tortoise.functions import Count, Sum
 
 

--- a/tests/test_values.py
+++ b/tests/test_values.py
@@ -4,7 +4,7 @@ from tests.testmodels import Event, Team, Tournament
 from tortoise.contrib import test
 from tortoise.contrib.test.condition import In, NotEQ
 from tortoise.exceptions import FieldError
-from tortoise.expressions import Q, Case, Function, When
+from tortoise.expressions import Case, Function, Q, When
 from tortoise.functions import Length, Trim
 
 

--- a/tortoise/backends/base/schema_generator.py
+++ b/tortoise/backends/base/schema_generator.py
@@ -324,15 +324,15 @@ class BaseSchemaGenerator:
             else:
                 backward_fk = forward_fk = ""
             exists = "IF NOT EXISTS " if safe else ""
-            table_name = field_object.through
+            through_table_name = field_object.through
             backward_type = self._get_pk_field_sql_type(model._meta.pk)
             forward_type = self._get_pk_field_sql_type(field_object.related_model._meta.pk)
             comment = ""
             if desc := field_object.description:
-                comment = self._table_comment_generator(table=table_name, comment=desc)
+                comment = self._table_comment_generator(table=through_table_name, comment=desc)
             m2m_create_string = self.M2M_TABLE_TEMPLATE.format(
                 exists=exists,
-                table_name=table_name,
+                table_name=through_table_name,
                 backward_fk=backward_fk,
                 forward_fk=forward_fk,
                 backward_key=backward_key,
@@ -352,7 +352,7 @@ class BaseSchemaGenerator:
             m2m_create_string += self._post_table_hook()
             if field_object.create_unique_index:
                 unique_index_create_sql = self._get_unique_index_sql(
-                    exists, table_name, [backward_key, forward_key]
+                    exists, through_table_name, [backward_key, forward_key]
                 )
                 if unique_index_create_sql.endswith(";"):
                     m2m_create_string += "\n" + unique_index_create_sql

--- a/tortoise/backends/base/schema_generator.py
+++ b/tortoise/backends/base/schema_generator.py
@@ -296,7 +296,7 @@ class BaseSchemaGenerator:
         return [val for val in list(dict.fromkeys(indexes)) if val]
 
     def _get_m2m_tables(
-        self, model: type[Model], table_name: str, safe: bool, models_tables: list[str]
+        self, model: type[Model], db_table: str, safe: bool, models_tables: list[str]
     ) -> list[str]:
         m2m_tables_for_create = []
         for m2m_field in model._meta.m2m_fields:
@@ -308,7 +308,7 @@ class BaseSchemaGenerator:
                 backward_fk = self._create_fk_string(
                     "",
                     backward_key,
-                    table_name,
+                    db_table,
                     model._meta.db_pk_column,
                     field_object.on_delete,
                     "",
@@ -327,6 +327,9 @@ class BaseSchemaGenerator:
             table_name = field_object.through
             backward_type = self._get_pk_field_sql_type(model._meta.pk)
             forward_type = self._get_pk_field_sql_type(field_object.related_model._meta.pk)
+            comment = ""
+            if desc := field_object.description:
+                comment = self._table_comment_generator(table=table_name, comment=desc)
             m2m_create_string = self.M2M_TABLE_TEMPLATE.format(
                 exists=exists,
                 table_name=table_name,
@@ -337,13 +340,7 @@ class BaseSchemaGenerator:
                 forward_key=forward_key,
                 forward_type=forward_type,
                 extra=self._table_generate_extra(table=field_object.through),
-                comment=(
-                    self._table_comment_generator(
-                        table=field_object.through, comment=field_object.description
-                    )
-                    if field_object.description
-                    else ""
-                ),
+                comment=comment,
             )
             if not field_object.db_constraint:
                 m2m_create_string = m2m_create_string.replace(

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -9,7 +9,7 @@ from pypika_tortoise import JoinType, Order, Table
 from pypika_tortoise.analytics import Count
 from pypika_tortoise.functions import Cast
 from pypika_tortoise.queries import QueryBuilder
-from pypika_tortoise.terms import Case, Field, Star, Term, ValueWrapper, PseudoColumn
+from pypika_tortoise.terms import Case, Field, PseudoColumn, Star, Term, ValueWrapper
 from typing_extensions import Literal, Protocol
 
 from tortoise.backends.base.client import BaseDBAsyncClient, Capabilities


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes #1893 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The new function `_get_m2m_tables` has argument `table_name` which is conflict with variable defined at https://github.com/tortoise/tortoise-orm/blob/0.24.1/tortoise/backends/base/schema_generator.py#L327

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
make ci

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

