### PR TITLE
ci: fix mysql myisam test error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
           sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18
       - name: Run ci
         run: uv run make ci
+        env:
+          TORTOISE_GTID_KEEP_OFF: 1
       - name: Test FastAPI/Blacksheep Example
         run: |
           PYTHONPATH=$DEST_FASTAPI uv run pytest $PYTEST_ARGS $DEST_FASTAPI/_tests.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           POSTGRES_USER: postgres
         options: --health-cmd=pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
       mysql:
-        image: mysql
+        image: mysql:8
         ports:
           - 3306:3306
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,6 @@ jobs:
           sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18
       - name: Run ci
         run: uv run make ci
-        env:
-          TORTOISE_GTID_KEEP_OFF: 1
       - name: Test FastAPI/Blacksheep Example
         run: |
           PYTHONPATH=$DEST_FASTAPI uv run pytest $PYTEST_ARGS $DEST_FASTAPI/_tests.py

--- a/conftest.py
+++ b/conftest.py
@@ -9,6 +9,54 @@ import pytest
 from tortoise.contrib.test import finalizer, initializer
 
 
+def _switch_gtid_mode() -> Callable[[], None] | None:
+    # SET gtid_mode to be OFF before testings
+    # And SET it ON after test before finalizer
+    from tortoise.contrib.test import _CONNECTIONS, _LOOP
+
+    conn = _CONNECTIONS.get("models")
+    assert conn is not None
+    run_coro = _LOOP.run_until_complete
+
+    async def get_var_value(statement: str) -> str:
+        result = await conn.execute_query_dict(statement)
+        return result[0]["Value"]
+
+    async def is_enforce_gtid() -> bool:
+        statement = "SHOW VARIABLES LIKE 'enforce_gtid_consistency';"
+        return (await get_var_value(statement)) == "ON"
+
+    async def is_gtid_mode_on() -> bool:
+        statement = "SHOW VARIABLES LIKE 'gtid_mode';"
+        return (await get_var_value(statement)) == "ON"
+
+    async def set_enforce_gtid_off() -> None:
+        statement = "SET GLOBAL enforce_gtid_consistency = OFF;"
+        if await is_gtid_mode_on():
+            off_mode = """
+            SET GLOBAL gtid_mode = ON_PERMISSIVE;
+            SET GLOBAL gtid_mode = OFF_PERMISSIVE;
+            SET GLOBAL gtid_mode = OFF;
+            """
+            statement = off_mode + statement
+        await conn.execute_script(statement)
+
+    async def set_enforce_gtid_on() -> None:
+        statement = "SET GLOBAL enforce_gtid_consistency = ON;"
+        if not (await is_gtid_mode_on()):
+            statement += """
+            SET GLOBAL gtid_mode = OFF_PERMISSIVE;
+            SET GLOBAL gtid_mode = ON_PERMISSIVE;
+            SET GLOBAL gtid_mode = ON;
+            """
+        await conn.execute_script(statement)
+
+    if run_coro(is_enforce_gtid()):
+        run_coro(set_enforce_gtid_off())
+        return functools.partial(run_coro, set_enforce_gtid_on())
+    return None
+
+
 @pytest.fixture(scope="session", autouse=True)
 def initialize_tests():
     # Reduce the default timeout for psycopg because the tests become very slow otherwise
@@ -24,50 +72,7 @@ def initialize_tests():
     rollback_sets: Callable[[], None] | None = None
     if db_url.startswith("mysql") and "storage_engine=MYISAM" in db_url:
         # Fixes "tortoise.exceptions.OperationalError: (1785, 'Statement violates GTID consistency: ...')" for `make test_mysql_myisam`
