### PR TITLE
Support relations in .only()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,14 +6,23 @@ Changelog
 
 .. rst-class:: emphasize-children
 
-0.24
+0.25
 ====
 
-0.24.3 (unreleased)
+0.25.0 (unreleased)
 ------
 Changed
 ^^^^^^^
 - Skip database selection if the router is not configured to improve performance (#1915)
+- `.values()`, `.values_list()` and `.only()` cannot be used together (#1923)
+
+Added
+^^^^^
+- `.only` supports selecting related fields, e.g. `.only("related__field")` (#1923)
+
+
+0.24
+====
 
 0.24.2
 ------

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -11,7 +11,7 @@ from tests.testmodels import (
 )
 from tortoise.contrib import test
 from tortoise.contrib.test.condition import In
-from tortoise.exceptions import ConfigurationError
+from tortoise.exceptions import FieldError
 from tortoise.expressions import F, Q
 from tortoise.functions import Avg, Coalesce, Concat, Count, Lower, Max, Min, Sum, Trim
 
@@ -60,7 +60,7 @@ class TestAggregation(test.TestCase):
             event_with_annotation.tournament_id,
         )
 
-        with self.assertRaisesRegex(ConfigurationError, "name__id not resolvable"):
+        with self.assertRaisesRegex(FieldError, "name__id not resolvable"):
             await Event.all().annotate(tournament_test_id=Sum("name__id")).first()
 
     async def test_nested_aggregation_in_annotation(self):

--- a/tests/test_only.py
+++ b/tests/test_only.py
@@ -1,6 +1,7 @@
 from tests.testmodels import DoubleFK, Event, SourceFields, StraightFields, Tournament
 from tortoise.contrib import test
-from tortoise.exceptions import IncompleteInstanceError
+from tortoise.functions import Count
+from tortoise.exceptions import FieldError, IncompleteInstanceError
 
 
 class TestOnlyStraight(test.TestCase):
@@ -171,3 +172,123 @@ class TestOnlyRelated(test.TestCase):
         self.assertEqual(len(ret), 2)
         self.assertEqual(ret[0].tournament.name, "New Tournament")
         self.assertEqual(ret[1].tournament.name, "New Tournament")
+
+
+class TestOnlyAdvanced(test.TestCase):
+    async def asyncSetUp(self) -> None:
+        await super().asyncSetUp()
+        self.tournament = await Tournament.create(name="Tournament A", desc="Description A")
+        self.event1 = await Event.create(name="Event 1", tournament=self.tournament)
+        self.event2 = await Event.create(name="Event 2", tournament=self.tournament)
+
+    async def test_exclude(self):
+        """Test .only() combined with .exclude()"""
+        events = await Event.filter(tournament=self.tournament).exclude(name="Event 2").only("name")
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].name, "Event 1")
+        with self.assertRaises(AttributeError):
+            _ = events[0].modified
+
+    async def test_limit(self):
+        """Test .only() combined with .limit()"""
+        events = await Event.all().only("name").limit(1)
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].name, "Event 1")  # Assumes ordering by PK
+        with self.assertRaises(AttributeError):
+            _ = events[0].modified
+
+    async def test_distinct(self):
+        """Test .only() combined with .distinct()"""
+        # Create duplicate event names
+        await Event.create(name="Event 1", tournament=self.tournament)
+
+        events = await Event.all().only("name").distinct()
+        # Should only have 2 distinct event names
+        self.assertEqual(len(events), 2)
+        event_names = {e.name for e in events}
+        self.assertEqual(event_names, {"Event 1", "Event 2"})
+
+    async def test_values(self):
+        """Test .only() combined with .values()"""
+        with self.assertRaises(ValueError, msg="values() cannot be used with .only()"):
+            await Event.all().only("name").values("name")
+
+    async def test_pk_field(self):
+        """Test .only() with just the primary key field"""
+        tournament = await Tournament.first().only("id")
+        self.assertIsNotNone(tournament.id)
+        with self.assertRaises(AttributeError):
+            _ = tournament.name
+
+    async def test_empty(self):
+        """Test .only() with no fields (should raise an error)"""
+        with self.assertRaises(ValueError):
+            await Event.all().only()
+
+    async def test_annotate(self):
+        tournaments = await Tournament.annotate(event_count=Count("events")).only(
+            "name", "event_count"
+        )
+
+        self.assertEqual(tournaments[0].name, "Tournament A")
+        self.assertEqual(tournaments[0].event_count, 2)
+        with self.assertRaises(AttributeError):
+            _ = tournaments[0].desc
+
+    async def test_nonexistent_field(self):
+        """Test .only() with a field that doesn't exist"""
+        with self.assertRaises(FieldError):
+            await Event.all().only("nonexistent_field").all()
+
+    async def test_join_in_filter(self):
+        event = await Event.filter(name="Event 1").only("name").first()
+        self.assertEqual(event.name, "Event 1")
+        with self.assertRaises(AttributeError):
+            _ = event.tournament
+
+        event = await Event.filter(tournament__name="Tournament A").only("name").first()
+        self.assertEqual(event.name, "Event 1")
+        with self.assertRaises(AttributeError):
+            _ = event.tournament
+
+        event = (
+            await Event.filter(tournament__name="Tournament A")
+            .only("name", "tournament__name")
+            .first()
+        )
+        self.assertEqual(event.name, "Event 1")
+        self.assertEqual(event.tournament.name, "Tournament A")
+
+    async def test_join_in_order_by(self):
+        events = await Event.all().order_by("name").only("name")
+        self.assertEqual(events[0].name, "Event 1")
+        with self.assertRaises(AttributeError):
+            _ = events[0].tournament
+
+        events = await Event.all().order_by("tournament__name", "name").only("name")
+        self.assertEqual(events[0].name, "Event 1")
+        with self.assertRaises(AttributeError):
+            _ = events[0].tournament
+
+        events = (
+            await Event.all().order_by("tournament__name", "name").only("name", "tournament__name")
+        )
+        self.assertEqual(events[0].name, "Event 1")
+        self.assertEqual(events[0].tournament.name, "Tournament A")
+
+    async def test_select_related(self):
+        """Test .only() with .select_related() for basic functionality"""
+        event = (
+            await Event.filter(name="Event 1")
+            .select_related("tournament")
+            .only("name", "tournament__name")
+            .first()
+        )
+
+        self.assertEqual(event.name, "Event 1")
+        self.assertEqual(event.tournament.name, "Tournament A")
+
+        with self.assertRaises(AttributeError):
+            _ = event.id
+        with self.assertRaises(AttributeError):
+            _ = event.tournament.id

