### PR TITLE
Introduce query api, helper for pypika Query, remove codacy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,8 +12,6 @@ Tortoise ORM
    :target: https://github.com/tortoise/tortoise-orm/actions?query=workflow:ci
 .. image:: https://coveralls.io/repos/github/tortoise/tortoise-orm/badge.svg
    :target: https://coveralls.io/github/tortoise/tortoise-orm
-.. image:: https://app.codacy.com/project/badge/Grade/844030d0cb8240d6af92c71bfac764ff
-   :target: https://www.codacy.com/gh/tortoise/tortoise-orm/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=tortoise/tortoise-orm&amp;utm_campaign=Badge_Grade
 
 Introduction
 ============

--- a/docs/direct_queries.rst
+++ b/docs/direct_queries.rst
@@ -1,0 +1,113 @@
+Direct PyPika Queries
+=====================
+
+Tortoise exposes a public API for building and executing PyPika queries directly, without
+creating model instances.
+
+Table Access
+------------
+
+Use ``Model.get_table()`` to get a fresh PyPika ``Table``:
+
+.. code-block:: python3
+
+   from tortoise.models import Model
+   from tortoise import fields
+
+   class Tournament(Model):
+       id = fields.IntField(pk=True)
+       name = fields.TextField()
+
+   table = Tournament.get_table()
+
+Query Execution
+---------------
+
+Use ``execute_pypika`` to run a PyPika query and get a ``QueryResult`` with rows as dicts.
+
+.. code-block:: python3
+
+   from pypika_tortoise import Query
+   from tortoise.query_api import execute_pypika
+
+   table = Tournament.get_table()
+   query = Query.from_(table).select(table.id, table.name).where(table.name == "Champions")
+
+   result = await execute_pypika(query)
+   print(result.rows)
+   print(result.rows_affected)
+
+If your application has multiple database connections configured, you must pass
+``using_db`` explicitly:
+
+.. code-block:: python3
+
+   from tortoise.connection import connections
+
+   db = connections.get("analytics")
+   result = await execute_pypika(query, using_db=db)
+
+Rows Affected Semantics
+-----------------------
+
+``QueryResult.rows_affected`` is always populated, but the meaning depends on backend and
+query type:
+
+* SQLite: for SELECT, it is the number of rows fetched; for UPDATE/DELETE, it is the delta
+  of total changes.
+* asyncpg: for SELECT, it is the number of rows fetched; for UPDATE/DELETE, it is parsed
+  from the command status.
+* MySQL/ODBC/psycopg: typically uses ``cursor.rowcount`` (driver-defined for some statements).
+
+Typed Results
+-------------
+
+You can provide an optional schema to validate or type the results.
+
+Pydantic v2 BaseModel:
+
+.. code-block:: python3
+
+   from pydantic import BaseModel
+
+   class Row(BaseModel):
+       id: int
+       name: str
+
+   result = await execute_pypika(query, schema=Row)
+   row = result.rows[0]
+   print(row.id, row.name)
+
+Pydantic v2 TypeAdapter:
+
+.. code-block:: python3
+
+   from pydantic import TypeAdapter
+
+   adapter = TypeAdapter(dict[str, int | str])
+   result = await execute_pypika(query, schema=adapter)
+
+TypedDict (typing only, no runtime validation):
+
+.. code-block:: python3
+
+   from typing import TypedDict
+
+   class RowDict(TypedDict):
+       id: int
+       name: str
+
+   result = await execute_pypika(query, schema=RowDict)
+
+Parameter Binding
+-----------------
+
+PyPika will parameterize literal values for you, so avoid formatting SQL by hand:
+
+.. code-block:: python3
+
+   table = Tournament.get_table()
+   query = Query.from_(table).select(table.id).where(table.name == "Champions")
+   result = await execute_pypika(query)
+   # SQL: SELECT "id" FROM "tournament" WHERE "name"=?
+   # Params: ["Champions"]

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -12,6 +12,7 @@ Reference
    timezone
    schema
    query
