### PR TITLE
Enable `parents.children.create(...)` syntax

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,15 @@ Changelog
 
 .. rst-class:: emphasize-children
 
+0.26
+====
+
+0.26.0 (unreleased)
+------------------- 
+Added
+^^^^^
+- Add `create()` method to reverse ForeignKey relations, enabling `parent.children.create()` syntax
+
 0.25
 ====
 

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -65,6 +65,7 @@ Contributors
 * Markus Beckschulte ``@markus-96``
 * Frederic Aoustin ``@fraoustin``
 * Ludwig Hähne ``@pankrat``
+* Christian Tanul ``@scriptogre``
 
 Special Thanks
 ==============

--- a/README.rst
+++ b/README.rst
@@ -152,6 +152,9 @@ With the Tortoise initialized, the models are available for use:
             team = await Team.create(name='Team {}'.format(i + 1))
             participants.append(team)
 
+        # One to Many (ForeignKey) relations support creating related objects
+        another_event = await tournament.events.create(name='Another Event')
+
         # Many to Many Relationship management is quite straightforward
         # (there are .remove(...) and .clear() too)
         await event.participants.add(*participants)

--- a/docs/query.rst
+++ b/docs/query.rst
@@ -50,6 +50,15 @@ The related objects can be filtered:
 
 which will return you a QuerySet object with predefined filter.
 
+You can also create related objects directly through the reverse ForeignKey relation:
+
+.. code-block:: python3
+
+    # Create a related object automatically setting the foreign key
+    new_event = await team.events.create(name='New Event')
+    # Equivalent to:
+    # new_event = await Event.create(name='New Event', team=team)
+
 QuerySet
 ========
 

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -18,7 +18,7 @@ from tests.testmodels import (
 )
 from tortoise.contrib import test
 from tortoise.contrib.test.condition import NotIn
-from tortoise.exceptions import FieldError, NoValuesFetched
+from tortoise.exceptions import FieldError, NoValuesFetched, OperationalError
 from tortoise.functions import Count, Trim
 
 
@@ -479,3 +479,25 @@ class TestDoubleFK(test.TestCase):
         self.assertEqual(await obj.nodes.all(), [])
         await obj.nodes.add(node)
         self.assertEqual(await obj.nodes.all(), [node])
+
+    async def test_reverse_relation_create_fk(self):
+        tournament = await Tournament.create(name="Test Tournament")
+        self.assertEqual(await tournament.events.all(), [])
+
+        event = await tournament.events.create(name="Test Event")
+
+        await tournament.fetch_related("events")
+
+        self.assertEqual(len(tournament.events), 1)
+        self.assertEqual(event.name, "Test Event")
+        self.assertEqual(event.tournament_id, tournament.id)
+        self.assertEqual(tournament.events[0].event_id, event.event_id)
+
+    async def test_reverse_relation_create_fk_errors_for_unsaved_instance(self):
+        tournament = Tournament(name="Unsaved Tournament")
+
+        # Should raise OperationalError since tournament isn't saved
+        with self.assertRaises(OperationalError) as cm:
+            await tournament.events.create(name="Test Event")
+
+        self.assertIn("hasn't been instanced", str(cm.exception))

--- a/tortoise/fields/relational.py
+++ b/tortoise/fields/relational.py
@@ -127,6 +127,38 @@ class ReverseRelation(Generic[MODEL]):
         """
         return self._query.offset(offset)
 
+    async def create(self, using_db: BaseDBAsyncClient | None = None, **kwargs: Any) -> MODEL:
+        """
+        Create a related record in the DB and returns the object, automatically setting the
+        foreign key relationship to the parent instance.
+
+        .. code-block:: python3
+
+            tournament = await Tournament.create(name="...")
+            event = await tournament.events.create(...)
+
+        Equivalent to:
+
+        .. code-block:: python3
+
+            tournament = await Tournament.create(name="...")
+            event = await Event.create(tournament=tournament, ...)
+
+        :param using_db: Specific DB connection to use instead of default bound.
+        :param kwargs: Model parameters for the new object.
+        :raises OperationalError: If parent instance is not saved to the database.
+        """
+        if not self.instance._saved_in_db:
+            raise OperationalError(
+                "This objects hasn't been instanced, call .save() before calling related queries"
+            )
+
+        # Inject foreign key relationship automatically
+        kwargs[self.relation_field] = getattr(self.instance, self.from_field)
+
+        # Call remote model's create method
+        return await self.remote_model.create(using_db=using_db, **kwargs)
+
     def _set_result_for_query(self, sequence: list[MODEL], attr: str | None = None) -> None:
         self._fetched = True
         self.related_objects = sequence


### PR DESCRIPTION
## Description
Add `create()` method to `ReverseRelation` for `ForeignKeyField`. 

Provide an ergonomic way to create related objects, and better fulfill expectations of people coming from Django's ORM.

**Before:**
```
event = await Event.create(tournament=tournament, ...)
```

**After:**
```
event = await tournament.events.create(...)  # Now possible
```

The implementation is simple (just ~5 lines of code):
1. Check if parent instance is saved in db (otherwise raise `OperationalError`)
2. Automatically inject relationship into `kwargs`
3. Call remote model's `create` method (with the updated `kwargs`)

## Motivation and Context
1. **Django compatibility**: Developers migrating from Django probably expect `parent.children.create()` to work.
2. **Consistency**: Tortoise already implements such methods for `ManyToMany` fields (`.add()`, `.clear()`, `.remove()`). `ForeignKey` should have the same level of support.
3. **Developer Experience**: Eliminates the need to manually specify the foreign key relationship, reducing boilerplate.

## How Has This Been Tested?
Added tests for successful creation and error handling with unsaved instances.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

