### PR TITLE
Fix AttributeError when using Nuitka-compiled models

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,9 @@ Changelog
 
 0.26.0 (unreleased)
 -------------------
+Fixed
+^^^^^
+- Fix ``AttributeError`` when using ``tortoise-orm`` with Nuitka-compiled Python code (#2053)
 
 0.25
 ====

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -66,6 +66,7 @@ Contributors
 * Frederic Aoustin ``@fraoustin``
 * Ludwig Hähne ``@pankrat``
 * Christian Tanul ``@scriptogre``
+* Qian Chen ``@shkey``
 
 Special Thanks
 ==============

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -151,7 +151,7 @@ def _get_comments(cls: type[Model]) -> dict[str, str]:
     """
     try:
         source = inspect.getsource(cls)
-    except (TypeError, OSError):  # pragma: nocoverage
+    except (AttributeError, TypeError, OSError):  # pragma: nocoverage
         return {}
     comments = {}
 


### PR DESCRIPTION
# Fix AttributeError when using Nuitka-compiled models

## Description

This PR fixes an `AttributeError` that occurs when using tortoise-orm with Nuitka-compiled Python code. The issue happens during model initialization when the `_get_comments` function attempts to retrieve source code from compiled modules.

**The Problem:**
When code is compiled with Nuitka, the original Python source files are not available at runtime. The `_get_comments` function calls `inspect.getsource(cls)`, which internally calls `inspect.getsourcefile()`. For Nuitka-compiled modules, this returns `None` instead of a file path. Subsequently, when `inspect.findsource()` tries to call `filename.endswith()` on this `None` value, it raises an `AttributeError`.

**The Solution:**
Add `AttributeError` to the exception handling in the `_get_comments` function (line 154 of `tortoise/models.py`), alongside the existing `TypeError` and `OSError` exceptions. This allows the function to gracefully return an empty dictionary when source code cannot be retrieved from compiled modules.

**Code Changes:**

Before:
```python
except (TypeError, OSError):  # pragma: nocoverage
```

After:
```python
except (AttributeError, TypeError, OSError):  # pragma: nocoverage
```

**Error Stack Trace:**
```
Process granian-worker:
Traceback (most recent call last):
  File "/opt/pyenv/versions/3.11.8/lib/python3.11/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/opt/pyenv/versions/3.11.8/lib/python3.11/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/var/app/enabled/.venv/lib/python3.11/site-packages/granian/server/mp.py", line 73, in wrapped
    callback = callback_loader()
               ^^^^^^^^^^^^^^^^^
  File "/var/app/enabled/.venv/lib/python3.11/site-packages/granian/_internal.py", line 65, in load_target
    module = load_module(path)
             ^^^^^^^^^^^^^^^^^
  File "/var/app/enabled/.venv/lib/python3.11/site-packages/granian/_internal.py", line 47, in load_module
    __import__(module_name)
......
  File "/var/app/enabled/.venv/lib/python3.11/site-packages/tortoise/models.py", line 516, in __new__
    for fname, comment in _get_comments(new_class).items():  # type: ignore
                          ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/app/enabled/.venv/lib/python3.11/site-packages/tortoise/models.py", line 153, in _get_comments
    source = inspect.getsource(cls)
             ^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pyenv/versions/3.11.8/lib/python3.11/inspect.py", line 1262, in getsource
    lines, lnum = getsourcelines(object)
                  ^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pyenv/versions/3.11.8/lib/python3.11/inspect.py", line 1244, in getsourcelines
    lines, lnum = findsource(object)
                  ^^^^^^^^^^^^^^^^^^
  File "/opt/pyenv/versions/3.11.8/lib/python3.11/inspect.py", line 1063, in findsource
    file = getsourcefile(object)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pyenv/versions/3.11.8/lib/python3.11/inspect.py", line 943, in getsourcefile
    if any(filename.endswith(s) for s in all_bytecode_suffixes):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pyenv/versions/3.11.8/lib/python3.11/inspect.py", line 943, in <genexpr>
    if any(filename.endswith(s) for s in all_bytecode_suffixes):
           ^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'endswith'
```

## Motivation and Context

This change is required to make tortoise-orm compatible with Nuitka-compiled Python applications. Currently, any application that uses tortoise-orm and is compiled with Nuitka will crash immediately during startup with an `AttributeError`.

**Why this happens:**
1. `_get_comments()` calls `inspect.getsource(cls)`
2. `inspect.getsource()` → `inspect.getsourcelines()` → `inspect.findsource()`
3. `inspect.getsourcefile()` returns `None` for Nuitka-compiled modules (no source file available)
4. `inspect.findsource()` tries to call `filename.endswith()` on the `None` value, causing `AttributeError`

**Impact of this fix:**
- **Compatibility**: Maintains full backward compatibility with existing code
- **Functionality**: Comment extraction still works for regular Python files; returns empty dict for compiled modules
- **No side effects**: The `_get_comments` function is only used for extracting field comments, which are optional metadata
- **Enables**: tortoise-orm can now be used in production applications that require Nuitka compilation for performance or distribution purposes

## How Has This Been Tested?

**Testing Environment:**
- Python 3.11.8
- Nuitka-compiled application
- tortoise-orm with granian ASGI server
- Production-like multiprocessing worker setup

**Test Scenarios:**
1. **Nuitka-compiled application with tortoise-orm**
   - Compiled the application using Nuitka
   - Started the application with granian workers
   - Result: Application now starts successfully without `AttributeError`
   - Model initialization completes normally
   - Field comments are not extracted from compiled code (expected behavior)

2. **Regular Python environment (regression testing)**
   - Verified that comment extraction still works correctly for non-compiled code
   - All existing functionality remains intact

3. **Model operations**
   - Tested model creation, queries, and relationships
   - All ORM operations work correctly after the fix
   - No impact on database operations or model behavior

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

**Notes on unchecked items:**
- Documentation: This is an internal fix that doesn't change the API or user-facing behavior
- Changelog: Will be added if requested by maintainers
- Tests: The fix handles a runtime environment (Nuitka compilation) that's difficult to test in the standard test suite. The exception handling pattern matches existing code style in the same function.
