### PR TITLE
Fix annotations being selected in ValuesListQuery despite not specified in `.values_list` fields list

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Fixed
 ^^^^^
 - Fix ``AttributeError`` when using ``tortoise-orm`` with Nuitka-compiled Python code (#2053)
 - Fix 'Self' in python standard library typing.py, but tortoise/model.py required it in 'typing_extensions' (#2051)
+- Fix annotations being selected in ValuesListQuery despite not specified in `.values_list` fields list (#2059)
 
 Changed
 ^^^^^

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -24,7 +24,6 @@ from tortoise.exceptions import (
 from tortoise.expressions import F, RawSQL, Subquery
 from tortoise.functions import Avg, Length
 
-
 # TODO: Test the many exceptions in QuerySet
 # TODO: .filter(intnum_null=None) does not work as expected
 
@@ -861,8 +860,7 @@ class TestQueryset(test.TestCase):
         reporter3 = await Reporter.create(name="33333")
 
         subquery = (
-            Reporter
-            .annotate(name_length=Length("name"))
+            Reporter.annotate(name_length=Length("name"))
             .filter(name_length__gt=3)
             .order_by("id")
             .values_list("id", flat=True)

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -862,19 +862,16 @@ class TestQueryset(test.TestCase):
         await Book.create(name="2", author=author2, rating=3)
         await Book.create(name="3", author=author3, rating=5)
 
-        subquery = (
-            Author.annotate(rating=Avg("books__rating"))
-            .filter(rating__gte=3)
-            .order_by("id")
-            .values_list("id", flat=True)
-        )
+        subquery = Author.annotate(rating=Avg("books__rating")).filter(rating__gte=3)
 
-        subquery_ret = await subquery
+        subquery_ret = await subquery.order_by("id").values_list("id", flat=True)
         self.assertEqual(len(subquery_ret), 2)
         self.assertEqual(subquery_ret[0], author2.pk)
         self.assertEqual(subquery_ret[1], author3.pk)
 
-        ret = await Author.filter(id__in=Subquery(subquery)).order_by("id")
+        ret = await Author.filter(id__in=Subquery(subquery.values_list("id", flat=True))).order_by(
+            "id"
+        )
         self.assertEqual(ret[0], author2)
         self.assertEqual(ret[1], author3)
 

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -22,7 +22,8 @@ from tortoise.exceptions import (
     ParamsError,
 )
 from tortoise.expressions import F, RawSQL, Subquery
-from tortoise.functions import Avg
+from tortoise.functions import Avg, Length
+
 
 # TODO: Test the many exceptions in QuerySet
 # TODO: .filter(intnum_null=None) does not work as expected
@@ -853,6 +854,28 @@ class TestQueryset(test.TestCase):
         ret = await Author.annotate(rating=Avg(F("books__rating") * 2 - F("books__rating")))
         self.assertEqual(len(ret), 1)
         self.assertEqual(ret[0].rating, 3.0)
+
+    async def test_annotations_in_flat_values_list(self):
+        await Reporter.create(name="111")
+        reporter2 = await Reporter.create(name="2222")
+        reporter3 = await Reporter.create(name="33333")
+
+        subquery = (
+            Reporter
+            .annotate(name_length=Length("name"))
+            .filter(name_length__gt=3)
+            .order_by("id")
+            .values_list("id", flat=True)
+        )
+
+        subquery_ret = await subquery
+        self.assertEqual(len(subquery_ret), 2)
+        self.assertEqual(subquery_ret[0], reporter2.id)
+        self.assertEqual(subquery_ret[1], reporter3.id)
+
+        ret = await Reporter.filter(id__in=Subquery(subquery)).order_by("id")
+        self.assertEqual(ret[0], reporter2)
+        self.assertEqual(ret[1], reporter3)
 
 
 class TestNotExist(test.TestCase):

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -855,25 +855,28 @@ class TestQueryset(test.TestCase):
         self.assertEqual(ret[0].rating, 3.0)
 
     async def test_annotations_in_flat_values_list(self):
-        await Reporter.create(name="111")
-        reporter2 = await Reporter.create(name="2222")
-        reporter3 = await Reporter.create(name="33333")
+        author1 = await Author.create(name="1")
+        author2 = await Author.create(name="2")
+        author3 = await Author.create(name="3")
+        await Book.create(name="1", author=author1, rating=1)
+        await Book.create(name="2", author=author2, rating=3)
+        await Book.create(name="3", author=author3, rating=5)
 
         subquery = (
-            Reporter.annotate(name_length=Length("name"))
-            .filter(name_length__gt=3)
+            Author.annotate(rating=Avg("books__rating"))
+            .filter(rating__gte=3)
             .order_by("id")
             .values_list("id", flat=True)
         )
 
         subquery_ret = await subquery
         self.assertEqual(len(subquery_ret), 2)
-        self.assertEqual(subquery_ret[0], reporter2.id)
-        self.assertEqual(subquery_ret[1], reporter3.id)
+        self.assertEqual(subquery_ret[0], author2.pk)
+        self.assertEqual(subquery_ret[1], author3.pk)
 
-        ret = await Reporter.filter(id__in=Subquery(subquery)).order_by("id")
-        self.assertEqual(ret[0], reporter2)
-        self.assertEqual(ret[1], reporter3)
+        ret = await Author.filter(id__in=Subquery(subquery)).order_by("id")
+        self.assertEqual(ret[0], author2)
+        self.assertEqual(ret[1], author3)
 
 
 class TestNotExist(test.TestCase):

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -22,7 +22,7 @@ from tortoise.exceptions import (
     ParamsError,
 )
 from tortoise.expressions import F, RawSQL, Subquery
-from tortoise.functions import Avg, Length
+from tortoise.functions import Avg
 
 # TODO: Test the many exceptions in QuerySet
 # TODO: .filter(intnum_null=None) does not work as expected

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -118,9 +118,9 @@ class AwaitableQuery(Generic[MODEL]):
         if self._db is None:
             self._db = self._choose_db(for_write)  # type: ignore
 
-    def resolve_filters(self) -> None:
+    def resolve_filters(self, fields_for_select: Collection[str] | None = None) -> None:
         """Builds the common filters for a QuerySet."""
-        has_aggregate = self._resolve_annotate()
+        has_aggregate = self._resolve_annotate(fields_for_select)
 
         modifier = QueryModifier()
         for node in self._q_objects:
@@ -256,7 +256,7 @@ class AwaitableQuery(Generic[MODEL]):
 
                 self.query = self.query.orderby(field, order=ordering[1])
 
-    def _resolve_annotate(self) -> bool:
+    def _resolve_annotate(self, fields_for_select: Collection[str] | None = None) -> bool:
         if not self._annotations:
             return False
 
@@ -277,7 +277,7 @@ class AwaitableQuery(Generic[MODEL]):
         for key, info in annotation_info.items():
             for join in info.joins:
                 self._join_table(join)
-            if key in self._annotations:
+            if key in self._annotations and (fields_for_select is None or key in fields_for_select):
                 self.query._select_other(info.term.as_(key))  # type:ignore[arg-type]
 
         return any(info.term.is_aggregate for info in annotation_info.values())
@@ -1618,6 +1618,7 @@ class ValuesListQuery(FieldSelectQuery, Generic[SINGLE]):
         "_group_bys",
         "_force_indexes",
         "_use_indexes",
+        "_fields_to_select_sql",
     )
 
     def __init__(
@@ -1659,6 +1660,10 @@ class ValuesListQuery(FieldSelectQuery, Generic[SINGLE]):
         self._group_bys = group_bys
         self._force_indexes = force_indexes
         self._use_indexes = use_indexes
+        self._fields_to_select_sql = {
+            *self._fields_for_select_list,
+            *(key for key, value in self.fields.items() if value in self._fields_for_select_list),
+        }
 
     def _make_query(self) -> None:
         self._joined_tables = []
@@ -1674,7 +1679,7 @@ class ValuesListQuery(FieldSelectQuery, Generic[SINGLE]):
             annotations=self._annotations,
             fields_for_select=self._fields_for_select_list,
         )
-        self.resolve_filters()
+        self.resolve_filters(self._fields_to_select_sql)
         if self._limit:
             self.query._limit = self.query._wrapper_cls(self._limit)
         if self._offset:


### PR DESCRIPTION
## Description
Fixes #2058 

## Motivation and Context

## How Has This Been Tested?
Added test case in test_queryset.py, ran `make test`.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

