### PR TITLE
Fix exception when creating aiosqlite connections on aiosqlite==0.22.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Changelog
 -------------------
 Fixed
 ^^^^^
-- Fix exception when creating aiosqlite connections on aiosqlite==1.22.0 (#2035)
+- Fix exception when creating aiosqlite connections on aiosqlite==0.22.0 (#2035)
 
 0.25
 ====

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,9 @@ Changelog
 
 0.26.0 (unreleased)
 -------------------
+Fixed
+^^^^^
+- Fix exception when creating aiosqlite connections on aiosqlite==1.22.0 (#2035)
 
 0.25
 ====

--- a/tortoise/backends/sqlite/client.py
+++ b/tortoise/backends/sqlite/client.py
@@ -78,9 +78,7 @@ class SqliteClient(BaseDBAsyncClient):
 
     async def create_connection(self, with_db: bool) -> None:
         if not self._connection:  # pragma: no branch
-            self._connection = aiosqlite.connect(self.filename, isolation_level=None)
-            self._connection.start()
-            await self._connection._connect()
+            self._connection = await aiosqlite.connect(self.filename, isolation_level=None)
             self._connection._conn.row_factory = sqlite3.Row
             for pragma, val in self.pragmas.items():
                 cursor = await self._connection.execute(f"PRAGMA {pragma}={val}")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
After recent changes in aiosqlite 0.22.0 (https://github.com/omnilib/aiosqlite/commit/1cd60adcab12347577150a6fa6c7d92b7b86d989), calling `self._connection.start()` results in `'Connection' object has no attribute 'start'` exception. Creating connection in this way seems to be a misuse of its API. To fix it, we create connection with `await aiosqlite.connect(...)` instead of directly calling the internal methods.

Closes #2037

```
  File "/home/donlon/test.py", line 74, in init_db
    await Tortoise.generate_schemas()
  File "/home/donlon/works/.venv/lib/python3.14/site-packages/tortoise/__init__.py", line 594, in generate_schemas
    await generate_schema_for_client(connection, safe)
  File "/home/donlon/works/.venv/lib/python3.14/site-packages/tortoise/utils.py", line 46, in generate_schema_for_client
    await generator.generate_from_string(schema)
  File "/home/donlon/works/.venv/lib/python3.14/site-packages/tortoise/backends/base/schema_generator.py", line 504, in generate_from_
string
    await self.client.execute_script(creation_string)
  File "/home/donlon/works/.venv/lib/python3.14/site-packages/tortoise/backends/sqlite/client.py", line 43, in translate_exceptions_
    return await func(self, query, *args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/donlon/works/.venv/lib/python3.14/site-packages/tortoise/backends/sqlite/client.py", line 167, in execute_script
    async with self.acquire_connection() as connection:
               ~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/donlon/works/.venv/lib/python3.14/site-packages/tortoise/backends/base/client.py", line 266, in __aenter__
    await self.ensure_connection()
  File "/home/donlon/works/.venv/lib/python3.14/site-packages/tortoise/backends/base/client.py", line 261, in ensure_connection
    await self.client.create_connection(with_db=True)
  File "/home/donlon/works/.venv/lib/python3.14/site-packages/tortoise/backends/sqlite/client.py", line 82, in create_connection
    self._connection.start()
    ^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Connection' object has no attribute 'start'
```



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

