### PR TITLE
Make ptpython optional, better shell, fix migration bug

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,6 +41,8 @@ Changed
 - ``ConnectionHandler`` now uses instance-based ContextVar storage (each context has isolated connections)
 - ``Tortoise.apps`` and ``Tortoise._inited`` now use ``classproperty`` descriptor (no metaclass)
 - feat: foreignkey to model type (#2027)
+- **Shell command now uses optional dependencies**: Install with ``pip install tortoise-orm[ipython]`` (recommended) or ``pip install tortoise-orm[ptpython]`` to enable. IPython is preferred over ptpython. Both shells are supported.
+- **DatetimeField and TimeField behavior change**: Fields with ``auto_now=True`` no longer incorrectly set ``auto_now_add=True`` internally.
 
 Deprecated
 ^^^^^^^^^^

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -109,9 +109,32 @@ shell
 
 Start an interactive shell with Tortoise initialized.
 
+**Installation**
+
+The shell command requires either IPython or ptpython. Install your preferred shell:
+
+.. code-block:: shell
+
+    # Install IPython (recommended)
+    pip install tortoise-orm[ipython]
+
+    # Or install ptpython
+    pip install tortoise-orm[ptpython]
+
+IPython is preferred when both are available.
+
+**Usage**
+
 .. code-block:: shell
 
     tortoise shell
+
+**Supported Shells**
+
+- **IPython** (>=8.0.0) - Preferred, better async/await support
+- **ptpython** (>=3.0.0) - Alternative with good async support
+
+If neither shell is installed, the command will display an error with installation instructions.
 
 Target shorthand
 ================

--- a/examples/fastapi/config.py
+++ b/examples/fastapi/config.py
@@ -1,11 +1,23 @@
 import os
 from functools import partial
 
+from tortoise.config import AppConfig, DBUrlConfig, TortoiseConfig
 from tortoise.contrib.fastapi import RegisterTortoise
+
+# Single source of truth for Tortoise ORM configuration
+TORTOISE_ORM = TortoiseConfig(
+    connections={"default": DBUrlConfig(url=os.getenv("DB_URL", "sqlite://db.sqlite3"))},
+    apps={
+        "models": AppConfig(
+            models=["models"],
+            default_connection="default",
+            migrations="migrations",  # Explicit path since models.py is a file, not a package
+        )
+    },
+)
 
 register_orm = partial(
     RegisterTortoise,
-    db_url=os.getenv("DB_URL", "sqlite://db.sqlite3"),
-    modules={"models": ["models"]},
+    config=TORTOISE_ORM,
     generate_schemas=True,
 )

--- a/examples/fastapi/migrations/0001_initial.py
+++ b/examples/fastapi/migrations/0001_initial.py
@@ -1,0 +1,35 @@
+from tortoise import fields, migrations
+from tortoise.migrations import operations as ops
+
+
+class Migration(migrations.Migration):
+    initial = True
+
+    operations = [
+        ops.CreateModel(
+            name="Users",
+            fields=[
+                (
+                    "id",
+                    fields.IntField(generated=True, primary_key=True, unique=True, db_index=True),
+                ),
+                (
+                    "username",
+                    fields.CharField(unique=True, description="This is a username", max_length=20),
+                ),
+                ("name", fields.CharField(null=True, max_length=50)),
+                ("family_name", fields.CharField(null=True, max_length=50)),
+                ("category", fields.CharField(default="misc", max_length=30)),
+                ("password_hash", fields.CharField(null=True, max_length=128)),
+                ("created_at", fields.DatetimeField(auto_now=False, auto_now_add=True)),
+                ("modified_at", fields.DatetimeField(auto_now=True, auto_now_add=False)),
+            ],
+            options={
+                "table": "users",
+                "app": "models",
+                "pk_attr": "id",
+                "table_description": "The User model",
+            },
+            bases=["Model"],
+        ),
+    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ dependencies = [
     "pytz",
     "tomlkit (>=0.11.4,<1.0.0); python_version < '3.11'",
     "typing-extensions (>= 4.1.0); python_version < '3.11'",
-    "nest-asyncio>=1.6.0",
 ]
 classifiers = [
     "License :: OSI Approved :: Apache Software License",
@@ -40,7 +39,10 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-ipython = []
+ipython = [
+    "ipython",
+    "nest-asyncio>=1.6.0",
+]
 ptpython = [
     "ptpython>=3.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,10 @@ dependencies = [
     "iso8601 (>=2.1.0,<3.0.0); python_version < '4.0'",
     "aiosqlite (>=0.16.0,<1.0.0)",
     "anyio",
-    "ptpython",
     "pytz",
     "tomlkit (>=0.11.4,<1.0.0); python_version < '3.11'",
     "typing-extensions (>= 4.1.0); python_version < '3.11'",
+    "nest-asyncio>=1.6.0",
 ]
 classifiers = [
     "License :: OSI Approved :: Apache Software License",
@@ -40,6 +40,10 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
+ipython = []
+ptpython = [
+    "ptpython>=3.0.0",
+]
 accel = [
     "ciso8601; sys_platform != 'win32' and implementation_name == 'cpython'",
     "uvloop; sys_platform != 'win32' and implementation_name == 'cpython'",

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -7,7 +7,7 @@ import io
 import sys
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any
 
 import pytest
 
@@ -280,8 +280,16 @@ TORTOISE_ORM = {
     assert called["target"] == "orders.__first__"
     assert called["direction"] == "backward"
     assert called["app_labels"] is None
-    called_config = cast(dict[str, Any], called["config"])
-    assert set(called_config["apps"].keys()) == {"accounts", "orders"}
+    called_config = called["config"]
+    # Config can be either dict or TortoiseConfig
+    if isinstance(called_config, dict):
+        apps = called_config["apps"]
+    else:
+        from tortoise.config import TortoiseConfig
+
+        assert isinstance(called_config, TortoiseConfig)
+        apps = called_config.apps
+    assert set(apps.keys()) == {"accounts", "orders"}
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -35,9 +35,17 @@ def test_tortoise_orm_config_empty(tmp_path: Path, monkeypatch: pytest.MonkeyPat
 
 
 def test_get_tortoise_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from tortoise.config import TortoiseConfig
+
     module_name = f"cli_settings_{tmp_path.name}"
     settings = tmp_path / f"{module_name}.py"
-    settings.write_text("TORTOISE_ORM = {'connections': {}, 'apps': {}}\n", encoding="utf-8")
+    settings.write_text(
+        "TORTOISE_ORM = {\n"
+        "    'connections': {'default': 'sqlite://:memory:'},\n"
+        "    'apps': {'models': {'models': ['__main__'], 'default_connection': 'default'}}\n"
+        "}\n",
+        encoding="utf-8",
+    )
     monkeypatch.syspath_prepend(str(tmp_path))
     importlib.invalidate_caches()
     import sys
@@ -45,18 +53,22 @@ def test_get_tortoise_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
     sys.modules.pop("cli_app", None)
     sys.modules.pop("cli_app.migrations", None)
 
-    assert utils.get_tortoise_config(f"{module_name}.TORTOISE_ORM") == {
-        "connections": {},
-        "apps": {},
-    }
+    result = utils.get_tortoise_config(f"{module_name}.TORTOISE_ORM")
+    assert isinstance(result, TortoiseConfig)
+    config_dict = result.to_dict()
+    assert config_dict["connections"] == {"default": "sqlite://:memory:"}
+    assert config_dict["apps"]["models"]["models"] == ["__main__"]
 
     with pytest.raises(
         utils.CLIError,
-        match="Error while importing configuration module: No module named 'missing'",
+        match="Cannot import configuration module: 'missing'",
     ):
         utils.get_tortoise_config("missing.TORTOISE_ORM")
 
-    with pytest.raises(utils.CLIUsageError):
+    with pytest.raises(
+        utils.CLIError,
+        match="Variable 'MISSING' not found in module",
+    ):
         utils.get_tortoise_config(f"{module_name}.MISSING")
 
 

--- a/tests/test_datetime_field_bug.py
+++ b/tests/test_datetime_field_bug.py
@@ -1,0 +1,92 @@
+"""Test coverage for DatetimeField auto_now and auto_now_add bug fix."""
+
+import pytest
+
+from tortoise import fields
+from tortoise.exceptions import ConfigurationError
+
+
+def test_datetimefield_auto_now_only():
+    """Test DatetimeField with only auto_now=True."""
+    field = fields.DatetimeField(auto_now=True)
+    assert field.auto_now is True
+    assert field.auto_now_add is False
+
+    # Verify describe() returns correct values
+    desc = field.describe(serializable=True)
+    assert desc["auto_now"] is True
+    assert desc["auto_now_add"] is False
+
+
+def test_datetimefield_auto_now_add_only():
+    """Test DatetimeField with only auto_now_add=True."""
+    field = fields.DatetimeField(auto_now_add=True)
+    assert field.auto_now is False
+    assert field.auto_now_add is True
+
+    # Verify describe() returns correct values
+    desc = field.describe(serializable=True)
+    assert desc["auto_now"] is False
+    assert desc["auto_now_add"] is True
+
+
+def test_datetimefield_both_flags_raises():
+    """Test DatetimeField raises when both auto_now and auto_now_add are True."""
+    with pytest.raises(
+        ConfigurationError, match="You can choose only 'auto_now' or 'auto_now_add'"
+    ):
+        fields.DatetimeField(auto_now=True, auto_now_add=True)
+
+
+def test_datetimefield_neither_flag():
+    """Test DatetimeField with neither flag set."""
+    field = fields.DatetimeField()
+    assert field.auto_now is False
+    assert field.auto_now_add is False
+
+    desc = field.describe(serializable=True)
+    assert desc["auto_now"] is False
+    assert desc["auto_now_add"] is False
+
+
+def test_datetimefield_constraints_auto_now():
+    """Test that auto_now sets readOnly constraint."""
+    field = fields.DatetimeField(auto_now=True)
+    constraints = field.constraints
+    assert constraints.get("readOnly") is True
+
+
+def test_datetimefield_constraints_auto_now_add():
+    """Test that auto_now_add sets readOnly constraint."""
+    field = fields.DatetimeField(auto_now_add=True)
+    constraints = field.constraints
+    assert constraints.get("readOnly") is True
+
+
+def test_datetimefield_constraints_neither():
+    """Test that neither flag sets no readOnly constraint."""
+    field = fields.DatetimeField()
+    constraints = field.constraints
+    assert "readOnly" not in constraints
+
+
+def test_timefield_auto_now_only():
+    """Test TimeField with only auto_now=True."""
+    field = fields.TimeField(auto_now=True)
+    assert field.auto_now is True
+    assert field.auto_now_add is False
+
+
+def test_timefield_auto_now_add_only():
+    """Test TimeField with only auto_now_add=True."""
+    field = fields.TimeField(auto_now_add=True)
+    assert field.auto_now is False
+    assert field.auto_now_add is True
+
+
+def test_timefield_both_flags_raises():
+    """Test TimeField raises when both auto_now and auto_now_add are True."""
+    with pytest.raises(
+        ConfigurationError, match="You can choose only 'auto_now' or 'auto_now_add'"
+    ):
+        fields.TimeField(auto_now=True, auto_now_add=True)

--- a/tests/test_datetime_migration_integration.py
+++ b/tests/test_datetime_migration_integration.py
@@ -1,0 +1,93 @@
+"""Integration test for DatetimeField migration generation bug fix.
+
+This test ensures that models with auto_now and auto_now_add fields
+generate valid migrations that can be applied without ConfigurationError.
+"""
+
+from tortoise import Model, fields
+
+
+class TimestampedModel(Model):
+    """Model with both created_at and modified_at fields."""
+
+    id = fields.IntField(primary_key=True)
+    name = fields.CharField(max_length=100)
+    created_at = fields.DatetimeField(auto_now_add=True)
+    modified_at = fields.DatetimeField(auto_now=True)
+
+    class Meta:
+        app = "test_app"
+
+
+def test_auto_now_field_describe():
+    """Test that auto_now field describes correctly for migrations."""
+    field = TimestampedModel._meta.fields_map["modified_at"]
+    desc = field.describe(serializable=True)
+
+    # Should have auto_now=True and auto_now_add=False
+    assert desc["auto_now"] is True
+    assert desc["auto_now_add"] is False
+
+    # Both should never be True
+    assert not (desc["auto_now"] and desc["auto_now_add"])
+
+
+def test_auto_now_add_field_describe():
+    """Test that auto_now_add field describes correctly for migrations."""
+    field = TimestampedModel._meta.fields_map["created_at"]
+    desc = field.describe(serializable=True)
+
+    # Should have auto_now_add=True and auto_now=False
+    assert desc["auto_now"] is False
+    assert desc["auto_now_add"] is True
+
+    # Both should never be True
+    assert not (desc["auto_now"] and desc["auto_now_add"])
+
+
+def test_regular_field_describe():
+    """Test that regular fields have both flags as False."""
+    field = TimestampedModel._meta.fields_map["name"]
+    desc = field.describe(serializable=True)
+
+    # Regular fields should have both as False (or not present)
+    assert desc.get("auto_now", False) is False
+    assert desc.get("auto_now_add", False) is False
+
+
+def test_migration_field_serialization():
+    """Test the actual migration field string that would be generated."""
+    # This simulates what the migration writer would generate
+    created_at = TimestampedModel._meta.fields_map["created_at"]
+    modified_at = TimestampedModel._meta.fields_map["modified_at"]
+
+    created_desc = created_at.describe(serializable=True)
+    modified_desc = modified_at.describe(serializable=True)
+
+    # Verify the exact scenario from the bug:
+    # created_at should be (auto_now=False, auto_now_add=True)
+    assert created_desc["auto_now"] is False
+    assert created_desc["auto_now_add"] is True
+
+    # modified_at should be (auto_now=True, auto_now_add=False)
+    # This was the bug: it was generating (True, True) which raises ConfigurationError
+    assert modified_desc["auto_now"] is True
+    assert modified_desc["auto_now_add"] is False
+
+
+def test_field_can_be_instantiated_from_describe():
+    """Test that a field recreated from describe() is valid."""
+    # Get the modified_at field and its describe() output
+    field = TimestampedModel._meta.fields_map["modified_at"]
+    desc = field.describe(serializable=True)
+
+    # Try to create a new field with these exact parameters
+    # This should not raise ConfigurationError
+    new_field = fields.DatetimeField(
+        auto_now=desc["auto_now"],
+        auto_now_add=desc["auto_now_add"],
+    )
+
+    # Verify the new field has correct values
+    assert new_field.auto_now is True
+    assert new_field.auto_now_add is False

--- a/tortoise/backends/base_postgres/schema_generator.py
+++ b/tortoise/backends/base_postgres/schema_generator.py
@@ -62,7 +62,7 @@ class BasePostgresSchemaGenerator(BaseSchemaGenerator):
         auto_now: bool = False,
     ) -> str:
         default_str = " DEFAULT"
-        default_str += " CURRENT_TIMESTAMP" if auto_now_add else f" {default}"
+        default_str += " CURRENT_TIMESTAMP" if (auto_now_add or auto_now) else f" {default}"
         return default_str
 
     def _escape_default_value(self, default: Any):

--- a/tortoise/backends/mssql/schema_generator.py
+++ b/tortoise/backends/mssql/schema_generator.py
@@ -55,7 +55,7 @@ class MSSQLSchemaGenerator(BaseSchemaGenerator):
         default_str = " DEFAULT"
         if not (auto_now or auto_now_add):
             default_str += f" {default}"
-        if auto_now_add:
+        if auto_now_add or auto_now:
             default_str += " CURRENT_TIMESTAMP"
         return default_str
 

--- a/tortoise/backends/mysql/schema_generator.py
+++ b/tortoise/backends/mysql/schema_generator.py
@@ -62,7 +62,7 @@ class MySQLSchemaGenerator(BaseSchemaGenerator):
         default_str = " DEFAULT"
         if not (auto_now or auto_now_add):
             default_str += f" {default}"
-        if auto_now_add:
+        if auto_now_add or auto_now:
             default_str += " CURRENT_TIMESTAMP(6)"
         if auto_now:
             default_str += " ON UPDATE CURRENT_TIMESTAMP(6)"

--- a/tortoise/backends/oracle/schema_generator.py
+++ b/tortoise/backends/oracle/schema_generator.py
@@ -81,7 +81,7 @@ class OracleSchemaGenerator(BaseSchemaGenerator):
         default_str = " DEFAULT"
         if not (auto_now or auto_now_add):
             default_str += f" {default}"
-        if auto_now_add:
+        if auto_now_add or auto_now:
             default_str += " CURRENT_TIMESTAMP"
         return default_str
 

--- a/tortoise/backends/sqlite/schema_generator.py
+++ b/tortoise/backends/sqlite/schema_generator.py
@@ -32,7 +32,7 @@ class SqliteSchemaGenerator(BaseSchemaGenerator):
         auto_now: bool = False,
     ) -> str:
         default_str = " DEFAULT"
-        default_str += " CURRENT_TIMESTAMP" if auto_now_add else f" {default}"
+        default_str += " CURRENT_TIMESTAMP" if (auto_now_add or auto_now) else f" {default}"
         return default_str
 
     def _escape_default_value(self, default: Any):

--- a/tortoise/cli/cli.py
+++ b/tortoise/cli/cli.py
@@ -8,13 +8,30 @@ import importlib.util
 import platform
 import sys
 from collections.abc import AsyncGenerator, Iterable
+from enum import Enum
 from pathlib import Path
 from typing import Any
 
-from ptpython.repl import embed
+# Conditional imports for optional shell dependencies
+try:
+    from IPython.terminal.embed import embed as ipython_embed
+
+    HAS_IPYTHON = True
+except ImportError:
+    ipython_embed = None
+    HAS_IPYTHON = False
+
+try:
+    from ptpython.repl import embed as ptpython_embed
+
+    HAS_PTPYTHON = True
+except ImportError:
+    ptpython_embed = None
+    HAS_PTPYTHON = False
 
 from tortoise import Tortoise, __version__
 from tortoise.cli import utils
+from tortoise.config import AppConfig, TortoiseConfig
 from tortoise.connection import get_connection
 from tortoise.context import TortoiseContext
 from tortoise.migrations.api import migrate as migrate_api
@@ -26,10 +43,14 @@ from tortoise.migrations.recorder import MigrationRecorder
 from tortoise.migrations.writer import MigrationWriter, format_migration_name
 
 if platform.system() == "Windows":
+    # Windows-specific patch for ptpython signal handler issues
+    # Only applied when launching ptpython shell on Windows
     # Remove when prompt-toolkit/ptpython#582 is fixed.
     from asyncio import get_event_loop_policy
 
     def _patch_loop_factory_for_ptpython() -> None:
+        """Patch event loop policy to work around ptpython signal handler bug on Windows."""
+
         def do_nothing(*_args, **_kwargs) -> None:
             return None
 
@@ -38,11 +59,98 @@ if platform.system() == "Windows":
             for attr in ("add_signal_handler", "remove_signal_handler"):
                 setattr(loop_factory, attr, do_nothing)
 
-    _patch_loop_factory_for_ptpython()
+
+class ShellProvider(Enum):
+    IPYTHON = "ipython"
+    PTPYTHON = "ptpython"
+
+
+def _get_available_shell_provider() -> ShellProvider | None:
+    if HAS_IPYTHON:
+        return ShellProvider.IPYTHON
+    elif HAS_PTPYTHON:
+        return ShellProvider.PTPYTHON
+    return None
+
+
+def _launch_ipython_shell(namespace: dict[str, Any]) -> None:
+    """Launch IPython shell synchronously.
+
+    IPython manages its own event loop for autoawait, so this must be called
+    from a synchronous context to avoid nested event loop errors.
+
+    Args:
+        namespace: The namespace dict to make available in the shell
+    """
+    # Apply nest_asyncio to allow IPython to run its own event loop
+    # This is needed because we're already inside an async context
+    import nest_asyncio
+
+    nest_asyncio.apply()
+
+    with contextlib.suppress(EOFError, ValueError):
+        # Configure IPython for async/await support
+        from IPython.terminal.embed import InteractiveShellEmbed
+
+        model_names = [
+            k for k in namespace.keys() if k not in ("Tortoise", "tortoise", "connections", "apps")
+        ]
+        models_info = (
+            f"Available models: {', '.join(model_names)}" if model_names else "No models loaded"
+        )
+
+        banner = (
+            "Tortoise ORM Shell (IPython with async support)\n"
+            f"{models_info}\n"
+            "Use 'await' directly for async operations (e.g., 'await YourModel.all()').\n"
+        )
+
+        # Create IPython shell with async autoawait enabled
+        ipshell = InteractiveShellEmbed(
+            user_ns=namespace,
+            banner1=banner,
+        )
+        # Enable autoawait for top-level await
+        ipshell.autoawait = True
+        ipshell()
+
+
+async def _launch_ptpython_shell(namespace: dict[str, Any]) -> None:
+    """Launch ptpython shell asynchronously.
+
+    Args:
+        namespace: The namespace dict to make available in the shell
+    """
+    # Apply Windows patch for ptpython signal handler issues
+    if platform.system() == "Windows":
+        _patch_loop_factory_for_ptpython()
+
+    model_names = [
+        k for k in namespace.keys() if k not in ("Tortoise", "tortoise", "connections", "apps")
+    ]
+
+    # Print banner before launching ptpython
+    models_info = (
+        f"Available models: {', '.join(model_names)}" if model_names else "No models loaded"
+    )
+    print("Tortoise ORM Shell (ptpython)")
+    print(models_info)
+    print("Use 'await' directly for async operations (e.g., 'await YourModel.all()').\n")
+
+    with contextlib.suppress(EOFError, ValueError):
+        await ptpython_embed(
+            globals=namespace,
+            title="Tortoise Shell",
+            vi_mode=True,
+            return_asyncio_coroutine=True,
+            patch_stdout=True,
+        )
 
 
 @contextlib.asynccontextmanager
-async def tortoise_cli_context(config: dict[str, Any]) -> AsyncGenerator[TortoiseContext, None]:
+async def tortoise_cli_context(
+    config: dict[str, Any] | TortoiseConfig,
+) -> AsyncGenerator[TortoiseContext, None]:
     async with TortoiseContext() as ctx:
         await ctx.init(config=config)
         yield ctx
@@ -59,11 +167,17 @@ class _NoopRecorder(MigrationRecorder):
         return None
 
 
-def _load_config(ctx: CLIContext) -> dict[str, Any]:
+def _load_config(ctx: CLIContext) -> TortoiseConfig:
+    """Load Tortoise ORM configuration from various sources.
+
+    Returns:
+        TortoiseConfig: Validated configuration object
+    """
     config_value = ctx.config
     config_file = ctx.config_file
     if config_file:
-        return Tortoise._get_config_from_config_file(config_file)
+        config_dict = Tortoise._get_config_from_config_file(config_file)
+        return TortoiseConfig.from_dict(config_dict)
     if not config_value:
         config_value = utils.tortoise_orm_config()
     if not config_value:
@@ -73,25 +187,17 @@ def _load_config(ctx: CLIContext) -> dict[str, Any]:
     return utils.get_tortoise_config(config_value)
 
 
-def _normalized_config(config: dict[str, Any]) -> dict[str, Any]:
-    normalized = dict(config)
-    apps_config = config.get("apps", {})
-    normalized["apps"] = utils.normalize_apps_config(apps_config)
-    return normalized
-
-
-def _select_apps(
-    apps_config: dict[str, dict[str, Any]], app_labels: Iterable[str] | None
-) -> dict[str, dict[str, Any]]:
-    if not apps_config:
+def _select_apps(config: TortoiseConfig, app_labels: Iterable[str] | None) -> dict[str, AppConfig]:
+    """Select specific apps from config, or all if no labels specified."""
+    if not config.apps:
         raise utils.CLIError("No apps configured in TORTOISE_ORM")
     if not app_labels:
-        return apps_config
-    selected: dict[str, dict[str, Any]] = {}
+        return dict(config.apps)
+    selected: dict[str, AppConfig] = {}
     for label in app_labels:
-        if label not in apps_config:
+        if label not in config.apps:
             raise utils.CLIUsageError(f"Unknown app label {label}")
-        selected[label] = apps_config[label]
+        selected[label] = config.apps[label]
     return selected
 
 
@@ -236,24 +342,71 @@ class CLIContext:
 
 
 async def init(ctx: CLIContext, app_labels: tuple[str, ...]) -> None:
-    config = _normalized_config(_load_config(ctx))
-    apps_config = _select_apps(config.get("apps", {}), app_labels or None)
+    config = _load_config(ctx)
+    apps_config = _select_apps(config, app_labels or None)
     for label, app_config in apps_config.items():
-        module, path = _ensure_migrations_package(label, app_config)
+        # Convert AppConfig to dict for _ensure_migrations_package
+        app_dict = app_config.to_dict()
+        module, path = _ensure_migrations_package(label, app_dict)
         print(f"{label}: {module} -> {path}")
 
 
 async def shell(ctx: CLIContext) -> None:
-    config = _normalized_config(_load_config(ctx))
-    async with tortoise_cli_context(config):
-        with contextlib.suppress(EOFError, ValueError):
-            await embed(
-                globals=globals(),
-                title="Tortoise Shell",
-                vi_mode=True,
-                return_asyncio_coroutine=True,
-                patch_stdout=True,
-            )
+    """Launch an interactive shell with Tortoise ORM context.
+
+    Prefers IPython if available, falls back to ptpython.
+    Requires at least one shell provider to be installed.
+
+    Raises:
+        CLIError: If neither IPython nor ptpython is installed
+    """
+    # Detect which shell provider is available
+    provider = _get_available_shell_provider()
+
+    if provider is None:
+        raise utils.CLIError(
+            "No interactive shell available. Please install one of the following:\n"
+            "  - IPython (recommended): pip install tortoise-orm[ipython]\\n"
+            "  - ptpython: pip install tortoise-orm[ptpython]\\n"
+            "  - Or install directly: pip install ipython (or ptpython)"
+        )
+
+    config = _load_config(ctx)
+
+    # For IPython: Initialize context, prepare namespace, then launch synchronously
+    # IPython manages its own event loop for autoawait
+    if provider == ShellProvider.IPYTHON:
+        async with tortoise_cli_context(config) as tortoise_ctx:
+            # Prepare namespace with Tortoise context and useful imports
+            namespace = {
+                "Tortoise": Tortoise,
+                "tortoise": tortoise_ctx,
+                "apps": tortoise_ctx.apps,
+            }
+            # Add all models to namespace for easy access
+            if tortoise_ctx.apps:
+                for app_name, models_dict in tortoise_ctx.apps.items():
+                    for model_name, model_class in models_dict.items():
+                        namespace[model_name] = model_class
+
+            # Launch IPython synchronously - it will manage its own event loop
+            _launch_ipython_shell(namespace)
+    else:
+        # ptpython works fine in async context
+        async with tortoise_cli_context(config) as tortoise_ctx:
+            # Prepare namespace with Tortoise context and useful imports
+            namespace = {
+                "Tortoise": Tortoise,
+                "tortoise": tortoise_ctx,
+                "apps": tortoise_ctx.apps,
+            }
+            # Add all models to namespace for easy access
+            if tortoise_ctx.apps:
+                for app_name, models_dict in tortoise_ctx.apps.items():
+                    for model_name, model_class in models_dict.items():
+                        namespace[model_name] = model_class
+
+            await _launch_ptpython_shell(namespace)
 
 
 async def makemigrations(
@@ -261,23 +414,27 @@ async def makemigrations(
 ) -> None:
     if empty and not app_labels:
         raise utils.CLIUsageError("--empty requires at least one APP_LABEL")
-    config = _normalized_config(_load_config(ctx))
-    apps_config = _select_apps(config.get("apps", {}), app_labels or None)
-    for label, app_config in apps_config.items():
+    tortoise_config = _load_config(ctx)
+    apps_config = _select_apps(tortoise_config, app_labels or None)
+
+    apps_dict = {label: app.to_dict() for label, app in apps_config.items()}
+    for label, app_config in apps_dict.items():
         migrations_module, _ = _ensure_migrations_package(label, app_config)
         app_config["migrations"] = migrations_module
-    config["apps"] = apps_config
 
-    async with tortoise_cli_context(config) as ctx:
+    config_dict = tortoise_config.to_dict()
+    config_dict["apps"] = apps_dict
+
+    async with tortoise_cli_context(config_dict) as ctx:
         if not ctx.apps:
             raise utils.CLIError("Tortoise apps are not initialized")
-        autodetector = MigrationAutodetector(ctx.apps, apps_config)
+        autodetector = MigrationAutodetector(ctx.apps, apps_dict)
         if empty:
             await autodetector.loader.build_graph()
             old_state = await autodetector._project_state()
             new_state = autodetector._current_state()
             writers = []
-            for label, app_config in apps_config.items():
+            for label, app_config in apps_dict.items():
                 migrations_module_name = app_config.get("migrations")
                 if not isinstance(migrations_module_name, str):
                     continue
@@ -327,7 +484,7 @@ async def _run_migrate(
     if app_label and not migration and "." in app_label:
         app_label, migration = app_label.split(".", 1)
 
-    config = _normalized_config(_load_config(ctx))
+    config = _load_config(ctx)
 
     target = target_override
     if target is None:
@@ -402,12 +559,15 @@ async def downgrade(
 
 
 async def history(ctx: CLIContext, app_labels: tuple[str, ...]) -> None:
-    config = _normalized_config(_load_config(ctx))
-    apps_config = _select_apps(config.get("apps", {}), app_labels or None)
-    config["apps"] = apps_config
-    apps_by_connection = _group_apps_by_connection(apps_config)
+    tortoise_config = _load_config(ctx)
+    apps_config = _select_apps(tortoise_config, app_labels or None)
+    apps_dict = {label: app.to_dict() for label, app in apps_config.items()}
+    apps_by_connection = _group_apps_by_connection(apps_dict)
 
-    async with tortoise_cli_context(config):
+    config_dict = tortoise_config.to_dict()
+    config_dict["apps"] = apps_dict
+
+    async with tortoise_cli_context(config_dict):
         for connection_name, subset in apps_by_connection.items():
             recorder = MigrationRecorder(get_connection(connection_name))
             applied = await recorder.applied_migrations()
@@ -415,12 +575,12 @@ async def history(ctx: CLIContext, app_labels: tuple[str, ...]) -> None:
 
 
 async def heads(ctx: CLIContext, app_labels: tuple[str, ...]) -> None:
-    config = _normalized_config(_load_config(ctx))
-    apps_config = _select_apps(config.get("apps", {}), app_labels or None)
-    config["apps"] = apps_config
-    apps_by_connection = _group_apps_by_connection(apps_config)
+    tortoise_config = _load_config(ctx)
+    apps_config = _select_apps(tortoise_config, app_labels or None)
+    apps_dict = {label: app.to_dict() for label, app in apps_config.items()}
+    apps_by_connection = _group_apps_by_connection(apps_dict)
 
-    loader = MigrationLoader(apps_config, _NoopRecorder(), load=False)
+    loader = MigrationLoader(apps_dict, _NoopRecorder(), load=False)
     await loader.build_graph()
 
     for connection_name, subset in apps_by_connection.items():
@@ -449,7 +609,9 @@ def _add_init_parser(subparsers: argparse._SubParsersAction) -> None:
 
 
 def _add_shell_parser(subparsers: argparse._SubParsersAction) -> None:
-    shell_parser = subparsers.add_parser("shell", help="Start an interactive shell.")
+    shell_parser = subparsers.add_parser(
+        "shell", help="Start an interactive shell (requires ipython or ptpython)."
+    )
     shell_parser.set_defaults(func=_run_shell)
 
 

--- a/tortoise/cli/utils.py
+++ b/tortoise/cli/utils.py
@@ -9,6 +9,9 @@ from pathlib import Path
 from types import ModuleType
 from typing import Any
 
+from tortoise.config import TortoiseConfig
+from tortoise.exceptions import ConfigurationError
+
 if sys.version_info >= (3, 11):
     import tomllib
 else:
@@ -36,25 +39,103 @@ def tortoise_orm_config(file: str = "pyproject.toml") -> str:
     return config
 
 
-def get_tortoise_config(config: str) -> dict[str, Any]:
+def get_tortoise_config(config: str) -> TortoiseConfig:
     """
-    Get tortoise config from module path.
+    Get tortoise config from module path with validation.
 
     :param config: module path + var name, e.g. "settings.TORTOISE_ORM"
+    :raises CLIUsageError: If config path is invalid (missing variable name)
+    :raises CLIError: If module can't be imported, variable doesn't exist, or config is invalid
+    :return: TortoiseConfig instance (converts dict configs automatically)
     """
+    if not config or not config.strip():
+        raise CLIUsageError(
+            "Config path cannot be empty.\n"
+            "Expected format: module.VARIABLE (e.g., 'config.TORTOISE_ORM')\n"
+            "Or use --config-file to load from a file."
+        )
+
     splits = config.split(".")
+    if len(splits) < 2:
+        raise CLIUsageError(
+            f"Invalid config path format: '{config}'\n"
+            f"Expected format: module.VARIABLE (e.g., 'config.TORTOISE_ORM')\n"
+            f"Got: '{config}' which has no variable name after the module.\n"
+            f"Alternative: use --config-file to load from a JSON/YAML file."
+        )
+
     config_path = ".".join(splits[:-1])
     tortoise_config = splits[-1]
 
+    if not config_path or not config_path.strip():
+        raise CLIUsageError(
+            f"Invalid config path: '{config}'\n"
+            f"Module path is empty. Expected format: module.VARIABLE"
+        )
+
     try:
         config_module = importlib.import_module(config_path)
-    except ModuleNotFoundError as exc:
-        raise CLIError(f"Error while importing configuration module: {exc}") from None
+    except ModuleNotFoundError:
+        raise CLIError(
+            f"Cannot import configuration module: '{config_path}'\n"
+            f"Make sure the module exists and is in your Python path.\n"
+            f"Current working directory: {Path.cwd()}\n"
+            f"Python path: {sys.path[:3]}...\n"
+            f"Hint: Try running from the directory containing '{config_path.split('.')[0]}'"
+        ) from None
+    except Exception as exc:
+        raise CLIError(
+            f"Error importing module '{config_path}': {type(exc).__name__}: {exc}"
+        ) from None
 
     config_value = getattr(config_module, tortoise_config, None)
-    if not config_value:
-        raise CLIUsageError(f'Can\'t get "{tortoise_config}" from module "{config_module}"')
-    return config_value
+    if config_value is None:
+        available_vars = [
+            name for name in dir(config_module) if not name.startswith("_") and name.isupper()
+        ]
+        hint = ""
+        if available_vars:
+            hint = f"\nAvailable config-like variables in {config_path}: {', '.join(available_vars[:5])}"
+
+        raise CLIError(
+            f"Variable '{tortoise_config}' not found in module '{config_path}'\n"
+            f"Checked: {config_module.__file__}{hint}\n"
+            f"Make sure '{tortoise_config}' is defined and not None."
+        )
+
+    if isinstance(config_value, TortoiseConfig):
+        return config_value
+
+    if not isinstance(config_value, dict):
+        raise CLIError(
+            f"Config variable '{config}' must be a dict or TortoiseConfig instance, got {type(config_value).__name__}\n"
+            f"Expected structure (as dict): {{\n"
+            f"    'connections': {{'default': 'sqlite://:memory:'}},\n"
+            f"    'apps': {{'models': {{'models': ['app.models'], 'default_connection': 'default'}}}}\n"
+            f"}}\n"
+            f"Or import and use: from tortoise.config import TortoiseConfig, DBUrlConfig, AppConfig"
+        )
+
+    try:
+        return TortoiseConfig.from_dict(config_value)
+    except ConfigurationError as exc:
+        raise CLIError(
+            f"Invalid Tortoise ORM configuration in '{config}':\n"
+            f"  {exc}\n\n"
+            f"Expected structure:\n"
+            f"  - 'connections': dict with at least one database connection\n"
+            f"  - 'apps': dict with at least one app configuration\n\n"
+            f"Example:\n"
+            f"  TORTOISE_ORM = {{\n"
+            f"      'connections': {{'default': 'sqlite://:memory:'}},\n"
+            f"      'apps': {{\n"
+            f"          'models': {{\n"
+            f"              'models': ['myapp.models'],\n"
+            f"              'default_connection': 'default'\n"
+            f"          }}\n"
+            f"      }}\n"
+            f"  }}"
+        ) from None
 
 
 def _first_models_module(models: Iterable[ModuleType | str] | str | None) -> str | None:
@@ -89,7 +170,12 @@ def normalize_apps_config(apps_config: dict[str, dict[str, Any]]) -> dict[str, d
         updated = dict(config)
         if "migrations" not in updated:
             inferred = infer_migrations_module(updated.get("models"))
-            if inferred and importlib.util.find_spec(inferred) is not None:
-                updated["migrations"] = inferred
+            if inferred:
+                try:
+                    if importlib.util.find_spec(inferred) is not None:
+                        updated["migrations"] = inferred
+                except (ModuleNotFoundError, AttributeError, ValueError):
+                    # Module doesn't exist or isn't a package - skip migrations inference
+                    pass
         normalized[label] = updated
     return normalized

--- a/tortoise/config.py
+++ b/tortoise/config.py
@@ -63,6 +63,7 @@ class ConnectionConfig:
 class AppConfig:
     models: list[str]
     default_connection: str | None = None
+    migrations: str | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.models, list) or not self.models:
@@ -72,11 +73,15 @@ class AppConfig:
                 raise ConfigurationError("AppConfig.models must contain non-empty strings")
         if self.default_connection is not None and not isinstance(self.default_connection, str):
             raise ConfigurationError("AppConfig.default_connection must be a string or None")
+        if self.migrations is not None and not isinstance(self.migrations, str):
+            raise ConfigurationError("AppConfig.migrations must be a string or None")
 
     def to_dict(self) -> dict[str, Any]:
         data: dict[str, Any] = {"models": self.models}
         if self.default_connection is not None:
             data["default_connection"] = self.default_connection
+        if self.migrations is not None:
+            data["migrations"] = self.migrations
         return data
 
     @classmethod
@@ -90,6 +95,7 @@ class AppConfig:
         return cls(
             models=list(data["models"]),
             default_connection=data.get("default_connection"),
+            migrations=data.get("migrations"),
         )
 
 

--- a/tortoise/context.py
+++ b/tortoise/context.py
@@ -322,15 +322,12 @@ class TortoiseContext:
         elif isinstance(config, TortoiseConfig):
             typed_config = config
         else:
-            # Validate and convert dict config to TortoiseConfig
             typed_config = TortoiseConfig.from_dict(config)
 
-        # Convert to dict for Apps and ConnectionHandler (they expect dict format)
         config_dict = typed_config.to_dict()
         connections_config = config_dict["connections"]
         apps_config = config_dict["apps"]
 
-        # Use typed config values with fallback to parameters
         effective_use_tz = typed_config.use_tz if typed_config.use_tz is not None else use_tz
         effective_timezone = (
             typed_config.timezone if typed_config.timezone is not None else timezone
@@ -339,20 +336,16 @@ class TortoiseContext:
 
         self._table_name_generator = table_name_generator
 
-        # Validate init_connections and _create_db combination
         if not init_connections and _create_db:
             raise ConfigurationError("init_connections=False cannot be used with _create_db=True")
 
-        # Initialize timezone
         self._init_timezone(effective_use_tz, effective_timezone)
 
-        # Initialize connections for this context
         if init_connections:
             await self.connections._init(connections_config, _create_db)
         else:
             self.connections._init_config(connections_config)
 
-        # Initialize apps for this context
         self._apps = Apps(
             apps_config,
             self.connections,
@@ -360,24 +353,18 @@ class TortoiseContext:
             validate_connections=init_connections,
         )
 
-        # Initialize routers
         self._init_routers(effective_routers)
 
-        # Detect default connection
         connection_names = list(typed_config.connections.keys())
         if len(connection_names) == 1:
-            # Single connection becomes the default automatically
             self._default_connection = connection_names[0]
         elif "default" in connection_names:
-            # Connection named "default" is used as default
             self._default_connection = "default"
         else:
-            # Multiple connections without a "default" - require explicit specification
             self._default_connection = None
 
         self._inited = True
 
-        # Set global fallback for cross-task access if enabled
         if _enable_global_fallback:
             set_global_context(self)
 
@@ -588,7 +575,6 @@ async def tortoise_test_context(
     """
     ctx = TortoiseContext()
     async with ctx:
-        # Build config with explicit connection label if provided
         config = generate_config(
             db_url,
             app_modules={app_label: modules},

--- a/tortoise/contrib/fastapi/__init__.py
+++ b/tortoise/contrib/fastapi/__init__.py
@@ -8,6 +8,7 @@ from types import ModuleType
 from typing import TYPE_CHECKING
 
 from tortoise import Tortoise
+from tortoise.config import TortoiseConfig
 from tortoise.connection import get_connections
 from tortoise.context import TortoiseContext
 from tortoise.exceptions import DoesNotExist, IntegrityError
@@ -54,7 +55,7 @@ class RegisterTortoise(AbstractAsyncContextManager):
     app:
         FastAPI app.
     config:
-        Dict containing config:
+        Dict containing config or TortoiseConfig instance:
 
         Example
         -------
@@ -118,7 +119,7 @@ class RegisterTortoise(AbstractAsyncContextManager):
     def __init__(
         self,
         app: FastAPI | None = None,
-        config: dict | None = None,
+        config: dict | TortoiseConfig | None = None,
         config_file: str | None = None,
         db_url: str | None = None,
         modules: dict[str, Iterable[str | ModuleType]] | None = None,
@@ -206,7 +207,7 @@ class RegisterTortoise(AbstractAsyncContextManager):
 
 def register_tortoise(
     app: FastAPI,
-    config: dict | None = None,
+    config: dict | TortoiseConfig | None = None,
     config_file: str | None = None,
     db_url: str | None = None,
     modules: dict[str, Iterable[str | ModuleType]] | None = None,
@@ -226,7 +227,7 @@ def register_tortoise(
     app:
         FastAPI app.
     config:
-        Dict containing config:
+        Dict containing config or TortoiseConfig instance:
 
         Example
         -------

--- a/tortoise/fields/data.py
+++ b/tortoise/fields/data.py
@@ -356,7 +356,7 @@ class DatetimeField(Field[datetime.datetime], datetime.datetime):
             raise ConfigurationError("You can choose only 'auto_now' or 'auto_now_add'")
         super().__init__(**kwargs)
         self.auto_now = auto_now
-        self.auto_now_add = auto_now | auto_now_add
+        self.auto_now_add = auto_now_add
 
     def to_python_value(self, value: Any) -> datetime.datetime | None:
         if value is not None:
@@ -398,7 +398,7 @@ class DatetimeField(Field[datetime.datetime], datetime.datetime):
     @property
     def constraints(self) -> dict:
         data = {}
-        if self.auto_now_add:
+        if self.auto_now_add or self.auto_now:
             data["readOnly"] = True
         return data
 
@@ -448,7 +448,7 @@ class TimeField(Field[datetime.time], datetime.time):
             raise ConfigurationError("You can choose only 'auto_now' or 'auto_now_add'")
         super().__init__(**kwargs)
         self.auto_now = auto_now
-        self.auto_now_add = auto_now | auto_now_add
+        self.auto_now_add = auto_now_add
 
     def to_python_value(self, value: Any) -> datetime.time | datetime.timedelta | None:
         if value is not None:

--- a/uv.lock
+++ b/uv.lock
@@ -972,7 +972,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1845,6 +1845,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "nest-asyncio"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
 ]
 
 [[package]]
@@ -3177,7 +3186,7 @@ dependencies = [
     { name = "aiosqlite" },
     { name = "anyio" },
     { name = "iso8601", marker = "python_full_version < '4'" },
-    { name = "ptpython" },
+    { name = "nest-asyncio" },
     { name = "pypika-tortoise" },
     { name = "pytz" },
     { name = "tomlkit", marker = "python_full_version < '3.11'" },
@@ -3204,6 +3213,9 @@ asyncpg = [
 ]
 psycopg = [
     { name = "psycopg", extra = ["binary", "pool"] },
+]
+ptpython = [
+    { name = "ptpython" },
 ]
 
 [package.dev-dependencies]
@@ -3258,16 +3270,17 @@ requires-dist = [
     { name = "asyncpg", marker = "extra == 'asyncpg'" },
     { name = "ciso8601", marker = "implementation_name == 'cpython' and sys_platform != 'win32' and extra == 'accel'" },
     { name = "iso8601", marker = "python_full_version < '4'", specifier = ">=2.1.0,<3.0.0" },
+    { name = "nest-asyncio", specifier = ">=1.6.0" },
     { name = "orjson", marker = "extra == 'accel'" },
     { name = "psycopg", extras = ["binary", "pool"], marker = "extra == 'psycopg'", specifier = ">=3.0.12,<4.0.0" },
-    { name = "ptpython" },
+    { name = "ptpython", marker = "extra == 'ptpython'", specifier = ">=3.0.0" },
     { name = "pypika-tortoise", specifier = ">=0.6.3,<1.0.0" },
     { name = "pytz" },
     { name = "tomlkit", marker = "python_full_version < '3.11'", specifier = ">=0.11.4,<1.0.0" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.1.0" },
     { name = "uvloop", marker = "implementation_name == 'cpython' and sys_platform != 'win32' and extra == 'accel'" },
 ]
-provides-extras = ["accel", "asyncpg", "aiomysql", "asyncmy", "psycopg", "asyncodbc"]
+provides-extras = ["ipython", "ptpython", "accel", "asyncpg", "aiomysql", "asyncmy", "psycopg", "asyncodbc"]
 
 [package.metadata.requires-dev]
 contrib = [

--- a/uv.lock
+++ b/uv.lock
@@ -254,6 +254,15 @@ wheels = [
 ]
 
 [[package]]
+name = "asttokens"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/a5/8e3f9b6771b0b408517c82d97aed8f2036509bc247d46114925e32fe33f0/asttokens-3.0.1.tar.gz", hash = "sha256:71a4ee5de0bde6a31d64f6b13f2293ac190344478f081c3d1bccfcf5eacb0cb7", size = 62308, upload-time = "2025-11-15T16:43:48.578Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl", hash = "sha256:15a3ebc0f43c2d0a50eeafea25e19046c68398e487b9f1f5b517f7c0f40f976a", size = 27047, upload-time = "2025-11-15T16:43:16.109Z" },
+]
+
+[[package]]
 name = "async-timeout"
 version = "5.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -911,6 +920,15 @@ wheels = [
 ]
 
 [[package]]
+name = "decorator"
+version = "5.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/fa/6d96a0978d19e17b68d634497769987b16c8f4cd0a7a05048bec693caa6b/decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360", size = 56711, upload-time = "2025-02-24T04:41:34.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a", size = 9190, upload-time = "2025-02-24T04:41:32.565Z" },
+]
+
+[[package]]
 name = "dill"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -986,6 +1004,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
+name = "executing"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
 ]
 
 [[package]]
@@ -1344,6 +1371,69 @@ wheels = [
 ]
 
 [[package]]
+name = "ipython"
+version = "8.38.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version < '3.11'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "jedi", marker = "python_full_version < '3.11'" },
+    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
+    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
+    { name = "pygments", marker = "python_full_version < '3.11'" },
+    { name = "stack-data", marker = "python_full_version < '3.11'" },
+    { name = "traitlets", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e5/61/1810830e8b93c72dcd3c0f150c80a00c3deb229562d9423807ec92c3a539/ipython-8.38.0.tar.gz", hash = "sha256:9cfea8c903ce0867cc2f23199ed8545eb741f3a69420bfcf3743ad1cec856d39", size = 5513996, upload-time = "2026-01-05T10:59:06.901Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/df/db59624f4c71b39717c423409950ac3f2c8b2ce4b0aac843112c7fb3f721/ipython-8.38.0-py3-none-any.whl", hash = "sha256:750162629d800ac65bb3b543a14e7a74b0e88063eac9b92124d4b2aa3f6d8e86", size = 831813, upload-time = "2026-01-05T10:59:04.239Z" },
+]
+
+[[package]]
+name = "ipython"
+version = "9.10.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version >= '3.11'" },
+    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
+    { name = "jedi", marker = "python_full_version >= '3.11'" },
+    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
+    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "stack-data", marker = "python_full_version >= '3.11'" },
+    { name = "traitlets", marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/60/2111715ea11f39b1535bed6024b7dec7918b71e5e5d30855a5b503056b50/ipython-9.10.0.tar.gz", hash = "sha256:cd9e656be97618a0676d058134cd44e6dc7012c0e5cb36a9ce96a8c904adaf77", size = 4426526, upload-time = "2026-02-02T10:00:33.594Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/aa/898dec789a05731cd5a9f50605b7b44a72bd198fd0d4528e11fc610177cc/ipython-9.10.0-py3-none-any.whl", hash = "sha256:c6ab68cc23bba8c7e18e9b932797014cc61ea7fd6f19de180ab9ba73e65ee58d", size = 622774, upload-time = "2026-02-02T10:00:31.503Z" },
+]
+
+[[package]]
+name = "ipython-pygments-lexers"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl", hash = "sha256:a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c", size = 8074, upload-time = "2025-01-17T11:24:33.271Z" },
+]
+
+[[package]]
 name = "iso8601"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1625,6 +1715,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "matplotlib-inline"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/74/97e72a36efd4ae2bccb3463284300f8953f199b5ffbc04cbbb0ec78f74b1/matplotlib_inline-0.2.1.tar.gz", hash = "sha256:e1ee949c340d771fc39e241ea75683deb94762c8fa5f2927ec57c83c4dffa9fe", size = 8110, upload-time = "2025-10-23T09:00:22.126Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/33/ee4519fa02ed11a94aef9559552f3b17bb863f2ecfe1a35dc7f548cde231/matplotlib_inline-0.2.1-py3-none-any.whl", hash = "sha256:d56ce5156ba6085e00a9d54fead6ed29a9c47e215cd1bba2e976ef39f5710a76", size = 9516, upload-time = "2025-10-23T09:00:20.675Z" },
 ]
 
 [[package]]
@@ -1998,6 +2100,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pexpect"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ptyprocess" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772, upload-time = "2023-11-25T06:56:14.81Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2258,6 +2372,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b6/8c/7e904ceeb512b4530c7ca1d918d3565d694a1fa7df337cdfc36a16347d68/ptpython-3.0.32.tar.gz", hash = "sha256:11651778236de95c582b42737294e50a66ba4a21fa01c0090ea70815af478fe0", size = 74080, upload-time = "2025-11-20T21:20:48.27Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4c/ac/0e35e5d7afd47ab0e2c71293ed2ad18df91a2a4a008c0ff59c2f22def377/ptpython-3.0.32-py3-none-any.whl", hash = "sha256:16435d323e5fc0a685d5f4dc5bb4494fb68ac68736689cd1247e1eda9369b616", size = 68099, upload-time = "2025-11-20T21:20:46.634Z" },
+]
+
+[[package]]
+name = "ptyprocess"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762, upload-time = "2020-12-28T15:15:30.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993, upload-time = "2020-12-28T15:15:28.35Z" },
+]
+
+[[package]]
+name = "pure-eval"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752, upload-time = "2024-07-21T12:58:21.801Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842, upload-time = "2024-07-21T12:58:20.04Z" },
 ]
 
 [[package]]
@@ -3082,6 +3214,20 @@ wheels = [
 ]
 
 [[package]]
+name = "stack-data"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asttokens" },
+    { name = "executing" },
+    { name = "pure-eval" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521, upload-time = "2023-09-30T13:58:03.53Z" },
+]
+
+[[package]]
 name = "starlette"
 version = "0.50.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3186,7 +3332,6 @@ dependencies = [
     { name = "aiosqlite" },
     { name = "anyio" },
     { name = "iso8601", marker = "python_full_version < '4'" },
-    { name = "nest-asyncio" },
     { name = "pypika-tortoise" },
     { name = "pytz" },
     { name = "tomlkit", marker = "python_full_version < '3.11'" },
@@ -3210,6 +3355,11 @@ asyncodbc = [
 ]
 asyncpg = [
     { name = "asyncpg" },
+]
+ipython = [
+    { name = "ipython", version = "8.38.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "ipython", version = "9.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "nest-asyncio" },
 ]
 psycopg = [
     { name = "psycopg", extra = ["binary", "pool"] },
@@ -3269,8 +3419,9 @@ requires-dist = [
     { name = "asyncodbc", marker = "python_full_version < '4' and extra == 'asyncodbc'", specifier = ">=0.1.1,<1.0.0" },
     { name = "asyncpg", marker = "extra == 'asyncpg'" },
     { name = "ciso8601", marker = "implementation_name == 'cpython' and sys_platform != 'win32' and extra == 'accel'" },
+    { name = "ipython", marker = "extra == 'ipython'" },
     { name = "iso8601", marker = "python_full_version < '4'", specifier = ">=2.1.0,<3.0.0" },
-    { name = "nest-asyncio", specifier = ">=1.6.0" },
+    { name = "nest-asyncio", marker = "extra == 'ipython'", specifier = ">=1.6.0" },
     { name = "orjson", marker = "extra == 'accel'" },
     { name = "psycopg", extras = ["binary", "pool"], marker = "extra == 'psycopg'", specifier = ">=3.0.12,<4.0.0" },
     { name = "ptpython", marker = "extra == 'ptpython'", specifier = ">=3.0.0" },
@@ -3333,6 +3484,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/15/b9/89b065c1818e5973c333a33311f823954ff4c7c48440c20b37669c5b752c/tracerite-2.3.1.tar.gz", hash = "sha256:f46ee672d240d500a2331781b09eb33564d473f6ae60cd871ebce6c2413cffa8", size = 61303, upload-time = "2025-12-30T22:51:19.32Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b6/62/3f385a67ff3cc91209f107d20bbebdecf7a4e4aba55a43f9f71bddc424a9/tracerite-2.3.1-py3-none-any.whl", hash = "sha256:5f9595ba90f075b58e14a9baf84d8204fec3cdce50029f1c32d757af79d9ccbe", size = 65884, upload-time = "2025-12-30T22:51:18.1Z" },
+]
+
+[[package]]
+name = "traitlets"
+version = "5.14.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Removed ptpython from required dependencies, now support optionally for shell both ptpython and ipython

Fixed some bugs and added better typings


AI summary: 
This pull request introduces two main improvements: it makes the Tortoise ORM CLI shell command rely on optional dependencies for interactive shells, and it fixes the behavior of `DatetimeField` and `TimeField` regarding `auto_now` and `auto_now_add` flags. The changes also update documentation, add comprehensive tests for the datetime bug fix, and improve configuration handling in examples and tests.

**Shell command improvements:**

* The `tortoise shell` command now uses optional dependencies: install with `pip install tortoise-orm[ipython]` (recommended) or `pip install tortoise-orm[ptpython]` to enable the shell. IPython is preferred if both are available, and the code conditionally imports and launches the appropriate shell. If neither is installed, the CLI displays an informative error. [[1]](diffhunk://#diff-ac84b6679b6b74a03e8a2669f0eaa4c896be16f60c65d48b2e6a4f1004768066R11-R34) [[2]](diffhunk://#diff-ac84b6679b6b74a03e8a2669f0eaa4c896be16f60c65d48b2e6a4f1004768066R46-R53) [[3]](diffhunk://#diff-ac84b6679b6b74a03e8a2669f0eaa4c896be16f60c65d48b2e6a4f1004768066R62-R153) [[4]](diffhunk://#diff-2c623f3c6a917be56c59d43279244996836262cb1e12d9d0786c9c49eef6b43cR44-R45) [[5]](diffhunk://#diff-c2a3f968b7ac8d84c3935f76af3a93c094b3c5c068777c4cd2548789b9a8d417R112-R138) [[6]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L15-R18) [[7]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R43-R46)
* The dependency on `ptpython` is moved to an optional dependency group in `pyproject.toml`, and `nest-asyncio` is added as a optional dependency to support IPython event loop integration. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L15-R18) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R43-R46)

**DatetimeField and TimeField bug fix:**

* Fixes the behavior where `auto_now=True` on `DatetimeField` or `TimeField` would incorrectly set `auto_now_add=True` internally. Now, only the specified flag is set, and both cannot be `True` at the same time. [[1]](diffhunk://#diff-2c623f3c6a917be56c59d43279244996836262cb1e12d9d0786c9c49eef6b43cR44-R45) [[2]](diffhunk://#diff-3592d6946aae3313b44dcfc2fbe1fbd2a62e7d6e93811cf39d0e853595ce35d3R1-R92) [[3]](diffhunk://#diff-14471d68ecfd252eddd9bb79b069801a2787a7bec19d30921c15052dc5c8d0d3R1-R93)
* Updates backend schema generators to treat `auto_now` and `auto_now_add` correctly when generating SQL defaults for all supported databases. [[1]](diffhunk://#diff-66a0c118afa0a7d2ce449e47adcbea8e5c9ad0f50d81cf68defcd87cd284583eL65-R65) [[2]](diffhunk://#diff-1d293786a26b664897ec1355a2006a32d5dbccb735ec351b97eb7b6db6fceea3L58-R58) [[3]](diffhunk://#diff-f850a13b4e2e67743d9e1d5d90d75615f4bd94777b1ec0abaf6bc9f7ac18d4edL65-R65) [[4]](diffhunk://#diff-a2245d1d713cb2d326e7e510d697beb3b06f76920569be92d040dacf84bbd625L84-R84) [[5]](diffhunk://#diff-6914bf17217d2d82b645a42c48a291401c3b581ca0ac75ebc1af84178a893731L35-R35)
* Adds comprehensive unit and integration tests to ensure the correct behavior of these fields and their migration serialization. [[1]](diffhunk://#diff-3592d6946aae3313b44dcfc2fbe1fbd2a62e7d6e93811cf39d0e853595ce35d3R1-R92) [[2]](diffhunk://#diff-14471d68ecfd252eddd9bb79b069801a2787a7bec19d30921c15052dc5c8d0d3R1-R93)

**Configuration and example improvements:**

* Updates the FastAPI example to use the new `TortoiseConfig` and `AppConfig` classes for a single source of truth in ORM configuration. [[1]](diffhunk://#diff-d465f047d4db1dc8b5674cda2086c2e57f4e310875a1a9b72b76b9c6996977f8R4-R21) [[2]](diffhunk://#diff-1a2a508ab9309c1bf4b28a2ec922dda94c2e3e402308256de57f101398bd8377R1-R35)
* Adjusts CLI and test utilities to support both dict and `TortoiseConfig` inputs, improving robustness and forward compatibility. [[1]](diffhunk://#diff-660e26820c979d67ecb21990d7711358f30db073138e8e9800584f8b2087ccc8L283-R292) [[2]](diffhunk://#diff-d73e532773442934c4c4fb02a30c0642187173a01243a2d646f5cda99b09f65dR38-R71)

**Documentation updates:**

* Improves documentation for the shell command, clarifying installation and usage instructions, and listing supported shells and their async capabilities. [[1]](diffhunk://#diff-c2a3f968b7ac8d84c3935f76af3a93c094b3c5c068777c4cd2548789b9a8d417R112-R138) [[2]](diffhunk://#diff-2c623f3c6a917be56c59d43279244996836262cb1e12d9d0786c9c49eef6b43cR44-R45)

**Test and code cleanup:**

* Minor typing and import cleanups in test files for clarity and maintainability.

---

**References:**  
Shell command improvements: [[1]](diffhunk://#diff-ac84b6679b6b74a03e8a2669f0eaa4c896be16f60c65d48b2e6a4f1004768066R11-R34) [[2]](diffhunk://#diff-ac84b6679b6b74a03e8a2669f0eaa4c896be16f60c65d48b2e6a4f1004768066R46-R53) [[3]](diffhunk://#diff-ac84b6679b6b74a03e8a2669f0eaa4c896be16f60c65d48b2e6a4f1004768066R62-R153) [[4]](diffhunk://#diff-2c623f3c6a917be56c59d43279244996836262cb1e12d9d0786c9c49eef6b43cR44-R45) [[5]](diffhunk://#diff-c2a3f968b7ac8d84c3935f76af3a93c094b3c5c068777c4cd2548789b9a8d417R112-R138) [[6]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L15-R18) [[7]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R43-R46)  
DatetimeField/TimeField bug fix: [[1]](diffhunk://#diff-2c623f3c6a917be56c59d43279244996836262cb1e12d9d0786c9c49eef6b43cR44-R45) [[2]](diffhunk://#diff-3592d6946aae3313b44dcfc2fbe1fbd2a62e7d6e93811cf39d0e853595ce35d3R1-R92) [[3]](diffhunk://#diff-14471d68ecfd252eddd9bb79b069801a2787a7bec19d30921c15052dc5c8d0d3R1-R93) [[4]](diffhunk://#diff-66a0c118afa0a7d2ce449e47adcbea8e5c9ad0f50d81cf68defcd87cd284583eL65-R65) [[5]](diffhunk://#diff-1d293786a26b664897ec1355a2006a32d5dbccb735ec351b97eb7b6db6fceea3L58-R58) [[6]](diffhunk://#diff-f850a13b4e2e67743d9e1d5d90d75615f4bd94777b1ec0abaf6bc9f7ac18d4edL65-R65) [[7]](diffhunk://#diff-a2245d1d713cb2d326e7e510d697beb3b06f76920569be92d040dacf84bbd625L84-R84) [[8]](diffhunk://#diff-6914bf17217d2d82b645a42c48a291401c3b581ca0ac75ebc1af84178a893731L35-R35)  
Configuration/example improvements: [[1]](diffhunk://#diff-d465f047d4db1dc8b5674cda2086c2e57f4e310875a1a9b72b76b9c6996977f8R4-R21) [[2]](diffhunk://#diff-1a2a508ab9309c1bf4b28a2ec922dda94c2e3e402308256de57f101398bd8377R1-R35) [[3]](diffhunk://#diff-660e26820c979d67ecb21990d7711358f30db073138e8e9800584f8b2087ccc8L283-R292) [[4]](diffhunk://#diff-d73e532773442934c4c4fb02a30c0642187173a01243a2d646f5cda99b09f65dR38-R71)  
Documentation: [[1]](diffhunk://#diff-c2a3f968b7ac8d84c3935f76af3a93c094b3c5c068777c4cd2548789b9a8d417R112-R138) [[2]](diffhunk://#diff-2c623f3c6a917be56c59d43279244996836262cb1e12d9d0786c9c49eef6b43cR44-R45)  
Test/code cleanup: