### PR TITLE
Fix using reserved words in order_by

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Changelog
 Fixed
 ^^^^^
 - Fix model with multi m2m fields generates wrong references name (#1897)
+- Fix using reserved words in order_by (#1900)
 
 0.24.1
 ------

--- a/tests/test_order_by.py
+++ b/tests/test_order_by.py
@@ -10,7 +10,7 @@ from tortoise.contrib import test
 from tortoise.contrib.test.condition import NotEQ
 from tortoise.exceptions import ConfigurationError, FieldError
 from tortoise.expressions import Case, Q, When
-from tortoise.functions import Count, Sum
+from tortoise.functions import Count, Lower, Sum
 
 
 class TestOrderBy(test.TestCase):
@@ -95,6 +95,16 @@ class TestOrderBy(test.TestCase):
         )
         self.assertEqual([t.name for t in tournaments], ["1", "2"])
 
+    async def test_order_by_reserved_word_annotation(self):
+        await Tournament.create(name="1")
+        await Tournament.create(name="2")
+
+        reserved_words = ["order", "group", "limit", "offset", "where"]
+
+        for word in reserved_words:
+            tournaments = await Tournament.annotate(**{word: Lower("name")}).order_by(word)
+            self.assertEqual([t.name for t in tournaments], ["1", "2"])
+
     async def test_distinct_values_with_annotation(self):
         await Tournament.create(name="3")
         await Tournament.create(name="1")
@@ -115,7 +125,7 @@ class TestOrderBy(test.TestCase):
         )
         self.assertEqual([t["name"] for t in tournaments], ["1", "2", "3"])
 
-    async def test_distinct_all_withl_annotation(self):
+    async def test_distinct_all_with_annotation(self):
         await Tournament.create(name="3")
         await Tournament.create(name="1")
         await Tournament.create(name="2")

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -9,7 +9,7 @@ from pypika_tortoise import JoinType, Order, Table
 from pypika_tortoise.analytics import Count
 from pypika_tortoise.functions import Cast
 from pypika_tortoise.queries import QueryBuilder
-from pypika_tortoise.terms import Case, Field, PseudoColumn, Star, Term, ValueWrapper
+from pypika_tortoise.terms import Case, Field, Star, Term, ValueWrapper
 from typing_extensions import Literal, Protocol
 
 from tortoise.backends.base.client import BaseDBAsyncClient, Capabilities
@@ -223,7 +223,7 @@ class AwaitableQuery(Generic[MODEL]):
                     # - Empty fields_for_select means that all columns and annotations are selected,
                     #   hence we can reference the annotation.
                     # - The annotation is in fields_for_select, hence we can reference it.
-                    term = PseudoColumn(field_name)
+                    term = Field(field_name)
                 else:
                     # The annotation is not in SELECT, resolve it
                     annotation = annotations[field_name]


### PR DESCRIPTION
## Description
Replacing `PseudoColumn` with `Field` when referencing annotations in ORDER BY because `PseudoColumn` doesn't add quotes.

## Motivation and Context
Should fix https://github.com/tortoise/tortoise-orm/issues/1899.

## How Has This Been Tested?
`make ci`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