--- a/tests/test_only.py
+++ b/tests/test_only.py
@@ -1,4 +1,4 @@
-from tests.testmodels import SourceFields, StraightFields
+from tests.testmodels import DoubleFK, Event, SourceFields, StraightFields, Tournament
 from tortoise.contrib import test
 from tortoise.exceptions import IncompleteInstanceError
 
@@ -64,3 +64,110 @@ class TestOnlySource(TestOnlyStraight):
         await super().asyncSetUp()
         self.model = SourceFields  # type: ignore
         self.instance = await self.model.create(chars="Test")
+
+
+class TestOnlyRecursive(test.TestCase):
+    async def test_one_level(self):
+        left_1st_lvl = await DoubleFK.create(name="1st")
+        root = await DoubleFK.create(name="root", left=left_1st_lvl)
+
+        ret = (
+            await DoubleFK.filter(pk=root.pk).only("name", "left__name", "left__left__name").first()
+        )
+        self.assertIsNotNone(ret)
+        with self.assertRaises(AttributeError):
+            _ = ret.id
+        self.assertEqual(ret.name, "root")
+        self.assertEqual(ret.left.name, "1st")
+        with self.assertRaises(AttributeError):
+            _ = ret.left.id
+        with self.assertRaises(AttributeError):
+            _ = ret.right
+
+    async def test_two_levels(self):
+        left_2nd_lvl = await DoubleFK.create(name="second leaf")
+        left_1st_lvl = await DoubleFK.create(name="1st", left=left_2nd_lvl)
+        root = await DoubleFK.create(name="root", left=left_1st_lvl)
+
+        ret = (
+            await DoubleFK.filter(pk=root.pk).only("name", "left__name", "left__left__name").first()
+        )
+        self.assertIsNotNone(ret)
+        with self.assertRaises(AttributeError):
+            _ = ret.id
+        self.assertEqual(ret.name, "root")
+        self.assertEqual(ret.left.name, "1st")
+        with self.assertRaises(AttributeError):
+            _ = ret.left.id
+        self.assertEqual(ret.left.left.name, "second leaf")
+
+    async def test_two_levels_reverse_argument_order(self):
+        left_2nd_lvl = await DoubleFK.create(name="second leaf")
+        left_1st_lvl = await DoubleFK.create(name="1st", left=left_2nd_lvl)
+        root = await DoubleFK.create(name="root", left=left_1st_lvl)
+
+        ret = (
+            await DoubleFK.filter(pk=root.pk).only("left__left__name", "left__name", "name").first()
+        )
+        self.assertIsNotNone(ret)
+        with self.assertRaises(AttributeError):
+            _ = ret.id
+        self.assertEqual(ret.name, "root")
+        self.assertEqual(ret.left.name, "1st")
+        with self.assertRaises(AttributeError):
+            _ = ret.left.id
+        self.assertEqual(ret.left.left.name, "second leaf")
+
+
+class TestOnlyRelated(test.TestCase):
+    async def test_related_one_level(self):
+        tournament = await Tournament.create(name="New Tournament", desc="New Description")
+        await Event.create(name="Event 1", tournament=tournament)
+        await Event.create(name="Event 2", tournament=tournament)
+
+        ret = (
+            await Event.filter(tournament=tournament)
+            .only("name", "tournament__name")
+            .order_by("name")
+        )
+        self.assertEqual(len(ret), 2)
+        self.assertEqual(ret[0].name, "Event 1")
+        with self.assertRaises(AttributeError):
+            _ = ret[0].alias
+        self.assertEqual(ret[1].name, "Event 2")
+        with self.assertRaises(AttributeError):
+            _ = ret[1].alias
+        self.assertEqual(ret[0].tournament.name, "New Tournament")
+        with self.assertRaises(AttributeError):
+            _ = ret[0].tournament.id
+        with self.assertRaises(AttributeError):
+            _ = ret[0].tournament.desc
+
+    async def test_related_one_level_reversed_argument_order(self):
+        tournament = await Tournament.create(name="New Tournament", desc="New Description")
+        await Event.create(name="Event 1", tournament=tournament)
+        await Event.create(name="Event 2", tournament=tournament)
+
+        ret = (
+            await Event.filter(tournament=tournament)
+            .only("tournament__name", "name")
+            .order_by("name")
+        )
+        self.assertEqual(len(ret), 2)
+        self.assertEqual(ret[0].name, "Event 1")
+        self.assertEqual(ret[0].tournament.name, "New Tournament")
+
+    async def test_just_related(self):
+        tournament = await Tournament.create(name="New Tournament", desc="New Description")
+        await Event.create(name="Event 1", tournament=tournament)
+        await Event.create(name="Event 2", tournament=tournament)
+
+        ret = (
+            await Event.filter(tournament=tournament)
+            .only("tournament__name")
+            .order_by("name")
+            .all()
+        )
+        self.assertEqual(len(ret), 2)
+        self.assertEqual(ret[0].tournament.name, "New Tournament")
+        self.assertEqual(ret[1].tournament.name, "New Tournament")

