### PR TITLE
Added m2m related table alias

### DIFF
--- a/tortoise/query_utils.py
+++ b/tortoise/query_utils.py
@@ -125,6 +125,8 @@ def resolve_nested_field(
             related_table = related_table.as_(
                 f"{table.get_table_name()}__{iter_field.model_field_name}"
             )
+        if isinstance(related_field, ManyToManyFieldInstance):
+            related_table = related_table.as_(f"{table.get_table_name()}__{iter_field.model_field_name}")
         table = related_table
 
     last_field = fields[-1]
@@ -142,6 +144,10 @@ def resolve_nested_field(
                 related_table = related_table.as_(
                     f"{table.get_table_name()}__{related_field.model_field_name}"
                 )
+        if isinstance(related_field, ManyToManyFieldInstance):
+            related_table = related_table.as_(
+                f"{table.get_table_name()}__{related_field.model_field_name}"
+            )
 
         term = related_table[related_field_meta.db_pk_column]
     else:

--- a/tortoise/query_utils.py
+++ b/tortoise/query_utils.py
@@ -37,6 +37,7 @@ def get_joins_for_related_field(
     related_table: Table = related_field.related_model._meta.basetable
     if isinstance(related_field, ManyToManyFieldInstance):
         through_table = Table(related_field.through)
+        related_table = related_table.as_(f"{table.get_table_name()}__{related_field_name}")
         required_joins.append(
             (
                 through_table,

--- a/tortoise/query_utils.py
+++ b/tortoise/query_utils.py
@@ -126,7 +126,9 @@ def resolve_nested_field(
                 f"{table.get_table_name()}__{iter_field.model_field_name}"
             )
         if isinstance(related_field, ManyToManyFieldInstance):
-            related_table = related_table.as_(f"{table.get_table_name()}__{iter_field.model_field_name}")
+            related_table = related_table.as_(
+                f"{table.get_table_name()}__{iter_field.model_field_name}"
+            )
         table = related_table
 
     last_field = fields[-1]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix incorrect JOIN aliasing when filtering on multiple ManyToMany relations to the same table

## Description
This PR fixes an issue where Tortoise ORM fails to properly alias JOINs when filtering on two different ManyToMany relations pointing to the same model. The problem occurred because `get_joins_for_related_field` function didn't apply table aliasing for ManyToManyFieldInstance cases.

The main change modifies the `get_joins_for_related_field` function to add proper table aliasing for ManyToMany relations by using the pattern `{table_name}__{field_name}` for the alias.

## Motivation and Context
When making queries that filter on two different ManyToMany relations to the same model (through different through tables), Tortoise ORM was generating SQL without proper table aliasing, causing ambiguity in the JOINs. This made such queries impossible to execute correctly.

Fixes issue #1969 