### PR TITLE
Release 0.24.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,13 +9,18 @@ Changelog
 0.24
 ====
 
-0.24.2 (Unreleased)
+0.24.2
 ------
 
 Fixed
 ^^^^^
 - Fix model with multi m2m fields generates wrong references name (#1897)
 - Fix using reserved words in order_by (#1900)
+- Fix installing tortoise-orm with poetry 2 (#1885)
+
+Changed
+^^^^^^^
+- Use 'unique' instead of 'create_unique_index' for m2m field (#1903)
 
 0.24.1
 ------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tortoise-orm"
-version = "0.24.1"
+version = "0.24.2"
 description = "Easy async ORM for python, built with relations in mind"
 authors = [{name="Andrey Bondar", email="andrey@bondar.ru"}, {name="Nickolas Grigoriadis", email="nagrigoriadis@gmail.com"}, {name="long2ice", email="long2ice@gmail.com"}]
 license = {text="Apache-2.0"}


### PR DESCRIPTION
Fixed
^^^^^
- Fix model with multi m2m fields generates wrong references name (#1897)
- Fix using reserved words in order_by (#1900)
- Fix installing tortoise-orm with poetry 2 (#1885)

Changed
^^^^^^^
- Use 'unique' instead of 'create_unique_index' for m2m field (#1903)