--- a/tortoise/backends/base/executor.py
+++ b/tortoise/backends/base/executor.py
@@ -114,7 +114,7 @@ class BaseExecutor:
                 for model, index, *__, full_path in self.select_related_idx[1:]:
                     (*path, attr) = full_path
                     related_items = row_items[current_idx : current_idx + index]
-                    if any((v for _, v in related_items)):
+                    if any(v for _, v in related_items):
                         obj = model._init_from_db(**{k.split(".")[1]: v for k, v in related_items})
                     elif index == 0:
                         # 0 signals that an empty "filler" object should be created in the case

--- a/tortoise/backends/base/executor.py
+++ b/tortoise/backends/base/executor.py
@@ -114,10 +114,12 @@ class BaseExecutor:
                 for model, index, *__, full_path in self.select_related_idx[1:]:
                     (*path, attr) = full_path
                     related_items = row_items[current_idx : current_idx + index]
-                    if not any((v for _, v in related_items)):
-                        obj = None
-                    else:
+                    if any((v for _, v in related_items)):
                         obj = model._init_from_db(**{k.split(".")[1]: v for k, v in related_items})
+                    elif index == 0:
+                        obj = model._init_from_db()
+                    else:
+                        obj = None
                     target = instances.get(tuple(path))
                     if target is not None:
                         setattr(target, f"_{attr}", obj)