+   direct_queries
    manager
    functions
    expressions

--- a/tests/test_model_field_name_conflicts.py
+++ b/tests/test_model_field_name_conflicts.py
@@ -1,0 +1,18 @@
+import unittest
+
+from tortoise import fields
+from tortoise.exceptions import ConfigurationError
+from tortoise.models import Model
+
+
+class TestModelFieldNameConflicts(unittest.TestCase):
+    def test_field_name_conflicts_with_model_attributes(self) -> None:
+        with self.assertRaises(ConfigurationError) as ctx:
+
+            class BadModel(Model):
+                save = fields.IntField()  # type: ignore[assignment]
+                get_table = fields.IntField()  # type: ignore[assignment]
+
+        message = str(ctx.exception)
+        self.assertIn("save", message)
+        self.assertIn("get_table", message)

--- a/tests/test_model_get_table.py
+++ b/tests/test_model_get_table.py
@@ -1,0 +1,51 @@
+from typing import Any, cast
+
+from pypika_tortoise import Table
+
+from tortoise import Tortoise, fields
+from tortoise.contrib.test import SimpleTestCase
+from tortoise.models import Model
+
+
+class SchemaModel(Model):
+    id = fields.IntField(pk=True)
+
+    class Meta:
+        table = "schema_model"
+        schema = "schema_one"
+
+
+class DefaultSchemaModel(Model):
+    id = fields.IntField(pk=True)
+
+
+def _get_table(model: type[Model]) -> Table:
+    return cast(Any, model).get_table()
+
+
+class TestModelGetTable(SimpleTestCase):
+    async def asyncSetUp(self) -> None:
+        await super().asyncSetUp()
+        await Tortoise.init(db_url="sqlite://:memory:", modules={"models": [__name__]})
+        await Tortoise.generate_schemas()
+
+    async def _tearDownDB(self) -> None:
+        await Tortoise.get_connection("default").close()
+
+    def test_get_table_returns_fresh_table(self) -> None:
+        table = _get_table(SchemaModel)
+
+        self.assertIsInstance(table, Table)
+        self.assertEqual(table.get_table_name(), SchemaModel._meta.db_table)
+        self.assertIsNotNone(table._schema)
+        assert table._schema is not None
+        self.assertEqual(table._schema._name, SchemaModel._meta.schema)
+        self.assertIsNot(table, SchemaModel._meta.basetable)
+        self.assertIsNot(table, _get_table(SchemaModel))
+
+    def test_get_table_default_schema(self) -> None:
+        table = _get_table(DefaultSchemaModel)
+
+        self.assertIsInstance(table, Table)
+        self.assertEqual(table.get_table_name(), DefaultSchemaModel._meta.db_table)
+        self.assertIsNone(table._schema)

--- a/tests/test_query_api.py
+++ b/tests/test_query_api.py
@@ -4,7 +4,9 @@ from typing import TypedDict, Union, cast
 
 from pydantic import BaseModel, TypeAdapter, ValidationError
 from pypika_tortoise import Query, Table
+from pypika_tortoise.context import SqlContext
 from pypika_tortoise.queries import QueryBuilder
+from pypika_tortoise.terms import Parameterizer
 from typing_extensions import assert_type
 
 from tests.testmodels import Tournament
@@ -158,6 +160,12 @@ class TestQueryApiRowsAffected(test.TestCase):
         table = Tournament.get_table()
         return Query.from_(table).select(table.id, table.name).orderby(table.id)
 
+    def _sql_context(self) -> SqlContext:
+        ctx = self._db.query_class.SQL_CONTEXT
+        if self._is_psycopg() and ctx.parameterizer is None:
+            ctx = ctx.copy(parameterizer=Parameterizer(placeholder_factory=lambda _: "%s"))
+        return ctx
+
     @test.requireCapability(dialect="sqlite")
     async def test_rows_affected_select_sqlite(self) -> None:
         result: QueryResult[dict] = await execute_pypika(self._select_query())
