### PR TITLE
docs: Update Getting Started installation commands

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,6 @@ Changelog
 Changed
 ^^^^^
 - Force async task switch every 2000 rows when converting db objects to python objects to avoid blocking the event loop (#1939)
-- Update installation commands to be zsh-friendly (#1958)
 
 Added
 ^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Changelog
 Changed
 ^^^^^
 - Force async task switch every 2000 rows when converting db objects to python objects to avoid blocking the event loop (#1939)
+- Update installation commands to be zsh-friendly (#1958)
 
 Added
 ^^^^^

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -17,17 +17,17 @@ The following table shows the available installation options for different datab
    * - SQLite
      - ``pip install tortoise-orm``
    * - PostgreSQL (psycopg)
-     - ``pip install tortoise-orm[psycopg]``
+     - ``pip install "tortoise-orm[psycopg]"``
    * - PostgreSQL (asyncpg)
-     - ``pip install tortoise-orm[asyncpg]``
+     - ``pip install "tortoise-orm[asyncpg]"``
    * - MySQL (aiomysql)
-     - ``pip install tortoise-orm[aiomysql]``
+     - ``pip install "tortoise-orm[aiomysql]"``
    * - MySQL (asyncmy)
-     - ``pip install tortoise-orm[asyncmy]``
+     - ``pip install "tortoise-orm[asyncmy]"``
    * - MS SQL
-     - ``pip install tortoise-orm[asyncodbc]``
+     - ``pip install "tortoise-orm[asyncodbc]"``
    * - Oracle
-     - ``pip install tortoise-orm[asyncodbc]``
+     - ``pip install "tortoise-orm[asyncodbc]"``
 
 
 Optional Dependencies
@@ -43,7 +43,7 @@ The following command will install all optional dependencies:
 
 .. code-block:: bash
 
-    pip install tortoise-orm[accel]
+    pip install "tortoise-orm[accel]"
 ..
 
 Tutorial


### PR DESCRIPTION
## Description
zsh misinterprets square brackets, but adding quotation marks resolves that.

## Motivation and Context
This is a minor change to avoid slight friction when someone wants to install the package with a non-default database.

## How Has This Been Tested?
Tested by successfully running the installation command with quotation marks.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