-        from tortoise.contrib.test import _CONNECTIONS, _LOOP
-
-        conn = _CONNECTIONS.get("models")
-        assert conn is not None
-        run_coro = _LOOP.run_until_complete
-
-        def get_var_value(statement: str) -> str:
-            result = run_coro(conn.execute_query_dict(statement))
-            return result[0]["Value"]
-
-        def is_enforce_gtid() -> bool:
-            statement = "SHOW VARIABLES LIKE 'enforce_gtid_consistency';"
-            return get_var_value(statement) == "ON"
-
-        def is_gtid_mode_on() -> bool:
-            statement = "SHOW VARIABLES LIKE 'gtid_mode';"
-            return get_var_value(statement) == "ON"
-
-        async def set_enforce_gtid_off(switch_mode: bool) -> None:
-            statement = "SET GLOBAL enforce_gtid_consistency = OFF;"
-            if switch_mode:
-                off_mode = """
-                SET GLOBAL gtid_mode = ON_PERMISSIVE;
-                SET GLOBAL gtid_mode = OFF_PERMISSIVE;
-                SET GLOBAL gtid_mode = OFF;
-                """
-                statement = off_mode + statement
-            await conn.execute_script(statement)
-
-        def set_enforce_gtid_on(switch_mode: bool) -> None:
-            statement = "SET GLOBAL enforce_gtid_consistency = ON;"
-            if switch_mode:
-                statement += """
-                SET GLOBAL gtid_mode = OFF_PERMISSIVE;
-                SET GLOBAL gtid_mode = ON_PERMISSIVE;
-                SET GLOBAL gtid_mode = ON;
-                """
-            run_coro(conn.execute_script(statement))
-
-        if is_enforce_gtid():
-            mode_on = is_gtid_mode_on()
-            run_coro(set_enforce_gtid_off(mode_on))
-            rollback_sets = functools.partial(set_enforce_gtid_on, mode_on)
-
+        rollback_sets = _switch_gtid_mode()
     try:
         yield
     finally:

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import functools
 import os
 from typing import Callable
@@ -13,6 +14,7 @@ def _switch_gtid_mode() -> Callable[[], None] | None:
     # SET gtid_mode to be OFF before testings
     # And SET it ON after test before finalizer
     from tortoise.contrib.test import _CONNECTIONS, _LOOP
+    from tortoise.exceptions import OperationalError
 
     conn = _CONNECTIONS.get("models")
     assert conn is not None
@@ -24,41 +26,41 @@ def _switch_gtid_mode() -> Callable[[], None] | None:
 
     async def is_enforce_gtid() -> bool:
         statement = "SHOW VARIABLES LIKE 'enforce_gtid_consistency';"
-        return (await get_var_value(statement)) == "ON"
+        return (await get_var_value(statement)).upper() == "ON"
 
-    async def is_gtid_mode_on() -> bool:
+    async def get_gtid_mode_status() -> str:
         statement = "SHOW VARIABLES LIKE 'gtid_mode';"
-        return (await get_var_value(statement)) == "ON"
+        return await get_var_value(statement)
 
-    async def execute_oneline_per_time(multi_line_sql: str) -> None:
-        for sql in multi_line_sql.strip().splitlines():
-            await conn.execute_script(sql.strip())
-
-    async def set_enforce_gtid_off() -> None:
+    async def set_enforce_gtid_off(mode_on: bool, gtid_mode: str) -> None:
         statement = "SET GLOBAL enforce_gtid_consistency = OFF;"
-        if await is_gtid_mode_on():
-            off_mode = """
-            SET GLOBAL gtid_mode = ON_PERMISSIVE;
-            SET GLOBAL gtid_mode = OFF_PERMISSIVE;
-            SET GLOBAL gtid_mode = OFF;
-            """
-            await execute_oneline_per_time(off_mode)
+        if mode_on:
+            if gtid_mode == "ON":
+                await conn.execute_script("SET GLOBAL gtid_mode = ON_PERMISSIVE;")
+            await conn.execute_script("SET GLOBAL gtid_mode = OFF_PERMISSIVE;")
         await conn.execute_script(statement)
 