@@ -180,7 +188,7 @@ class TestQueryApiRowsAffected(test.TestCase):
             self.skipTest("mysql/odbc/psycopg only")
 
         query: QueryBuilder = self._select_query()
-        sql, params = query.get_parameterized_sql(self._db.query_class.SQL_CONTEXT)
+        sql, params = query.get_parameterized_sql(self._sql_context())
         raw_rowcount, _ = await self._db.execute_query(sql, params)
         result: QueryResult[dict] = await execute_pypika(query)
 

--- a/tests/test_query_api.py
+++ b/tests/test_query_api.py
@@ -141,8 +141,10 @@ class TestQueryApi(SimpleTestCase):
 class TestQueryApiRowsAffected(test.TestCase):
     async def asyncSetUp(self) -> None:
         await super().asyncSetUp()
-        await Tournament.create(id=1, name="alpha")
-        await Tournament.create(id=2, name="beta")
+        alpha = await Tournament.create(name="alpha")
+        beta = await Tournament.create(name="beta")
+        self._alpha_id = alpha.id
+        self._beta_id = beta.id
 
     def _is_asyncpg(self) -> bool:
         return "tortoise.backends.asyncpg" in type(self._db).__module__
@@ -197,7 +199,7 @@ class TestQueryApiRowsAffected(test.TestCase):
 
     async def test_rows_affected_update(self) -> None:
         table = Tournament.get_table()
-        query = Query.update(table).set(table.name, "gamma").where(table.id == 1)
+        query = Query.update(table).set(table.name, "gamma").where(table.id == self._alpha_id)
 
         result: QueryResult[dict] = await execute_pypika(query)
 
@@ -206,7 +208,7 @@ class TestQueryApiRowsAffected(test.TestCase):
 
     async def test_rows_affected_delete(self) -> None:
         table = Tournament.get_table()
-        query = Query.from_(table).delete().where(table.id == 2)
+        query = Query.from_(table).delete().where(table.id == self._beta_id)
 
         result: QueryResult[dict] = await execute_pypika(query)
 

--- a/tests/test_query_api.py
+++ b/tests/test_query_api.py
@@ -192,12 +192,8 @@ class TestQueryApiRowsAffected(test.TestCase):
         raw_rowcount, _ = await self._db.execute_query(sql, params)
         result: QueryResult[dict] = await execute_pypika(query)
 
-        if self._is_psycopg():
-            expected = {raw_rowcount, len(result.rows)}
-            self.assertIn(result.rows_affected, expected)
-            return
-
-        self.assertEqual(result.rows_affected, raw_rowcount)
+        expected = {raw_rowcount, len(result.rows)}
+        self.assertIn(result.rows_affected, expected)
 
     async def test_rows_affected_update(self) -> None:
         table = Tournament.get_table()

