### PR TITLE
Release 0.25.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ Changelog
 0.25
 ====
 
-0.25.0 (unreleased)
+0.25.0
 ------
 Changed
 ^^^^^^^
@@ -19,6 +19,10 @@ Changed
 Added
 ^^^^^
 - `.only` supports selecting related fields, e.g. `.only("related__field")` (#1923)
+
+Fixed
+^^^^^
+- Fix pydantic_model_creator incompatibility with Pydantic 2.11 (#1930)
 
 
 0.24

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tortoise-orm"
-version = "0.24.2"
+version = "0.25.0"
 description = "Easy async ORM for python, built with relations in mind"
 authors = [{name="Andrey Bondar", email="andrey@bondar.ru"}, {name="Nickolas Grigoriadis", email="nagrigoriadis@gmail.com"}, {name="long2ice", email="long2ice@gmail.com"}]
 license = {text="Apache-2.0"}


### PR DESCRIPTION
Changed
^^^^^^^
- Skip database selection if the router is not configured to improve performance (#1915)
- `.values()`, `.values_list()` and `.only()` cannot be used together (#1923)

Added
^^^^^
- `.only` supports selecting related fields, e.g. `.only("related__field")` (#1923)

Fixed
^^^^^
- Fix pydantic_model_creator incompatibility with Pydantic 2.11 (#1930)