### PR TITLE
[WIP] Fix connection from router edgecase

### DIFF
--- a/tortoise/router.py
+++ b/tortoise/router.py
@@ -30,10 +30,14 @@ class ConnectionRouter:
                     return chosen_db
 
     def _db_route(self, model: type[Model], action: str) -> BaseDBAsyncClient | None:
-        try:
-            return connections.get(self._router_func(model, action))
-        except ConfigurationError:
-            return None
+        conn_alias = self._router_func(model, action)
+        if conn_alias is not None:
+            try:
+                return connections.get(conn_alias)
+            except ConfigurationError:
+                return None
+            
+        return None
 
     def db_for_read(self, model: type[Model]) -> BaseDBAsyncClient | None:
         return self._db_route(model, "db_for_read")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix for preventing the `_router_func` method from passing a `NoneType` to `connections.get`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I was receiving a `TypeError: 'NoneType' object is not iterable` when using a configuration based on what is described in the [Two Databases](https://tortoise.github.io/examples/basic.html#two-databases) documentation. The exception was occurring when using `Model.create` (in a subclass) without specifying a database to use. The exception was traced up though `Model._choose_db()`.

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
No additional tests have been conducted besides verifying that my use case is now working as expected.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