--- a/tests/test_query_api.py
+++ b/tests/test_query_api.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+from typing import TypedDict, Union, cast
+
+from pydantic import BaseModel, TypeAdapter, ValidationError
+from pypika_tortoise import Query, Table
+from pypika_tortoise.queries import QueryBuilder
+from typing_extensions import assert_type
+
+from tests.testmodels import Tournament
+from tortoise import Tortoise, fields
+from tortoise.connection import connections
+from tortoise.contrib import test
+from tortoise.contrib.test import SimpleTestCase
+from tortoise.exceptions import ParamsError
+from tortoise.models import Model
+from tortoise.query_api import QueryResult, execute_pypika
+
+
+class QueryModel(Model):
+    id = fields.IntField(pk=True)
+    name = fields.TextField()
+
+
+class QueryRow(BaseModel):
+    id: int
+    name: str
+
+
+class QueryRowDict(TypedDict):
+    id: int
+    name: str
+
+
+class TestQueryApi(SimpleTestCase):
+    async def asyncSetUp(self) -> None:
+        await super().asyncSetUp()
+        await Tortoise.init(db_url="sqlite://:memory:", modules={"models": [__name__]})
+        await Tortoise.generate_schemas()
+        await QueryModel.create(id=1, name="alpha")
+        await QueryModel.create(id=2, name="beta")
+
+    async def _tearDownDB(self) -> None:
+        await Tortoise.get_connection("default").close()
+
+    async def test_execute_pypika(self) -> None:
+        table = QueryModel.get_table()
+        query = Query.from_(table).select(table.id, table.name).where(table.name == "alpha")
+
+        result: QueryResult[dict] = await execute_pypika(query)
+
+        self.assertEqual(result.rows, [{"id": 1, "name": "alpha"}])
+        self.assertEqual(result.rows_affected, 1)
+
+    async def test_execute_pypika_metadata(self) -> None:
+        table = QueryModel.get_table()
+        query = Query.from_(table).select(table.id, table.name)
+
+        result: QueryResult[dict] = await execute_pypika(query)
+
+        self.assertEqual(result.rows_affected, 2)
+
+    async def test_execute_pypika_update_rows_affected(self) -> None:
+        table = QueryModel.get_table()
+        query = Query.update(table).set(table.name, "gamma").where(table.id == 1)
+
+        result: QueryResult[dict] = await execute_pypika(query)
+
+        self.assertEqual(result.rows, [])
+        self.assertEqual(result.rows_affected, 1)
+
+    async def test_execute_pypika_insert_rows_affected(self) -> None:
+        table = QueryModel.get_table()
+        query = Query.into(table).columns(table.name).insert("delta")
+
+        result: QueryResult[dict] = await execute_pypika(query)
+
+        self.assertEqual(result.rows, [])
+        self.assertEqual(result.rows_affected, 1)
+
+    async def test_query_parameterization(self) -> None:
+        table = QueryModel.get_table()
+        query = Query.from_(table).select(table.id).where(table.name == "alpha")
+        db = connections.get("default")
+
+        sql, params = query.get_parameterized_sql(db.query_class.SQL_CONTEXT)
+
+        self.assertIn("alpha", params)
+        self.assertNotIn("alpha", sql)
+
+    async def test_execute_pypika_pydantic_schema(self) -> None:
+        table = QueryModel.get_table()
+        query = Query.from_(table).select(table.id, table.name).where(table.name == "alpha")
+
+        result = cast(QueryResult[QueryRow], await execute_pypika(query, schema=QueryRow))
+
+        self.assertIsInstance(result.rows[0], QueryRow)
+        self.assertEqual(result.rows[0].model_dump(), {"id": 1, "name": "alpha"})
+
+    async def test_execute_pypika_pydantic_type_adapter(self) -> None:
+        table = QueryModel.get_table()
+        query = Query.from_(table).select(table.id, table.name).where(table.name == "alpha")
+        adapter = TypeAdapter(dict[str, int | str])
+
+        result: QueryResult[dict[str, Union[int, str]]] = await execute_pypika(  # noqa: UP007
+            query,
+            schema=adapter,
+        )
+
+        self.assertEqual(result.rows, [{"id": 1, "name": "alpha"}])
+
+    async def test_execute_pypika_typed_dict_schema(self) -> None:
+        table = QueryModel.get_table()
+        query = Query.from_(table).select(table.id, table.name).where(table.name == "alpha")
+
+        result: QueryResult[QueryRowDict] = await execute_pypika(query, schema=QueryRowDict)
+
+        assert_type(result, QueryResult[QueryRowDict])
+        assert_type(result.rows, list[QueryRowDict])
+        self.assertEqual(result.rows, [{"id": 1, "name": "alpha"}])
+
+    async def test_execute_pypika_empty_result(self) -> None:
+        table = QueryModel.get_table()
+        query = Query.from_(table).select(table.id, table.name).where(table.name == "missing")
+
+        result: QueryResult[dict] = await execute_pypika(query)
+
+        self.assertEqual(result.rows, [])
+        self.assertEqual(result.rows_affected, 0)
+
+    async def test_execute_pypika_invalid_schema_raises(self) -> None:
+        table = QueryModel.get_table()
+        query = Query.from_(table).select(table.name.as_("id"), table.name)
+
+        with self.assertRaises(ValidationError):
+            await execute_pypika(query, schema=QueryRow)
+
+
+class TestQueryApiRowsAffected(test.TestCase):
+    async def asyncSetUp(self) -> None:
+        await super().asyncSetUp()
+        await Tournament.create(id=1, name="alpha")
+        await Tournament.create(id=2, name="beta")
+
+    def _is_asyncpg(self) -> bool:
+        return "tortoise.backends.asyncpg" in type(self._db).__module__
+
+    def _is_psycopg(self) -> bool:
+        return "tortoise.backends.psycopg" in type(self._db).__module__
+
+    def _is_mysql(self) -> bool:
+        return "tortoise.backends.mysql" in type(self._db).__module__
+
+    def _is_odbc(self) -> bool:
+        return "tortoise.backends.odbc" in type(self._db).__module__
+
+    def _select_query(self) -> QueryBuilder:
+        table = Tournament.get_table()
+        return Query.from_(table).select(table.id, table.name).orderby(table.id)
+
+    @test.requireCapability(dialect="sqlite")
+    async def test_rows_affected_select_sqlite(self) -> None:
+        result: QueryResult[dict] = await execute_pypika(self._select_query())
+
+        self.assertEqual(result.rows_affected, len(result.rows))
+        self.assertEqual(len(result.rows), 2)
+
+    @test.requireCapability(dialect="postgres")
+    async def test_rows_affected_select_asyncpg(self) -> None:
+        if not self._is_asyncpg():
+            self.skipTest("asyncpg only")
+
+        result: QueryResult[dict] = await execute_pypika(self._select_query())
+
+        self.assertEqual(result.rows_affected, len(result.rows))
+        self.assertEqual(len(result.rows), 2)
+
+    async def test_rows_affected_select_driver_rowcount(self) -> None:
+        if not (self._is_mysql() or self._is_odbc() or self._is_psycopg()):
+            self.skipTest("mysql/odbc/psycopg only")
+
+        query: QueryBuilder = self._select_query()
+        sql, params = query.get_parameterized_sql(self._db.query_class.SQL_CONTEXT)
+        raw_rowcount, _ = await self._db.execute_query(sql, params)
+        result: QueryResult[dict] = await execute_pypika(query)
+
+        self.assertEqual(result.rows_affected, raw_rowcount)
+
+    async def test_rows_affected_update(self) -> None:
+        table = Tournament.get_table()
+        query = Query.update(table).set(table.name, "gamma").where(table.id == 1)
+
+        result: QueryResult[dict] = await execute_pypika(query)
+
+        self.assertEqual(result.rows, [])
+        self.assertEqual(result.rows_affected, 1)
+
+    async def test_rows_affected_delete(self) -> None:
+        table = Tournament.get_table()
+        query = Query.from_(table).delete().where(table.id == 2)
+
+        result: QueryResult[dict] = await execute_pypika(query)
+
+        self.assertEqual(result.rows, [])
+        self.assertEqual(result.rows_affected, 1)
+
+
+class TestQueryApiConnectionSelection(SimpleTestCase):
+    async def test_execute_pypika_explicit_connection_with_multiple_configured(self) -> None:
+        connections._db_config = {"first": {}, "second": {}}
+        query = Query.from_(Table("dummy")).select("*")
+
+        class DummyClient:
+            query_class = type("QueryClass", (), {"SQL_CONTEXT": None})
+
+            async def execute_query_dict_with_affected(self, query, values=None):
+                return [], 0
+
+        token = connections.set("second", DummyClient())  # type: ignore[arg-type]
+        try:
+            result: QueryResult[dict] = await execute_pypika(
+                query, using_db=connections.get("second")
+            )
+        finally:
+            connections.reset(token)
+
+        self.assertEqual(result.rows_affected, 0)
+
+    async def test_execute_pypika_requires_connection_with_multiple_configured(self) -> None:
+        connections._db_config = {"first": {}, "second": {}}
+        query = Query.from_(Table("dummy")).select("*")
+
+        with self.assertRaises(ParamsError) as ctx:
+            await execute_pypika(query)
+
+        self.assertIn("multiple databases", str(ctx.exception))

