### PR TITLE
fix: sqlite decimal filter error with `__gt`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Added
 ^^^^^
 - Add `create()` method to reverse ForeignKey relations, enabling `parent.children.create()` syntax
 
+Fixed
+^^^^^
+- Fix sqlite decimal filter error with `__gt` (#2020)
+
 0.25
 ====
 

--- a/tests/fields/test_decimal.py
+++ b/tests/fields/test_decimal.py
@@ -62,6 +62,10 @@ class TestDecimalFields(test.TestCase):
             .first()
         )
         self.assertEqual(obj, obj0)
+        objs = await testmodels.DecimalFields.filter(decimal_nodec__gt=2).all()
+        self.assertIn(obj, objs)
+        objs = await testmodels.DecimalFields.filter(decimal_nodec__lt=100).all()
+        self.assertIn(obj, objs)
 
     async def test_f_expression_update(self):
         obj0 = await testmodels.DecimalFields.create(decimal=Decimal("1.23456"), decimal_nodec=18.7)

--- a/tortoise/expressions.py
+++ b/tortoise/expressions.py
@@ -387,6 +387,7 @@ class Q:
         else:
             filter_info = model._meta.get_filter(key)
 
+        field_object = None
         if "table" in filter_info:
             # join the table
             join = (
@@ -405,7 +406,12 @@ class Q:
                 else field_object.to_db_value(value, model)
             )
         op = filter_info["operator"]
-        criterion = op(table[filter_info.get("source_field", filter_info["field"])], value)
+        term: Term = table[filter_info.get("source_field", filter_info["field"])]
+        if func := field_object and field_object.get_for_dialect(
+            model._meta.db.capabilities.dialect, "function_cast"
+        ):
+            term = func(field_object, term)
+        criterion = op(term, value)
         return criterion, join
 
     def _resolve_regular_kwarg(

--- a/tortoise/expressions.py
+++ b/tortoise/expressions.py
@@ -407,10 +407,12 @@ class Q:
             )
         op = filter_info["operator"]
         term: Term = table[filter_info.get("source_field", filter_info["field"])]
-        if func := field_object and field_object.get_for_dialect(
-            model._meta.db.capabilities.dialect, "function_cast"
-        ):
-            term = func(field_object, term)
+        if field_object is not None:
+            func = field_object.get_for_dialect(
+                model._meta.db.capabilities.dialect, "function_cast"
+            )
+            if func is not None:
+                term = func(field_object, term)
         criterion = op(term, value)
         return criterion, join
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes #2017 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<img width="1830" height="1770" alt="image" src="https://github.com/user-attachments/assets/ed45dcce-12a2-441d-a085-41d93afc6149" />

`function_cast` of DecimalField for sqlite does not used when querying. BUG fixed when this function  was called as expected.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
make ci

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

