### PR TITLE
Fix GROUP BY alias in subquery generation

### DIFF
--- a/tests/test_group_by.py
+++ b/tests/test_group_by.py
@@ -1,5 +1,6 @@
 from tests.testmodels import Author, Book, Event, Team, Tournament
 from tortoise.contrib import test
+from tortoise.expressions import Subquery
 from tortoise.functions import Avg, Count, Sum, Upper
 
 
@@ -317,3 +318,16 @@ class TestGroupBy(test.TestCase):
     async def test_group_by_id_with_nested_filter(self):
         ret = await Book.filter(author__name="author1").group_by("id").values_list("id")
         self.assertEqual(set(ret), {(book.id,) for book in self.books1})
+
+    async def test_subquery_group_by_no_alias(self):
+        query = Author.annotate(
+            book_name=Subquery(Book.all().group_by("name").order_by("name").limit(1).values("name"))
+        )
+
+        sql = query.sql()
+
+        self.assertIn('GROUP BY "name"', sql)
+        self.assertNotIn('GROUP BY "name" "', sql)
+
+        result = await query.values("name", "book_name")
+        self.assertIsInstance(result, list)

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -1598,9 +1598,7 @@ class FieldSelectQuery(AwaitableQuery):
                 field=field,
                 forwarded_fields=forwarded_fields,
             )
-            field = related_table[related_db_field].as_(
-                f"{related_table.get_table_name()}__{field_name}"
-            )
+            field = related_table[related_db_field]
             group_bys.append(field)
         return group_bys
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed invalid SQL generation in subquery GROUP BY clauses. The _resolve_group_bys method was incorrectly adding field aliases to GROUP BY clauses, causing invalid SQL syntax like GROUP BY "name" "alias" instead of the correct GROUP BY "name".

## Motivation and Context
https://github.com/tortoise/tortoise-orm/issues/1999
It fixes the open issue 1999. 

## How Has This Been Tested?
Added regression test test_subquery_group_by_no_alias to verify GROUP BY clauses don't include aliases
Ran make check - all style, lint, and tests passed
Verified SQL generation produces valid GROUP BY "field" instead of invalid GROUP BY "field" "alias"
Tested with the exact reproduction case from issue #1999

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

