### PR TITLE
Add SELECT ... FOR NO KEY UPDATE support for Postgres

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Changed
 ^^^^^
 - Force async task switch every 2000 rows when converting db objects to python objects to avoid blocking the event loop (#1939)
 
+Added
+^^^^^
+- Add `no_key` parameter to `queryset.select_for_update`.
+
 0.25.0
 ------
 Fixed

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -64,6 +64,7 @@ Contributors
 * Lance Moe ``@lancemoe``
 * Markus Beckschulte ``@markus-96``
 * Frederic Aoustin ``@fraoustin``
+* Ludwig Hähne ``@pankrat``
 
 Special Thanks
 ==============

--- a/poetry.lock
+++ b/poetry.lock
@@ -303,7 +303,7 @@ name = "asyncmy"
 version = "0.2.10"
 description = "A fast asyncio MySQL driver"
 optional = true
-python-versions = ">=3.8,<4.0"
+python-versions = "<4.0,>=3.8"
 groups = ["main"]
 markers = "python_version < \"4.0\" and extra == \"asyncmy\""
 files = [
@@ -1113,7 +1113,7 @@ name = "coveralls"
 version = "4.0.1"
 description = "Show coverage stats online via coveralls.io"
 optional = false
-python-versions = ">=3.8,<3.13"
+python-versions = "<3.13,>=3.8"
 groups = ["dev"]
 markers = "python_version <= \"3.11\""
 files = [
@@ -1185,7 +1185,7 @@ name = "cryptography"
 version = "45.0.2"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
-python-versions = ">=3.7, !=3.9.0, !=3.9.1"
+python-versions = "!=3.9.0,!=3.9.1,>=3.7"
 groups = ["dev"]
 markers = "platform_machine != \"ppc64le\" and platform_machine != \"s390x\" and sys_platform == \"linux\" and python_version >= \"3.11\""
 files = [
@@ -3027,15 +3027,15 @@ files = [
 
 [[package]]
 name = "pypika-tortoise"
-version = "0.5.0"
+version = "0.6.0"
 description = "Forked from pypika and streamline just for tortoise-orm"
 optional = false
-python-versions = ">=3.8,<4.0"
+python-versions = ">=3.9"
 groups = ["main"]
 markers = "python_version < \"4.0\""
 files = [
-    {file = "pypika_tortoise-0.5.0-py3-none-any.whl", hash = "sha256:dbdc47eb52ce17407b05ce9f8560ce93b856d7b28beb01971d956b017846691f"},
-    {file = "pypika_tortoise-0.5.0.tar.gz", hash = "sha256:ed0f56761868dc222c03e477578638590b972280b03c7c45cd93345b18b61f58"},
+    {file = "pypika_tortoise-0.6.0-py3-none-any.whl", hash = "sha256:cd097121bd8a89ec2209ff41caf4f389c18ebed628ffdeb35793e98f7ab16b5a"},
+    {file = "pypika_tortoise-0.6.0.tar.gz", hash = "sha256:3899e45b59b506c5b2a83232094437dc63bd8cccf754123f0b48f847931cdc8c"},
 ]
 
 [[package]]
@@ -3561,7 +3561,7 @@ name = "six"
 version = "1.17.0"
 description = "Python 2 and 3 compatibility utilities"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 groups = ["dev"]
 files = [
     {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
@@ -3585,7 +3585,7 @@ name = "snowballstemmer"
 version = "3.0.1"
 description = "This package provides 32 stemmers for 30 languages generated from Snowball algorithms."
 optional = false
-python-versions = "!=3.0.*, !=3.1.*, !=3.2.*"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*"
 groups = ["dev"]
 files = [
     {file = "snowballstemmer-3.0.1-py3-none-any.whl", hash = "sha256:6cd7b3897da8d6c9ffb968a6781fa6532dce9c3618a4b127d920dab764a19064"},
@@ -4492,4 +4492,4 @@ psycopg = ["psycopg"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "9cbdbf0932c833c8f4f6e12984c4cab897854155c2eb354e4ed2153877d34c0c"
+content-hash = "be8881c15fd0b0a6a979882af966cb12d9a4ea85b8f284aaa848d42e7efb4655"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ include = ["CHANGELOG.rst", "LICENSE", "README.rst"]
 dynamic = [ "classifiers" ]
 requires-python = ">=3.9"
 dependencies = [
-    "pypika-tortoise (>=0.5.0,<1.0.0); python_version < '4.0'",
+    "pypika-tortoise (>0.5.0,<1.0.0); python_version < '4.0'",
     "iso8601 (>=2.1.0,<3.0.0); python_version < '4.0'",
     "aiosqlite (>=0.16.0,<1.0.0)",
     "pytz",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ include = ["CHANGELOG.rst", "LICENSE", "README.rst"]
 dynamic = [ "classifiers" ]
 requires-python = ">=3.9"
 dependencies = [
-    "pypika-tortoise (>0.5.0,<1.0.0); python_version < '4.0'",
+    "pypika-tortoise (>=0.6.0,<1.0.0); python_version < '4.0'",
     "iso8601 (>=2.1.0,<3.0.0); python_version < '4.0'",
     "aiosqlite (>=0.16.0,<1.0.0)",
     "pytz",

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -674,6 +674,7 @@ class TestQueryset(test.TestCase):
         sql2 = IntFields.filter(pk=1).only("id").select_for_update(nowait=True).sql()
         sql3 = IntFields.filter(pk=1).only("id").select_for_update(skip_locked=True).sql()
         sql4 = IntFields.filter(pk=1).only("id").select_for_update(of=("intfields",)).sql()
+        sql5 = IntFields.filter(pk=1).only("id").select_for_update(no_key=True).sql()
 
         dialect = self.db.schema_generator.DIALECT
         if dialect == "postgres":
@@ -694,6 +695,10 @@ class TestQueryset(test.TestCase):
                     sql4,
                     'SELECT "id" "id" FROM "intfields" WHERE "id"=%s FOR UPDATE OF "intfields"',
                 )
+                self.assertEqual(
+                    sql5,
+                    'SELECT "id" "id" FROM "intfields" WHERE "id"=%s FOR NO KEY UPDATE',
+                )
             else:
                 self.assertEqual(
                     sql1,
@@ -711,6 +716,10 @@ class TestQueryset(test.TestCase):
                     sql4,
                     'SELECT "id" "id" FROM "intfields" WHERE "id"=$1 FOR UPDATE OF "intfields"',
                 )
+                self.assertEqual(
+                    sql5,
+                    'SELECT "id" "id" FROM "intfields" WHERE "id"=$1 FOR NO KEY UPDATE',
+                )
         elif dialect == "mysql":
             self.assertEqual(
                 sql1,
@@ -727,6 +736,10 @@ class TestQueryset(test.TestCase):
             self.assertEqual(
                 sql4,
                 "SELECT `id` `id` FROM `intfields` WHERE `id`=%s FOR UPDATE OF `intfields`",
+            )
+            self.assertEqual(
+                sql5,
+                "SELECT `id` `id` FROM `intfields` WHERE `id`=%s FOR UPDATE",
             )
 
     async def test_select_related(self):

--- a/tortoise/backends/base/client.py
+++ b/tortoise/backends/base/client.py
@@ -34,6 +34,7 @@ class Capabilities:
         DDL statement, and not as a separate statement.
     :param supports_transactions: Indicates that this DB supports transactions.
     :param support_for_update: Indicates that this DB supports SELECT ... FOR UPDATE SQL statement.
+    :param support_for_update_no_key: Indicates that this DB supports SELECT ... FOR NO KEY UPDATE SQL statement.
     :param support_index_hint: Support force index or use index.
     :param support_update_limit_order_by: support update/delete with limit and order by.
     :param: support_for_posix_regex_queries: indicated if the db supports posix regex queries
@@ -50,6 +51,7 @@ class Capabilities:
         inline_comment: bool = False,
         supports_transactions: bool = True,
         support_for_update: bool = True,
+        support_for_no_key_update: bool = False,
         # Support force index or use index?
         support_index_hint: bool = False,
         # support update/delete with limit and order by
@@ -64,6 +66,7 @@ class Capabilities:
         self.inline_comment = inline_comment
         self.supports_transactions = supports_transactions
         self.support_for_update = support_for_update
+        self.support_for_no_key_update = support_for_no_key_update
         self.support_index_hint = support_index_hint
         self.support_update_limit_order_by = support_update_limit_order_by
         self.support_for_posix_regex_queries = support_for_posix_regex_queries

--- a/tortoise/backends/base_postgres/client.py
+++ b/tortoise/backends/base_postgres/client.py
@@ -45,7 +45,10 @@ class BasePostgresClient(BaseDBAsyncClient, abc.ABC):
     executor_class: type[BasePostgresExecutor] = BasePostgresExecutor
     schema_generator: type[BasePostgresSchemaGenerator] = BasePostgresSchemaGenerator
     capabilities = Capabilities(
-        "postgres", support_update_limit_order_by=False, support_for_posix_regex_queries=True
+        "postgres",
+        support_update_limit_order_by=False,
+        support_for_posix_regex_queries=True,
+        support_for_no_key_update=True,
     )
     connection_class: AsyncConnection | Connection | None = None
     loop: AbstractEventLoop | None = None

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -1147,6 +1147,7 @@ class Model(metaclass=ModelMeta):
         skip_locked: bool = False,
         of: tuple[str, ...] = (),
         using_db: BaseDBAsyncClient | None = None,
+        no_key: bool = False,
     ) -> QuerySet[Self]:
         """
         Make QuerySet select for update.
@@ -1154,7 +1155,9 @@ class Model(metaclass=ModelMeta):
         Returns a queryset that will lock rows until the end of the transaction,
         generating a SELECT ... FOR UPDATE SQL statement on supported databases.
         """
-        return cls._db_queryset(using_db, for_write=True).select_for_update(nowait, skip_locked, of)
+        return cls._db_queryset(using_db, for_write=True).select_for_update(
+            nowait, skip_locked, of, no_key=no_key
+        )
 
     @classmethod
     async def update_or_create(


### PR DESCRIPTION
## Description

Allow slightly reducing the lock level when using `select_for_update` on Postgres DBs. In contrast to the classic `SELECT FOR UPDATE` this lock level allows concurrent inserts and deletes on tables that have foreign key references to the locked rows.

The parameter follow the Django ORM design:

https://code.djangoproject.com/ticket/30375

This depends on these changes in pypika-tortoise: https://github.com/tortoise/pypika-tortoise/pull/29

Please see the linked PR for an alternative approach that exposes lock strength directly (which would allow supporting `SELECT FOR SHARE` and `SELECT FOR KEY SHARE` as well but lose the "compatibility" with Django ORM). 

## Motivation and Context

I'm currently working on a project that suffers from lock contention issues blocking INSERTs and DELETEs where SELECT FOR UPDATE is involved. The SELECT FOR UPDATE is often used in a transaction where certain columns are modified for the locked rows but the primary key is untouched and the rows are not deleted. Since I'm using Postgres, `SELECT FOR NO KEY UPDATE` would be a simple way to reduce lock contention slightly. However, this is not supported by Tortoise so I'd have to fall back to raw queries which is somewhat cumbersome.

## How Has This Been Tested?

I've used the test suite of tortoise-orm and pypika-tortoise and ran test against PostgreSQL and MySql and MacOS with docker:

```
# Start test databases
docker run --name tortoise-test-postgres -e POSTGRES_PASSWORD=123456 -p 5432:5432 -d postgres
docker run --name tortoise-test-mysql -e MYSQL_ROOT_PASSWORD=123456 -p 3306:3306 -d mysql

# Use modified version of pypika-tortoise
pip install git+https://github.com/Pankrat/pypika-tortoise.git@select-for-no-key-update

# Run tests (seems to reset pypika-tortoise, need to re-run pip install command above before each run)
pip install cryptography
make test_mysql
make test_postgres_asyncpg
make test_postgres_psycopg
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.