-    async def set_enforce_gtid_on() -> None:
+    async def set_enforce_gtid_on(mode_on: bool, origin_gtid_mode: str) -> None:
         statement = "SET GLOBAL enforce_gtid_consistency = ON;"
         await conn.execute_script(statement)
-        if not (await is_gtid_mode_on()):
-            on_mode = """
-            SET GLOBAL gtid_mode = OFF_PERMISSIVE;
-            SET GLOBAL gtid_mode = ON_PERMISSIVE;
-            SET GLOBAL gtid_mode = ON;
-            """
-            await execute_oneline_per_time(on_mode)
+        if mode_on:
+            current_status = (await get_gtid_mode_status()).upper()
+            if current_status == origin_gtid_mode.upper():
+                return
+            with contextlib.suppress(OperationalError):
+                if current_status == "OFF":
+                    await conn.execute_script("SET GLOBAL gtid_mode = OFF_PERMISSIVE;")
+                await conn.execute_script("SET GLOBAL gtid_mode = ON_PERMISSIVE;")
+                if origin_gtid_mode.upper() == "ON":
+                    await conn.execute_script("SET GLOBAL gtid_mode = ON;")
 
     if run_coro(is_enforce_gtid()):
-        run_coro(set_enforce_gtid_off())
-        return functools.partial(run_coro, set_enforce_gtid_on())
+        origin_gtid_mode = run_coro(get_gtid_mode_status())
+        gtid_mode = origin_gtid_mode.upper()
+        mode_on = gtid_mode.startswith("ON")
+        run_coro(set_enforce_gtid_off(mode_on, gtid_mode))
+        if mode_on and not os.getenv("TORTOISE_GTID_KEEP_OFF"):
+            return functools.partial(run_coro, set_enforce_gtid_on(mode_on, origin_gtid_mode))
     return None
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import functools
 import os
-from typing import Any, Callable
+from typing import Callable
 
 import pytest
 
@@ -21,17 +21,17 @@ def initialize_tests(request):
 
     db_url = os.getenv("TORTOISE_TEST_DB", "sqlite://:memory:")
     initializer(["tests.testmodels"], db_url=db_url)
-    rollback_vars: Callable[[], Any] | None = None
+    rollback_sets: Callable[[], None] | None = None
     if db_url.startswith("mysql") and "storage_engine=MYISAM" in db_url:
         # Fixes "tortoise.exceptions.OperationalError: (1785, 'Statement violates GTID consistency: ...')" for `make test_mysql_myisam`
         from tortoise.contrib.test import _CONNECTIONS, _LOOP
 
         conn = _CONNECTIONS.get("models")
         assert conn is not None
-        run_async = _LOOP.run_until_complete
+        run_coro = _LOOP.run_until_complete
 
         def get_var_value(statement: str) -> str:
-            result = run_async(conn.execute_query(statement))
+            result = run_coro(conn.execute_query(statement))
             return result[1][0]["Value"]
 
         def is_enforce_gtid() -> bool:
@@ -53,7 +53,7 @@ def initialize_tests(request):
                 statement = off_mode + statement
             await conn.execute_script(statement)
 
-        async def set_enforce_gtid_on(switch_mode: bool) -> None:
+        def set_enforce_gtid_on(switch_mode: bool) -> None:
             statement = "SET GLOBAL enforce_gtid_consistency = ON;"
             if switch_mode:
                 statement += """
@@ -61,13 +61,13 @@ def initialize_tests(request):
                 SET GLOBAL gtid_mode = ON_PERMISSIVE;
                 SET GLOBAL gtid_mode = ON;
                 """
-            await conn.execute_script(statement)
+            run_coro(conn.execute_script(statement))
 
         if is_enforce_gtid():
             mode_on = is_gtid_mode_on()
