### PR TITLE
Model.in_bulk type fix

### DIFF
--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -61,6 +61,7 @@ if TYPE_CHECKING:
         from typing_extensions import Self
 
 MODEL = TypeVar("MODEL", bound="Model")
+PRIMARY_KEY = TypeVar("PRIMARY_KEY")
 EMPTY = object()
 
 
@@ -1278,10 +1279,10 @@ class Model(metaclass=ModelMeta):
     @classmethod
     async def in_bulk(
         cls: type[MODEL],
-        id_list: Iterable[str | int],
+        id_list: Iterable[PRIMARY_KEY],
         field_name: str = "pk",
         using_db: BaseDBAsyncClient | None = None,
-    ) -> dict[str, MODEL]:
+    ) -> dict[PRIMARY_KEY, MODEL]:
         """
         Return a dictionary mapping each of the given IDs to the object with
         that ID. If `id_list` isn't provided, evaluate the entire QuerySet.

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -45,6 +45,7 @@ if TYPE_CHECKING:  # pragma: nocoverage
     from tortoise.models import Model
 
 MODEL = TypeVar("MODEL", bound="Model")
+PRIMARY_KEY = TypeVar("PRIMARY_KEY")
 T_co = TypeVar("T_co", covariant=True)
 SINGLE = TypeVar("SINGLE", bound=bool)
 
@@ -855,7 +856,9 @@ class QuerySet(AwaitableQuery[MODEL]):
         queryset._raise_does_not_exist = True
         return queryset  # type: ignore
 
-    async def in_bulk(self, id_list: Iterable[str | int], field_name: str) -> dict[str, MODEL]:
+    async def in_bulk(
+        self, id_list: Iterable[PRIMARY_KEY], field_name: str
+    ) -> dict[PRIMARY_KEY, MODEL]:
         """
         Return a dictionary mapping each of the given IDs to the object with
         that ID. If `id_list` isn't provided, evaluate the entire QuerySet.


### PR DESCRIPTION
## Description
`Model.in_bulk` supports not any primary key type.

## Motivation and Context
Closes https://github.com/tortoise/tortoise-orm/issues/2052

## How Has This Been Tested?
Local testing.

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