--- a/tortoise/backends/base/executor.py
+++ b/tortoise/backends/base/executor.py
@@ -117,6 +117,9 @@ class BaseExecutor:
                     if any((v for _, v in related_items)):
                         obj = model._init_from_db(**{k.split(".")[1]: v for k, v in related_items})
                     elif index == 0:
+                        # 0 signals that an empty "filler" object should be created in the case
+                        # where a field of related model is selected but model itself isn't,
+                        # e.g. .only("relatedmodel__field")
                         obj = model._init_from_db()
                     else:
                         obj = None

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -1066,7 +1066,9 @@ class Model(metaclass=ModelMeta):
         if not self._saved_in_db:
             raise OperationalError("Can't refresh unpersisted record")
         db = using_db or self._choose_db()
-        qs = QuerySet(self.__class__).using_db(db).only(*(fields or []))
+        qs = QuerySet(self.__class__).using_db(db)
+        if fields:
+            qs = qs.only(*fields)
         obj = await qs.get(pk=self.pk)
 
         for field in fields or self._meta.db_fields:

--- a/tortoise/query_utils.py
+++ b/tortoise/query_utils.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 from copy import copy
 from typing import TYPE_CHECKING, cast
+from collections.abc import Sequence
 
 from pypika_tortoise import Table
 from pypika_tortoise.terms import Criterion, Term
 