-            run_async(set_enforce_gtid_off(mode_on))
-            rollback_vars = functools.partial(run_async, set_enforce_gtid_on(mode_on))
+            run_coro(set_enforce_gtid_off(mode_on))
+            rollback_sets = functools.partial(set_enforce_gtid_on, mode_on)
 
     request.addfinalizer(finalizer)
-    if rollback_vars is not None:
-        request.addfinalizer(rollback_vars)
+    if rollback_sets is not None:
+        request.addfinalizer(rollback_sets)

--- a/conftest.py
+++ b/conftest.py
@@ -30,28 +30,31 @@ def _switch_gtid_mode() -> Callable[[], None] | None:
         statement = "SHOW VARIABLES LIKE 'gtid_mode';"
         return (await get_var_value(statement)) == "ON"
 
+    async def execute_oneline_per_time(multi_line_sql: str) -> None:
+        for sql in multi_line_sql.strip().splitlines():
+            await conn.execute_script(sql.strip())
+
     async def set_enforce_gtid_off() -> None:
         statement = "SET GLOBAL enforce_gtid_consistency = OFF;"
         if await is_gtid_mode_on():
             off_mode = """
             SET GLOBAL gtid_mode = ON_PERMISSIVE;
             SET GLOBAL gtid_mode = OFF_PERMISSIVE;
-            SHOW STATUS LIKE 'ONGOING_ANONYMOUS_TRANSACTION_COUNT';
             SET GLOBAL gtid_mode = OFF;
             """
-            statement = off_mode + statement
+            await execute_oneline_per_time(off_mode)
         await conn.execute_script(statement)
 
     async def set_enforce_gtid_on() -> None:
         statement = "SET GLOBAL enforce_gtid_consistency = ON;"
+        await conn.execute_script(statement)
         if not (await is_gtid_mode_on()):
-            statement += """
+            on_mode = """
             SET GLOBAL gtid_mode = OFF_PERMISSIVE;
             SET GLOBAL gtid_mode = ON_PERMISSIVE;
-            SHOW STATUS LIKE 'ONGOING_ANONYMOUS_TRANSACTION_COUNT';
             SET GLOBAL gtid_mode = ON;
             """
-        await conn.execute_script(statement)
+            await execute_oneline_per_time(on_mode)
 
     if run_coro(is_enforce_gtid()):
         run_coro(set_enforce_gtid_off())

--- a/conftest.py
+++ b/conftest.py
@@ -36,6 +36,7 @@ def _switch_gtid_mode() -> Callable[[], None] | None:
             off_mode = """
             SET GLOBAL gtid_mode = ON_PERMISSIVE;
             SET GLOBAL gtid_mode = OFF_PERMISSIVE;
+            SHOW STATUS LIKE 'ONGOING_ANONYMOUS_TRANSACTION_COUNT';
             SET GLOBAL gtid_mode = OFF;
             """
             statement = off_mode + statement
@@ -47,6 +48,7 @@ def _switch_gtid_mode() -> Callable[[], None] | None:
             statement += """
             SET GLOBAL gtid_mode = OFF_PERMISSIVE;
             SET GLOBAL gtid_mode = ON_PERMISSIVE;
