### PR TITLE
Force task switch every 2000 rows when creating objects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,12 @@ Changelog
 0.25
 ====
 
+0.25.1 (unreleased)
+------------------
+Changed
+^^^^^
+- Force async task switch every 2000 rows when converting db objects to python objects to avoid blocking the event loop (#1939)
+
 0.25.0
 ------
 Fixed
@@ -23,10 +29,6 @@ Changed
 Added
 ^^^^^
 - `.only` supports selecting related fields, e.g. `.only("related__field")` (#1923)
-
-Fixed
-^^^^^
-- Fix pydantic_model_creator incompatibility with Pydantic 2.11 (#1930)
 
 
 0.24


### PR DESCRIPTION
## Description
When selecting a large number of records, the process of converting database records to Tortoise objects might completely block the event loop. This PR introduces a task switch every 2000 rows to allow other workloads.

## Motivation and Context
Fixes https://github.com/tortoise/tortoise-orm/issues/1378.
I remember seeing other similar issues.

## How Has This Been Tested?
`make ci` and testing it in my hobby project.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