-from tortoise.exceptions import ConfigurationError, OperationalError
+from tortoise.exceptions import FieldError, OperationalError
 from tortoise.fields.base import Field
 from tortoise.fields.relational import (
     BackwardFKRelation,
@@ -78,6 +79,20 @@ def get_joins_for_related_field(
     return required_joins
 
 
+def expand_field_expression(rooot_model: type[Model], field_expression: str) -> Sequence[Field]:
+    field_names = field_expression.split("__")
+    fields: list[Field | RelationalField] = []
+    model = rooot_model
+    for field_name in field_names[:-1]:
+        if field_name not in model._meta.fetch_fields:
+            raise FieldError(f"{field_expression} not resolvable")
+        field = cast(RelationalField, model._meta.fields_map[field_name])
+        fields.append(field)
+        model = field.related_model
+    fields.append(model._meta.fields_map[field_names[-1]])
+    return fields
+
+
 def resolve_nested_field(
     model: type[Model], table: Table, field: str
 ) -> tuple[Term, list[TableCriterionTuple], Field | None]:
@@ -86,52 +101,51 @@ def resolve_nested_field(
     returns the pypika term, required joins and the Field that can be used for
     converting the value.
     """
-    field_object = None
     joins = []
-    fields = field.split("__")
+    fields = expand_field_expression(model, field)
 
     for iter_field in fields[:-1]:
-        if iter_field not in model._meta.fetch_fields:
-            raise ConfigurationError(f"{field} not resolvable")
-
-        related_field = cast(RelationalField, model._meta.fields_map[iter_field])
-        joins.extend(get_joins_for_related_field(table, related_field, iter_field))
+        related_field = cast(RelationalField, iter_field)
+        joins.extend(get_joins_for_related_field(table, related_field, iter_field.model_field_name))
 
         model = related_field.related_model
         related_table: Table = related_field.related_model._meta.basetable
         if isinstance(related_field, ForeignKeyFieldInstance):
             # Only FK's can be to same table, so we only auto-alias FK join tables
-            related_table = related_table.as_(f"{table.get_table_name()}__{iter_field}")
+            related_table = related_table.as_(
+                f"{table.get_table_name()}__{iter_field.model_field_name}"
+            )
         table = related_table
 
     last_field = fields[-1]
-    if last_field in model._meta.fetch_fields:
-        related_field = cast(RelationalField, model._meta.fields_map[last_field])
+    if last_field.model_field_name in model._meta.fetch_fields:
+        related_field = cast(RelationalField, last_field)
         related_field_meta = related_field.related_model._meta
 
-        joins.extend(get_joins_for_related_field(table, related_field, last_field))
+        joins.extend(
+            get_joins_for_related_field(table, related_field, related_field.model_field_name)
+        )
         related_table = related_field_meta.basetable
 
         if isinstance(related_field, BackwardFKRelation):
             if table == related_table:
-                related_table = related_table.as_(f"{table.get_table_name()}__{last_field}")
+                related_table = related_table.as_(
+                    f"{table.get_table_name()}__{related_field.model_field_name}"
+                )
 
         term = related_table[related_field_meta.db_pk_column]
     else:
-        field_object = model._meta.fields_map[last_field]
-        if field_object.source_field:
-            term = table[field_object.source_field]
+        if last_field.source_field:
+            term = table[last_field.source_field]
         else:
-            term = table[last_field]
+            term = table[last_field.model_field_name]
 
-        if field_object:  # pragma: nobranch
-            func = field_object.get_for_dialect(
-                model._meta.db.capabilities.dialect, "function_cast"
-            )
+        if last_field:  # pragma: nobranch
+            func = last_field.get_for_dialect(model._meta.db.capabilities.dialect, "function_cast")
             if func:
-                term = func(field_object, term)
+                term = func(last_field, term)
 
-    return term, joins, field_object
+    return term, joins, last_field
 
 
 class EmptyCriterion(Criterion):

--- a/tortoise/query_utils.py
+++ b/tortoise/query_utils.py
@@ -79,17 +79,20 @@ def get_joins_for_related_field(
     return required_joins
 
 
-def expand_field_expression(rooot_model: type[Model], field_expression: str) -> Sequence[Field]:
-    field_names = field_expression.split("__")
+def expand_lookup_expression(root_model: type[Model], lookup_expression: str) -> Sequence[Field]:
+    field_names = lookup_expression.split("__")
     fields: list[Field | RelationalField] = []
-    model = rooot_model
+    model = root_model
     for field_name in field_names[:-1]:
         if field_name not in model._meta.fetch_fields:
-            raise FieldError(f"{field_expression} not resolvable")
+            raise FieldError(f"{lookup_expression} not resolvable")
         field = cast(RelationalField, model._meta.fields_map[field_name])
         fields.append(field)
         model = field.related_model
-    fields.append(model._meta.fields_map[field_names[-1]])
+    try:
+        fields.append(model._meta.fields_map[field_names[-1]])
+    except KeyError:
+        raise FieldError(f"{lookup_expression} not resolvable")
     return fields
 
 
@@ -102,7 +105,7 @@ def resolve_nested_field(
     converting the value.
     """
     joins = []
-    fields = expand_field_expression(model, field)
+    fields = expand_lookup_expression(model, field)
 
     for iter_field in fields[:-1]:
         related_field = cast(RelationalField, iter_field)

--- a/tortoise/query_utils.py
+++ b/tortoise/query_utils.py
@@ -89,6 +89,7 @@ def expand_lookup_expression(root_model: type[Model], lookup_expression: str) ->
         field = cast(RelationalField, model._meta.fields_map[field_name])
         fields.append(field)
         model = field.related_model
+    # the last field is not necessarily a RelationalField, so threting it differently
     try:
         fields.append(model._meta.fields_map[field_names[-1]])
     except KeyError:

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -1144,9 +1144,7 @@ class QuerySet(AwaitableQuery[MODEL]):
                 self.model,
                 (None,),
             )
-            # TODO: if isnot required?
-            if append_item not in self._select_related_idx:
-                self._select_related_idx.append(append_item)
+            self._select_related_idx.append(append_item)
         self.resolve_ordering(
             self.model,
             self.model._meta.basetable,

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import defaultdict
 import types
 from collections.abc import AsyncIterator, Callable, Collection, Generator, Iterable
 from copy import copy
@@ -31,7 +32,7 @@ from tortoise.query_utils import (
     Prefetch,
     QueryModifier,
     TableCriterionTuple,
-    expand_field_expression,
+    expand_lookup_expression,
     get_joins_for_related_field,
 )
 from tortoise.router import router
@@ -1018,8 +1019,8 @@ class QuerySet(AwaitableQuery[MODEL]):
         queryset._db = _db if _db else queryset._db
         return queryset
 
-    def _join_select_related(self, select_related: str) -> QueryBuilder:
-        fields = expand_field_expression(self.model, select_related)
+    def _join_select_related(self, lookup_expression: str) -> tuple[type[Model], Table]:
+        fields = expand_lookup_expression(self.model, lookup_expression)
         model = self.model
         table = self.model._meta.basetable
         path: tuple[str | None, ...] = (None,)
@@ -1038,12 +1039,91 @@ class QuerySet(AwaitableQuery[MODEL]):
             model = field.related_model
             if append_item not in self._select_related_idx:
                 self._select_related_idx.append(append_item)
-            for related_field in related_fields:
-                # TODO pass all fields
-                self.query = self.query.select(
+            self.query = self.query.select(
+                *[
                     table[related_field].as_(f"{table.get_table_name()}.{related_field}")
+                    for related_field in related_fields
+                ]
+            )
+        return model, table
+
+    def _resolve_only(self, only_lookup_expressions: tuple[str, ...]) -> None:
+        # Group fields by fetch fields, e.g. ["a__b", "a__c"] -> {"a": ["b", "c"]}.
+        # The direct fields of the model are the ones that would have the key "".
+        fetch_to_fields = defaultdict(list)
+        # the order is important here, we need to process the shallowest fields first
+        # because we want to populate _select_related_idx with actual items that need to be
+        # selected, not "filler" items tha just tell the executor that an empty instance has
+        # to be created
+        for expression in sorted(only_lookup_expressions, key=lambda x: x.count("__")):
+            fetch_fields_lookup, __, field_name = expression.rpartition("__")
+            fetch_to_fields[fetch_fields_lookup].append(field_name)
+
+        # select direct model fields which would have the key "": {"": ["a", "b"]}
+        data_fields = fetch_to_fields.pop("", None)
+        if data_fields:
+            table = self.model._meta.basetable
+            self._select_related_idx.append(
+                (
+                    self.model,
+                    len(data_fields),
+                    table,
+                    self.model,
+                    (None,),
                 )
-        return self.query
+            )
+            self.query = self.query.select(
+                *[
+                    table[self.model._meta.fields_db_projection[field]].as_(field)
+                    for field in data_fields
+                ]
+            )
+        else:
+            # even though no data fields are selected, we need to let the executor know
+            # that an empty instance of the model has to be created
+            self._select_related_idx.append(
+                (
+                    self.model,
+                    0,
+                    self.model._meta.basetable,
+                    self.model,
+                    (None,),
+                )
+            )
+
+        # Select fields of related models, e.g. {"a": ["b", "c"]}
+        added_paths = set()
+        for fetch_fields_lookup, data_fields in fetch_to_fields.items():
+            fetch_fields = expand_lookup_expression(self.model, fetch_fields_lookup)
+            referring_model = model = self.model
+            table = self.model._meta.basetable
+            path: tuple[str | None, ...] = (None,)
+            for i, fetch_field in enumerate(fetch_fields):
+                field = cast(RelationalField, fetch_field)
+                path = path + (field.model_field_name,)
+                table = self._join_table_by_field(table, field.model_field_name, field)
+                referring_model = model
+                model = field.related_model
+
+                if path in added_paths:
+                    continue
+
+                self._select_related_idx.append(
+                    (
+                        model,
+                        # we need 0 items for letting know the executor that instances need to
+                        # be created even though no their fields are selected, e.g.
+                        # .only("a__b__field")
+                        len(data_fields) if i == len(fetch_fields) - 1 else 0,
+                        table,
+                        referring_model,
+                        path,
+                    )
+                )
+                added_paths.add(path)
+            self.query = self.query.select(
+                *[table[field].as_(f"{table.get_table_name()}.{field}") for field in data_fields]
+            )
 
     def _make_query(self) -> None:
         # clean tmp records first
@@ -1051,21 +1131,11 @@ class QuerySet(AwaitableQuery[MODEL]):
         self._joined_tables = []
         table = self.model._meta.basetable
         if self._fields_for_select:
-            append_item = (
-                self.model,
-                len(self._fields_for_select),
-                table,
-                self.model,
-                (None,),
-            )
-            if append_item not in self._select_related_idx:
-                self._select_related_idx.append(append_item)
-            db_fields_for_select = [
-                table[self.model._meta.fields_db_projection[field]].as_(field)
-                for field in self._fields_for_select
-            ]
-            self.query = copy(self.model._meta.basequery).select(*db_fields_for_select)
+            # select .only() fields
+            self.query = self.model._meta.basequery.select()
+            self._resolve_only(self._fields_for_select)
         else:
+            # select all fields
             self.query = copy(self.model._meta.basequery_all_fields)  # type:ignore[assignment]
             append_item = (
                 self.model,
@@ -1074,6 +1144,7 @@ class QuerySet(AwaitableQuery[MODEL]):
                 self.model,
                 (None,),
             )
+            # TODO: if isnot required?
             if append_item not in self._select_related_idx:
                 self._select_related_idx.append(append_item)
         self.resolve_ordering(
@@ -1098,7 +1169,7 @@ class QuerySet(AwaitableQuery[MODEL]):
             )
         if self._select_related:
             for select_related in self._select_related:
-                self.query = self._join_select_related(select_related)
+                self._join_select_related(select_related)
         if self._force_indexes:
             self.query._force_indexes = []
             self.query = self.query.force_index(*self._force_indexes)

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -928,6 +928,8 @@ class QuerySet(AwaitableQuery[MODEL]):
         * If you do a ``<model>.save(update_fields=[...])`` and one of the fields in ``update_fields`` was not in the ``.only(...)``,
           then ``IncompleteInstanceError`` as that field is not available to be updated.
         """
+        if not fields_for_select:
+            raise ValueError(".only() requires at least one field")
         queryset = self._clone()
         queryset._fields_for_select = fields_for_select
         return queryset
@@ -1036,6 +1038,11 @@ class QuerySet(AwaitableQuery[MODEL]):
             field = cast(RelationalField, field)
             path = path + (field.model_field_name,)
             table = self._join_table_by_field(table, field.model_field_name, field)
+
+            # do not select related fields if we are only selecting a subset of fields
+            if self._fields_for_select:
+                continue
+
             related_fields = field.related_model._meta.db_fields
             append_item = (
                 field.related_model,
@@ -1080,12 +1087,19 @@ class QuerySet(AwaitableQuery[MODEL]):
                     (None,),
                 )
             )
-            self.query = self.query.select(
-                *[
-                    table[self.model._meta.fields_db_projection[field]].as_(field)
-                    for field in data_fields
-                ]
-            )
+            try:
+                self.query = self.query.select(
+                    *[
+                        table[self.model._meta.fields_db_projection[field]].as_(field)
+                        for field in data_fields
+                        if field not in self._annotations
+                    ]
+                )
+            except KeyError as e:
+                raise FieldError(
+                    f'Unknown field "{e.args[0]}" for model "{self.model.__name__}"'
+                ) from e
+
         else:
             # even though no data fields are selected, we need to let the executor know
             # that an empty instance of the model has to be created

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -31,6 +31,7 @@ from tortoise.query_utils import (
     Prefetch,
     QueryModifier,
     TableCriterionTuple,
+    expand_field_expression,
     get_joins_for_related_field,
 )
 from tortoise.router import router
@@ -1017,45 +1018,31 @@ class QuerySet(AwaitableQuery[MODEL]):
         queryset._db = _db if _db else queryset._db
         return queryset
 
-    def _join_table_with_select_related(
-        self,
-        model: type[Model],
-        table: Table,
-        field: str,
-        forwarded_fields: str,
-        path: Iterable[str | None],
-    ) -> QueryBuilder:
-        if field in model._meta.fields_db_projection and forwarded_fields:
-            raise FieldError(f'Field "{field}" for model "{model.__name__}" is not relation')
-
-        field_object = cast(RelationalField, model._meta.fields_map.get(field))
-        if not field_object:
-            raise FieldError(f'Unknown field "{field}" for model "{model.__name__}"')
-
-        table = self._join_table_by_field(table, field, field_object)
-        related_fields = field_object.related_model._meta.db_fields
-        append_item = (
-            field_object.related_model,
-            len(related_fields),
-            field,
-            model,
-            path,
-        )
-        if append_item not in self._select_related_idx:
-            self._select_related_idx.append(append_item)
-        for related_field in related_fields:
-            self.query = self.query.select(
-                table[related_field].as_(f"{table.get_table_name()}.{related_field}")
+    def _join_select_related(self, select_related: str) -> QueryBuilder:
+        fields = expand_field_expression(self.model, select_related)
+        model = self.model
+        table = self.model._meta.basetable
+        path: tuple[str | None, ...] = (None,)
+        for field in fields:
+            field = cast(RelationalField, field)
+            path = path + (field.model_field_name,)
+            table = self._join_table_by_field(table, field.model_field_name, field)
+            related_fields = field.related_model._meta.db_fields
+            append_item = (
+                field.related_model,
+                len(related_fields),
+                field.model_field_name,
+                model,
+                path,
             )
-        if forwarded_fields:
-            field, __, forwarded_fields_ = forwarded_fields.partition("__")
-            self.query = self._join_table_with_select_related(
-                model=field_object.related_model,
-                table=table,
-                field=field,
-                forwarded_fields=forwarded_fields_,
-                path=(*path, field),
-            )
+            model = field.related_model
+            if append_item not in self._select_related_idx:
+                self._select_related_idx.append(append_item)
+            for related_field in related_fields:
+                # TODO pass all fields
+                self.query = self.query.select(
+                    table[related_field].as_(f"{table.get_table_name()}.{related_field}")
+                )
         return self.query
 
     def _make_query(self) -> None:
@@ -1110,15 +1097,8 @@ class QuerySet(AwaitableQuery[MODEL]):
                 self._select_for_update_of,
             )
         if self._select_related:
-            for field in self._select_related:
-                field, __, forwarded_fields = field.partition("__")
-                self.query = self._join_table_with_select_related(
-                    model=self.model,
-                    table=self.model._meta.basetable,
-                    field=field,
-                    forwarded_fields=forwarded_fields,
-                    path=(None, field),
-                )
+            for select_related in self._select_related:
+                self.query = self._join_select_related(select_related)
         if self._force_indexes:
             self.query._force_indexes = []
             self.query = self.query.force_index(*self._force_indexes)

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -626,6 +626,9 @@ class QuerySet(AwaitableQuery[MODEL]):
         If no arguments are passed it will default to a tuple containing all fields
         in order of declaration.
         """
+        if self._fields_for_select:
+            raise ValueError(".values_list() cannot be used with .only()")
+
         fields_for_select_list = fields_ or [
             field for field in self.model._meta.fields_map if field in self.model._meta.db_fields
         ] + list(self._annotations.keys())
@@ -652,14 +655,19 @@ class QuerySet(AwaitableQuery[MODEL]):
         """
         Make QuerySet return dicts instead of objects.
 
-        If call after `.get()`, `.get_or_none()` or `.first()` return dict instead of object.
+        If called after `.get()`, `.get_or_none()` or `.first()`, returns a dict instead of an object.
 
-        Can pass names of fields to fetch, or as a ``field_name='name_in_dict'`` kwarg.
+        You can specify which fields to include by:
+        - Passing field names as positional arguments
+        - Using kwargs in the format `field_name='name_in_dict'` to customize the keys in the resulting dict
 
-        If no arguments are passed it will default to a dict containing all fields.
+        If no arguments are passed, it will default to a dict containing all fields.
 
         :raises FieldError: If duplicate key has been provided.
         """
+        if self._fields_for_select:
+            raise ValueError(".values() cannot be used with .only()")
+
         if args or kwargs:
             fields_for_select: dict[str, str] = {}
             for field in args:


### PR DESCRIPTION
## Description
- `.only` supports selecting related fields, e.g. `.only("related__field")`
- Add a check that `.values()`, `.values_list()` and `.only()` cannot be used together
- Add `expand_lookup_expression` that can be used to convert the lookup expression (`a__b__c`) to a list of fields. Currently it is used in `_join_select_related` and `_resolve_only` but it can be reused in other places that support lookup expressions, for instance, in filters and ordering.

## Motivation and Context
- Will resolve https://github.com/tortoise/tortoise-orm/issues/1918
- Will resolve https://github.com/tortoise/tortoise-orm/issues/916

## How Has This Been Tested?
`make ci` + a lot of new tests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