+            SHOW STATUS LIKE 'ONGOING_ANONYMOUS_TRANSACTION_COUNT';
             SET GLOBAL gtid_mode = ON;
             """
         await conn.execute_script(statement)

--- a/conftest.py
+++ b/conftest.py
@@ -10,7 +10,7 @@ from tortoise.contrib.test import finalizer, initializer
 
 
 @pytest.fixture(scope="session", autouse=True)
-def initialize_tests(request):
+def initialize_tests():
     # Reduce the default timeout for psycopg because the tests become very slow otherwise
     try:
         from tortoise.backends.psycopg import PsycopgClient
@@ -31,8 +31,8 @@ def initialize_tests(request):
         run_coro = _LOOP.run_until_complete
 
         def get_var_value(statement: str) -> str:
-            result = run_coro(conn.execute_query(statement))
-            return result[1][0]["Value"]
+            result = run_coro(conn.execute_query_dict(statement))
+            return result[0]["Value"]
 
         def is_enforce_gtid() -> bool:
             statement = "SHOW VARIABLES LIKE 'enforce_gtid_consistency';"
@@ -68,6 +68,9 @@ def initialize_tests(request):
             run_coro(set_enforce_gtid_off(mode_on))
             rollback_sets = functools.partial(set_enforce_gtid_on, mode_on)
 
-    request.addfinalizer(finalizer)
-    if rollback_sets is not None:
-        request.addfinalizer(rollback_sets)
+    try:
+        yield
+    finally:
+        if rollback_sets is not None:
+            rollback_sets()
+        finalizer()

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,8 @@
+from __future__ import annotations
+
+import functools
 import os
+from typing import Any, Callable
 
 import pytest
 
@@ -17,4 +21,53 @@ def initialize_tests(request):
 
     db_url = os.getenv("TORTOISE_TEST_DB", "sqlite://:memory:")
     initializer(["tests.testmodels"], db_url=db_url)
+    rollback_vars: Callable[[], Any] | None = None
+    if db_url.startswith("mysql") and "storage_engine=MYISAM" in db_url:
+        # Fixes "tortoise.exceptions.OperationalError: (1785, 'Statement violates GTID consistency: ...')" for `make test_mysql_myisam`
+        from tortoise.contrib.test import _CONNECTIONS, _LOOP
+
+        conn = _CONNECTIONS.get("models")
+        assert conn is not None
+        run_async = _LOOP.run_until_complete
+
+        def get_var_value(statement: str) -> str:
+            result = run_async(conn.execute_query(statement))
+            return result[1][0]["Value"]
+
+        def is_enforce_gtid() -> bool:
+            statement = "SHOW VARIABLES LIKE 'enforce_gtid_consistency';"
+            return get_var_value(statement) == "ON"
+
+        def is_gtid_mode_on() -> bool:
+            statement = "SHOW VARIABLES LIKE 'gtid_mode';"
+            return get_var_value(statement) == "ON"
+
+        async def set_enforce_gtid_off(switch_mode: bool) -> None:
+            statement = "SET GLOBAL enforce_gtid_consistency = OFF;"
+            if switch_mode:
+                off_mode = """
+                SET GLOBAL gtid_mode = ON_PERMISSIVE;
+                SET GLOBAL gtid_mode = OFF_PERMISSIVE;
+                SET GLOBAL gtid_mode = OFF;
+                """
+                statement = off_mode + statement
+            await conn.execute_script(statement)
+
+        async def set_enforce_gtid_on(switch_mode: bool) -> None:
+            statement = "SET GLOBAL enforce_gtid_consistency = ON;"
+            if switch_mode:
+                statement += """
+                SET GLOBAL gtid_mode = OFF_PERMISSIVE;
+                SET GLOBAL gtid_mode = ON_PERMISSIVE;
+                SET GLOBAL gtid_mode = ON;
+                """
+            await conn.execute_script(statement)
+
+        if is_enforce_gtid():
+            mode_on = is_gtid_mode_on()
+            run_async(set_enforce_gtid_off(mode_on))
+            rollback_vars = functools.partial(run_async, set_enforce_gtid_on(mode_on))
+
     request.addfinalizer(finalizer)
+    if rollback_vars is not None:
+        request.addfinalizer(rollback_vars)

--- a/conftest.py
+++ b/conftest.py
@@ -1,71 +1,12 @@
-from __future__ import annotations
-
-import contextlib
-import functools
 import os
-from typing import Callable
 
 import pytest
 
 from tortoise.contrib.test import finalizer, initializer
 
 
-def _switch_gtid_mode() -> Callable[[], None] | None:
-    # SET gtid_mode to be OFF before testings
-    # And SET it ON after test before finalizer
-    from tortoise.contrib.test import _CONNECTIONS, _LOOP
-    from tortoise.exceptions import OperationalError
-
-    conn = _CONNECTIONS.get("models")
-    assert conn is not None
-    run_coro = _LOOP.run_until_complete
-
-    async def get_var_value(statement: str) -> str:
-        result = await conn.execute_query_dict(statement)
-        return result[0]["Value"]
-
-    async def is_enforce_gtid() -> bool:
-        statement = "SHOW VARIABLES LIKE 'enforce_gtid_consistency';"
-        return (await get_var_value(statement)).upper() == "ON"
-
-    async def get_gtid_mode_status() -> str:
-        statement = "SHOW VARIABLES LIKE 'gtid_mode';"
-        return await get_var_value(statement)
-
-    async def set_enforce_gtid_off(mode_on: bool, gtid_mode: str) -> None:
-        statement = "SET GLOBAL enforce_gtid_consistency = OFF;"
-        if mode_on:
-            if gtid_mode == "ON":
-                await conn.execute_script("SET GLOBAL gtid_mode = ON_PERMISSIVE;")
-            await conn.execute_script("SET GLOBAL gtid_mode = OFF_PERMISSIVE;")
-        await conn.execute_script(statement)
-
-    async def set_enforce_gtid_on(mode_on: bool, origin_gtid_mode: str) -> None:
-        statement = "SET GLOBAL enforce_gtid_consistency = ON;"
-        await conn.execute_script(statement)
-        if mode_on:
-            current_status = (await get_gtid_mode_status()).upper()
-            if current_status == origin_gtid_mode.upper():
-                return
-            with contextlib.suppress(OperationalError):
-                if current_status == "OFF":
-                    await conn.execute_script("SET GLOBAL gtid_mode = OFF_PERMISSIVE;")
-                await conn.execute_script("SET GLOBAL gtid_mode = ON_PERMISSIVE;")
-                if origin_gtid_mode.upper() == "ON":
-                    await conn.execute_script("SET GLOBAL gtid_mode = ON;")
-
-    if run_coro(is_enforce_gtid()):
-        origin_gtid_mode = run_coro(get_gtid_mode_status())
-        gtid_mode = origin_gtid_mode.upper()
-        mode_on = gtid_mode.startswith("ON")
-        run_coro(set_enforce_gtid_off(mode_on, gtid_mode))
-        if mode_on and not os.getenv("TORTOISE_GTID_KEEP_OFF"):
-            return functools.partial(run_coro, set_enforce_gtid_on(mode_on, origin_gtid_mode))
-    return None
-
-
 @pytest.fixture(scope="session", autouse=True)
-def initialize_tests():
+def initialize_tests(request):
     # Reduce the default timeout for psycopg because the tests become very slow otherwise
     try:
         from tortoise.backends.psycopg import PsycopgClient
@@ -76,13 +17,4 @@ def initialize_tests():
 
     db_url = os.getenv("TORTOISE_TEST_DB", "sqlite://:memory:")
     initializer(["tests.testmodels"], db_url=db_url)
-    rollback_sets: Callable[[], None] | None = None
-    if db_url.startswith("mysql") and "storage_engine=MYISAM" in db_url:
-        # Fixes "tortoise.exceptions.OperationalError: (1785, 'Statement violates GTID consistency: ...')" for `make test_mysql_myisam`
-        rollback_sets = _switch_gtid_mode()
-    try:
-        yield
-    finally:
-        if rollback_sets is not None:
-            rollback_sets()
-        finalizer()
+    request.addfinalizer(finalizer)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The `mysql:latest` Docker image now points to MySQL 9 (previously MySQL 8), with GTID mode enabled by default. 

This breaks our CI tests for mysql that use the MyISAM storage engine.

https://github.com/tortoise/tortoise-orm/actions/runs/19282005009/job/55134921663

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Turn off gtid_mode when runing `make test_mysql_myisam` and turn it back after this test 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
make ci

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

