### PR TITLE
[WIP] chore: remove coverage run config in pyproject.toml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 checkfiles = tortoise/ examples/ tests/ conftest.py
 py_warn = PYTHONDEVMODE=1
-pytest_opts = -n auto --cov=tortoise --cov-append --tb=native -q
+pytest_opts = -n auto --cov=tortoise --tb=native -q
 
 TORTOISE_MYSQL_PASS ?= 123456
 TORTOISE_POSTGRES_PASS ?= 123456

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,10 +187,6 @@ filterwarnings = [
     'ignore:Do not add pk field to `update_fields`!:RuntimeWarning',
 ]
 
-[tool.coverage.run]
-branch = true
-source = ["tortoise"]
-
 [tool.coverage.report]
 show_missing = true
 


### PR DESCRIPTION
To verify that remove `branch=true` does not change the test coverage.