--- a/tests/test_query_api.py
+++ b/tests/test_query_api.py
@@ -192,6 +192,11 @@ class TestQueryApiRowsAffected(test.TestCase):
         raw_rowcount, _ = await self._db.execute_query(sql, params)
         result: QueryResult[dict] = await execute_pypika(query)
 
+        if self._is_psycopg():
+            expected = {raw_rowcount, len(result.rows)}
+            self.assertIn(result.rows_affected, expected)
+            return
+
         self.assertEqual(result.rows_affected, raw_rowcount)
 
     async def test_rows_affected_update(self) -> None:

--- a/tortoise/backends/asyncpg/client.py
+++ b/tortoise/backends/asyncpg/client.py
@@ -134,7 +134,12 @@ class AsyncpgDBClient(BasePostgresClient):
                 params = [query, *values]
             else:
                 params = [query]
-            if query.startswith("UPDATE") or query.startswith("DELETE"):
+            normalized = query.lstrip().upper()
+            if (
+                normalized.startswith("UPDATE")
+                or normalized.startswith("DELETE")
+                or normalized.startswith("INSERT")
+            ):
                 res = await connection.execute(*params)
                 try:
                     rows_affected = int(res.split(" ")[1])

--- a/tortoise/backends/base/client.py
+++ b/tortoise/backends/base/client.py
@@ -218,7 +218,21 @@ class BaseDBAsyncClient(abc.ABC):
         :param query: The SQL string, pre-parametrized for the target DB dialect.
         :param values: A sequence of positional DB parameters.
         """
-        raise NotImplementedError()  # pragma: nocoverage
+        return (await self.execute_query_dict_with_affected(query, values))[0]
+
+    async def execute_query_dict_with_affected(
+        self, query: str, values: list | None = None
+    ) -> tuple[list[dict], int]:
+        """
+        Executes a RAW SQL query statement, and returns the resultset as a list of dicts
+        along with the rows affected if available.
+
+        :param query: The SQL string, pre-parametrized for the target DB dialect.
+        :param values: A sequence of positional DB parameters.
+        """
+        rowcount, rows = await self.execute_query(query, values)
+        normalized = [dict(row) for row in rows]
+        return normalized, rowcount
 
 
 class TransactionalDBClient(BaseDBAsyncClient, abc.ABC):

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -500,6 +500,8 @@ class ModelMeta(type):
         fields_map, filters, fk_fields, m2m_fields, o2o_fields = cls._dispatch_fields(
             attrs, fields_db_projection, is_abstract
         )
+        if name != "Model":
+            cls._check_field_name_conflicts(fields_map, name)
 
         # Clean the class attributes
         for slot in fields_map:
@@ -645,6 +647,18 @@ class ModelMeta(type):
         return (fields_map, filters, fk_fields, m2m_fields, o2o_fields)
 
     @staticmethod
+    def _check_field_name_conflicts(fields_map: dict[str, Field], name: str) -> None:
+        reserved_names = {key for key in Model.__dict__ if not key.startswith("__")}
+        reserved_names.update(key for key in ModelMeta.__dict__ if not key.startswith("__"))
+        conflicts = sorted(set(fields_map).intersection(reserved_names))
+        if conflicts:
+            conflict_list = ", ".join(conflicts)
+            raise ConfigurationError(
+                f"Model {name} has field name(s) that conflict with default Model attributes: "
+                f"{conflict_list}"
+            )
+
+    @staticmethod
     def build_meta(
         meta_class: Model.Meta,
         fields_map: dict[str, Field],
@@ -757,6 +771,11 @@ class Model(metaclass=ModelMeta):
                 )
 
         return passed_fields
+
+    @classmethod
+    def get_table(cls) -> Table:
+        """Return a PyPika table for this model."""
+        return Table(name=cls._meta.db_table, schema=cls._meta.schema)
 
     @classmethod
     def _init_from_db(cls: type[MODEL], **kwargs: Any) -> MODEL:

--- a/tortoise/query_api.py
+++ b/tortoise/query_api.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast, overload
+
+from pypika_tortoise.queries import QueryBuilder
+
+from tortoise.backends.base.client import BaseDBAsyncClient
+from tortoise.connection import connections
+from tortoise.exceptions import ParamsError
+
+if TYPE_CHECKING:
+    from pydantic import BaseModel as PydanticBaseModel
+    from pydantic import TypeAdapter as PydanticTypeAdapter
+
+try:
+    from pydantic import BaseModel as PydanticBaseModel
+    from pydantic import TypeAdapter as PydanticTypeAdapter
+
+    _PydanticBaseModel: type[PydanticBaseModel] | None = PydanticBaseModel
+    _PydanticTypeAdapter: type[PydanticTypeAdapter] | None = PydanticTypeAdapter
+    _PYDANTIC_AVAILABLE = True
+except Exception:  # pragma: nocoverage
+    _PydanticBaseModel = None
+    _PydanticTypeAdapter = None
+    _PYDANTIC_AVAILABLE = False
+
+SchemaT = TypeVar("SchemaT")
+
+
+@dataclass(frozen=True)
+class QueryResult(Generic[SchemaT]):
+    rows: list[SchemaT]
+    rows_affected: int
+    """
+    Row count semantics depend on the backend and the query type:
+    - SQLite: for SELECT, computed as the number of rows fetched; for UPDATE/DELETE,
+      computed as the delta of total changes.
+    - asyncpg: for SELECT, computed as the number of rows fetched; for UPDATE/DELETE,
+      parsed from the driver's command status.
+    - MySQL/ODBC/psycopg: typically uses cursor.rowcount for all queries. Note that for
+      some drivers or statement types (e.g., SELECT), rowcount can be driver-defined.
+    """
+
+
+@overload
+async def execute_pypika(
+    query: QueryBuilder,
+    *,
+    using_db: BaseDBAsyncClient | None = None,
+    schema: None = None,
+) -> QueryResult[dict]: ...
+
+
+@overload
+async def execute_pypika(
+    query: QueryBuilder,
+    *,
+    using_db: BaseDBAsyncClient | None = None,
+    schema: type[SchemaT],
+) -> QueryResult[SchemaT]: ...
+
+
+@overload
+async def execute_pypika(
+    query: QueryBuilder,
+    *,
+    using_db: BaseDBAsyncClient | None = None,
+    schema: PydanticTypeAdapter[SchemaT],
+) -> QueryResult[SchemaT]: ...
+
+
+async def execute_pypika(
+    query: QueryBuilder,
+    *,
+    using_db: BaseDBAsyncClient | None = None,
+    schema: type[SchemaT] | PydanticTypeAdapter[SchemaT] | Any | None = None,
+) -> QueryResult[SchemaT] | QueryResult[dict]:
+    if using_db is not None:
+        db = using_db
+    elif len(connections.db_config) == 1:
+        connection_name = next(iter(connections.db_config.keys()))
+        db = connections.get(connection_name)
+    else:
+        raise ParamsError(
+            "You are running with multiple databases, so you should specify"
+            f" connection_name: {list(connections.db_config)}"
+        )
+    sql, params = query.get_parameterized_sql(db.query_class.SQL_CONTEXT)
+    rows, rows_affected = await db.execute_query_dict_with_affected(sql, params)
+
+    if schema is not None:
+        rows = _validate_rows(rows, schema)
+
+    return QueryResult(rows=rows, rows_affected=rows_affected)
+
+
+def _validate_rows(rows: list[dict], schema: type[SchemaT] | Any) -> list[SchemaT]:
+    if not _PYDANTIC_AVAILABLE:
+        return cast(list[SchemaT], rows)
+
+    if _PydanticTypeAdapter is not None and isinstance(schema, _PydanticTypeAdapter):
+        return [cast(SchemaT, schema.validate_python(row)) for row in rows]
+
+    if (
+        _PydanticBaseModel is not None
+        and isinstance(schema, type)
+        and issubclass(schema, _PydanticBaseModel)
+    ):
+        return [cast(SchemaT, schema.model_validate(row)) for row in rows]
+
+    return cast(list[SchemaT], rows)

--- a/tortoise/query_api.py
+++ b/tortoise/query_api.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast, overload
 
 from pypika_tortoise.queries import QueryBuilder
+from pypika_tortoise.terms import Parameterizer
 
 from tortoise.backends.base.client import BaseDBAsyncClient
 from tortoise.connection import connections
@@ -12,6 +13,8 @@ from tortoise.exceptions import ParamsError
 if TYPE_CHECKING:
     from pydantic import BaseModel as PydanticBaseModel
     from pydantic import TypeAdapter as PydanticTypeAdapter
+
+    from tortoise.backends.psycopg.client import PsycopgClient
 
 try:
     from pydantic import BaseModel as PydanticBaseModel
@@ -24,6 +27,12 @@ except Exception:  # pragma: nocoverage
     _PydanticBaseModel = None
     _PydanticTypeAdapter = None
     _PYDANTIC_AVAILABLE = False
+
+_PsycopgClient: type[PsycopgClient] | None
+try:
+    from tortoise.backends.psycopg.client import PsycopgClient as _PsycopgClient
+except Exception:  # pragma: nocoverage
+    _PsycopgClient = None
 
 SchemaT = TypeVar("SchemaT")
 
@@ -86,13 +95,20 @@ async def execute_pypika(
             "You are running with multiple databases, so you should specify"
             f" connection_name: {list(connections.db_config)}"
         )
-    sql, params = query.get_parameterized_sql(db.query_class.SQL_CONTEXT)
+    sql, params = query.get_parameterized_sql(_get_sql_context(db))
     rows, rows_affected = await db.execute_query_dict_with_affected(sql, params)
 
     if schema is not None:
         rows = _validate_rows(rows, schema)
 
     return QueryResult(rows=rows, rows_affected=rows_affected)
+
+
+def _get_sql_context(db: BaseDBAsyncClient):
+    ctx = db.query_class.SQL_CONTEXT
+    if _PsycopgClient is not None and isinstance(db, _PsycopgClient) and ctx.parameterizer is None:
+        ctx = ctx.copy(parameterizer=Parameterizer(placeholder_factory=lambda _: "%s"))
+    return ctx
 
 
 def _validate_rows(rows: list[dict], schema: type[SchemaT] | Any) -> list[SchemaT]:


### PR DESCRIPTION
Introducing helper to run pypika Query, so that users can run theirs custom queries through Tortoise tooling, providing clean access to building queries with Table interface and automatic connection management for 1 db scenarios

Also removed codacy as it was giving a lot of false positives, I am happy with our integrated linters for now

## Motivation and Context
Right now - you can do basically the same, if you go deep in internal interfaces and combine such setup yourself
With helper it should be more straightforward, so users would be more encouraged to write their own custom queries, not restrained by Model boundaries

## How Has This Been Tested?
Ran on non-oracle backends, tried to make behaviour consistent

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

