### PR TITLE
refactor: delete duplicate model name validate in OneToOneFieldInstance

### DIFF
--- a/tortoise/fields/relational.py
+++ b/tortoise/fields/relational.py
@@ -320,8 +320,8 @@ class ForeignKeyFieldInstance(RelationalField[MODEL]):
         on_delete: OnDelete = CASCADE,
         **kwargs: Any,
     ) -> None:
-        super().__init__(None, **kwargs)  # type: ignore
         self.validate_model_name(model_name)
+        super().__init__(None, **kwargs)  # type: ignore
         self.model_name = model_name
         self.related_name = related_name
         if on_delete not in set(OnDelete):
@@ -363,7 +363,6 @@ class OneToOneFieldInstance(ForeignKeyFieldInstance[MODEL]):
         on_delete: OnDelete = CASCADE,
         **kwargs: Any,
     ) -> None:
-        self.validate_model_name(model_name)
         super().__init__(model_name, related_name, on_delete, unique=True, **kwargs)
 
 

--- a/tortoise/fields/relational.py
+++ b/tortoise/fields/relational.py
@@ -320,8 +320,8 @@ class ForeignKeyFieldInstance(RelationalField[MODEL]):
         on_delete: OnDelete = CASCADE,
         **kwargs: Any,
     ) -> None:
+        super().__init__(None, **kwargs)  # type:ignore[arg-type]
         self.validate_model_name(model_name)
-        super().__init__(None, **kwargs)  # type: ignore
         self.model_name = model_name
         self.related_name = related_name
         if on_delete not in set(OnDelete):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`self.validate_model_name(model_name)` run twice when initial OneToOneFieldInstance

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<img width="889" height="437" alt="image" src="https://github.com/user-attachments/assets/9ff30468-26c2-4abb-a39e-d3ea3442039f" />
<img width="971" height="369" alt="image" src="https://github.com/user-attachments/assets/b061a6a3-92d5-42ad-8bae-d44d0be0a5c7" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

