### PR TITLE
Micro optimisations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,9 @@ _codeqc:
 test: deps
 	$(py_warn) TORTOISE_TEST_DB=sqlite://:memory: uv run --frozen pytest $(pytest_opts)
 
+test_fast: deps
+	$(py_warn) TORTOISE_TEST_DB=sqlite://:memory: uv run --frozen pytest -n auto --tb=native -q
+
 test_sqlite:
 	$(py_warn) TORTOISE_TEST_DB=sqlite://:memory: uv run --frozen pytest --cov-report= $(pytest_opts)
 

--- a/tests/benchmarks/test_hydration.py
+++ b/tests/benchmarks/test_hydration.py
@@ -1,0 +1,151 @@
+"""Benchmarks for model hydration and query building at scale.
+
+Each benchmark performs many operations per iteration so that Python-level
+overhead (hydration, cloning, value conversion) is amplified relative to
+per-query DB I/O, producing stable and meaningful numbers.
+"""
+
+import asyncio
+import random
+from decimal import Decimal
+
+from tests.testmodels import Author, BenchmarkFewFields, BenchmarkManyFields, Book
+
+
+def test_hydrate_1000_rows_few_fields(benchmark, db):
+    """Read 1000 rows of a small model — _init_from_db called 1000x."""
+    loop = asyncio.get_event_loop()
+
+    async def _setup():
+        await BenchmarkFewFields.bulk_create(
+            [BenchmarkFewFields(level=i % 100, text=f"item_{i}") for i in range(1000)]
+        )
+
+    loop.run_until_complete(_setup())
+
+    @benchmark
+    def bench():
+        async def _bench():
+            await BenchmarkFewFields.all()
+
+        loop.run_until_complete(_bench())
+
+
+def test_hydrate_1000_rows_many_fields(benchmark, db, gen_many_fields_data):
+    """Read 1000 rows of a large (30+ field) model — _init_from_db called 1000x."""
+    loop = asyncio.get_event_loop()
+
+    async def _setup():
+        await BenchmarkManyFields.bulk_create(
+            [BenchmarkManyFields(**gen_many_fields_data()) for _ in range(1000)]
+        )
+
+    loop.run_until_complete(_setup())
+
+    @benchmark
+    def bench():
+        async def _bench():
+            await BenchmarkManyFields.all()
+
+        loop.run_until_complete(_bench())
+
+
+def test_values_list_1000_rows(benchmark, db):
+    """values_list() over 1000 rows — resolve_to_python_value called per field per row."""
+    loop = asyncio.get_event_loop()
+
+    async def _setup():
+        await BenchmarkFewFields.bulk_create(
+            [BenchmarkFewFields(level=i % 100, text=f"item_{i}") for i in range(1000)]
+        )
+
+    loop.run_until_complete(_setup())
+
+    @benchmark
+    def bench():
+        async def _bench():
+            await BenchmarkFewFields.all().values_list("id", "level", "text", flat=False)
+
+        loop.run_until_complete(_bench())
+
+
+def test_values_1000_rows_many_fields(benchmark, db, gen_many_fields_data):
+    """values() over 1000 rows with 8 selected fields — resolve_to_python_value at scale."""
+    loop = asyncio.get_event_loop()
+
+    async def _setup():
+        await BenchmarkManyFields.bulk_create(
+            [BenchmarkManyFields(**gen_many_fields_data()) for _ in range(1000)]
+        )
+
+    loop.run_until_complete(_setup())
+
+    @benchmark
+    def bench():
+        async def _bench():
+            await BenchmarkManyFields.all().values(
+                "id", "level", "text", "col_float1",
+                "col_int1", "col_char1", "col_decimal1", "col_json1",
+            )
+
+        loop.run_until_complete(_bench())
+
+
+def test_select_related_1000_rows(benchmark, db):
+    """select_related with FK over 1000 rows — column split cache + hydration."""
+    loop = asyncio.get_event_loop()
+
+    async def _setup():
+        authors = await Author.bulk_create(
+            [Author(name=f"Author {i}") for i in range(20)]
+        )
+        author_ids = [a.id for a in await Author.all()]
+        await Book.bulk_create(
+            [
+                Book(
+                    name=f"Book {i}",
+                    author_id=random.choice(author_ids),  # nosec
+                    rating=round(random.uniform(1.0, 5.0), 2),  # nosec
+                )
+                for i in range(1000)
+            ]
+        )
+
+    loop.run_until_complete(_setup())
+
+    @benchmark
+    def bench():
+        async def _bench():
+            await Book.all().select_related("author")
+
+        loop.run_until_complete(_bench())
+
+
+def test_chained_filters_100(benchmark, db):
+    """Build and execute 100 chained filter queries — _clone() called 100x."""
+    loop = asyncio.get_event_loop()
+
+    async def _setup():
+        await BenchmarkFewFields.bulk_create(
+            [BenchmarkFewFields(level=i % 100, text=f"item_{i}") for i in range(100)]
+        )
+
+    loop.run_until_complete(_setup())
+
+    @benchmark
+    def bench():
+        async def _bench():
+            for i in range(100):
+                await BenchmarkFewFields.filter(level=i).filter(text=f"item_{i}")
+
+        loop.run_until_complete(_bench())
+
+
+def test_constructor_1000_many_defaults(benchmark, db):
+    """Construct 1000 model instances with many defaults — deepcopy skip path."""
+    loop = asyncio.get_event_loop()
+
+    @benchmark
+    def bench():
+        for _ in range(1000):
+            BenchmarkManyFields(level=1, text="test")

--- a/tests/benchmarks/test_hydration.py
+++ b/tests/benchmarks/test_hydration.py
@@ -1,27 +1,19 @@
 """Benchmarks for model hydration and query building at scale.
 
-Each benchmark performs many operations per iteration so that Python-level
+Each benchmark reads/builds many objects per iteration so that Python-level
 overhead (hydration, cloning, value conversion) is amplified relative to
-per-query DB I/O, producing stable and meaningful numbers.
+per-query DB I/O.
 """
 
 import asyncio
 import random
-from decimal import Decimal
 
 from tests.testmodels import Author, BenchmarkFewFields, BenchmarkManyFields, Book
 
 
-def test_hydrate_1000_rows_few_fields(benchmark, db):
-    """Read 1000 rows of a small model — _init_from_db called 1000x."""
+def test_hydrate_100_rows_few_fields(benchmark, few_fields_benchmark_dataset):
+    """Read 100 rows of a small model — _init_from_db called 100x."""
     loop = asyncio.get_event_loop()
-
-    async def _setup():
-        await BenchmarkFewFields.bulk_create(
-            [BenchmarkFewFields(level=i % 100, text=f"item_{i}") for i in range(1000)]
-        )
-
-    loop.run_until_complete(_setup())
 
     @benchmark
     def bench():
@@ -31,16 +23,9 @@ def test_hydrate_1000_rows_few_fields(benchmark, db):
         loop.run_until_complete(_bench())
 
 
-def test_hydrate_1000_rows_many_fields(benchmark, db, gen_many_fields_data):
-    """Read 1000 rows of a large (30+ field) model — _init_from_db called 1000x."""
+def test_hydrate_100_rows_many_fields(benchmark, many_fields_benchmark_dataset):
+    """Read 100 rows of a large (30+ field) model — _init_from_db called 100x."""
     loop = asyncio.get_event_loop()
-
-    async def _setup():
-        await BenchmarkManyFields.bulk_create(
-            [BenchmarkManyFields(**gen_many_fields_data()) for _ in range(1000)]
-        )
-
-    loop.run_until_complete(_setup())
 
     @benchmark
     def bench():
@@ -50,16 +35,9 @@ def test_hydrate_1000_rows_many_fields(benchmark, db, gen_many_fields_data):
         loop.run_until_complete(_bench())
 
 
-def test_values_list_1000_rows(benchmark, db):
-    """values_list() over 1000 rows — resolve_to_python_value called per field per row."""
+def test_values_list_100_rows(benchmark, few_fields_benchmark_dataset):
+    """values_list() over 100 rows — resolve_to_python_value called per field per row."""
     loop = asyncio.get_event_loop()
-
-    async def _setup():
-        await BenchmarkFewFields.bulk_create(
-            [BenchmarkFewFields(level=i % 100, text=f"item_{i}") for i in range(1000)]
-        )
-
-    loop.run_until_complete(_setup())
 
     @benchmark
     def bench():
@@ -69,36 +47,33 @@ def test_values_list_1000_rows(benchmark, db):
         loop.run_until_complete(_bench())
 
 
-def test_values_1000_rows_many_fields(benchmark, db, gen_many_fields_data):
-    """values() over 1000 rows with 8 selected fields — resolve_to_python_value at scale."""
+def test_values_100_rows_many_fields(benchmark, many_fields_benchmark_dataset):
+    """values() over 100 rows with 8 selected fields."""
     loop = asyncio.get_event_loop()
-
-    async def _setup():
-        await BenchmarkManyFields.bulk_create(
-            [BenchmarkManyFields(**gen_many_fields_data()) for _ in range(1000)]
-        )
-
-    loop.run_until_complete(_setup())
 
     @benchmark
     def bench():
         async def _bench():
             await BenchmarkManyFields.all().values(
-                "id", "level", "text", "col_float1",
-                "col_int1", "col_char1", "col_decimal1", "col_json1",
+                "id",
+                "level",
+                "text",
+                "col_float1",
+                "col_int1",
+                "col_char1",
+                "col_decimal1",
+                "col_json1",
             )
 
         loop.run_until_complete(_bench())
 
 
-def test_select_related_1000_rows(benchmark, db):
-    """select_related with FK over 1000 rows — column split cache + hydration."""
+def test_select_related_100_rows(benchmark, db):
+    """select_related with FK over 100 rows — column split cache + hydration."""
     loop = asyncio.get_event_loop()
 
     async def _setup():
-        authors = await Author.bulk_create(
-            [Author(name=f"Author {i}") for i in range(20)]
-        )
+        authors = await Author.bulk_create([Author(name=f"Author {i}") for i in range(10)])
         author_ids = [a.id for a in await Author.all()]
         await Book.bulk_create(
             [
@@ -107,7 +82,7 @@ def test_select_related_1000_rows(benchmark, db):
                     author_id=random.choice(author_ids),  # nosec
                     rating=round(random.uniform(1.0, 5.0), 2),  # nosec
                 )
-                for i in range(1000)
+                for i in range(100)
             ]
         )
 
@@ -121,31 +96,23 @@ def test_select_related_1000_rows(benchmark, db):
         loop.run_until_complete(_bench())
 
 
-def test_chained_filters_100(benchmark, db):
-    """Build and execute 100 chained filter queries — _clone() called 100x."""
+def test_chained_filters_10(benchmark, few_fields_benchmark_dataset):
+    """Build and execute 10 chained filter queries — _clone() called 20x."""
     loop = asyncio.get_event_loop()
-
-    async def _setup():
-        await BenchmarkFewFields.bulk_create(
-            [BenchmarkFewFields(level=i % 100, text=f"item_{i}") for i in range(100)]
-        )
-
-    loop.run_until_complete(_setup())
 
     @benchmark
     def bench():
         async def _bench():
-            for i in range(100):
+            for i in range(10):
                 await BenchmarkFewFields.filter(level=i).filter(text=f"item_{i}")
 
         loop.run_until_complete(_bench())
 
 
-def test_constructor_1000_many_defaults(benchmark, db):
-    """Construct 1000 model instances with many defaults — deepcopy skip path."""
-    loop = asyncio.get_event_loop()
+def test_constructor_100_many_defaults(benchmark, db):
+    """Construct 100 model instances with many defaults — deepcopy skip path."""
 
     @benchmark
     def bench():
-        for _ in range(1000):
+        for _ in range(100):
             BenchmarkManyFields(level=1, text="test")

--- a/tests/benchmarks/test_hydration.py
+++ b/tests/benchmarks/test_hydration.py
@@ -73,7 +73,7 @@ def test_select_related_100_rows(benchmark, db):
     loop = asyncio.get_event_loop()
 
     async def _setup():
-        authors = await Author.bulk_create([Author(name=f"Author {i}") for i in range(10)])
+        await Author.bulk_create([Author(name=f"Author {i}") for i in range(10)])
         author_ids = [a.id for a in await Author.all()]
         await Book.bulk_create(
             [

--- a/tests/benchmarks/test_state_building.py
+++ b/tests/benchmarks/test_state_building.py
@@ -1,0 +1,60 @@
+"""Benchmark for migration state building performance.
+
+Exercises State.apply() over 200 CreateModel operations (every 3rd with FK).
+"""
+
+import asyncio
+from typing import Any
+
+from tortoise import fields
+from tortoise.migrations.migration import Migration
+from tortoise.migrations.operations import CreateModel, Operation
+from tortoise.migrations.schema_generator.state import State
+from tortoise.migrations.schema_generator.state_apps import StateApps
+
+
+def _make_create_model_op(i: int) -> CreateModel:
+    field_list: list[tuple[str, Any]] = [
+        ("id", fields.IntField(primary_key=True)),
+        ("name", fields.CharField(max_length=255)),
+        ("description", fields.TextField(null=True)),
+        ("created_at", fields.DatetimeField(auto_now_add=True)),
+        ("updated_at", fields.DatetimeField(auto_now=True)),
+        ("is_active", fields.BooleanField(default=True)),
+        ("sort_order", fields.IntField(default=0)),
+    ]
+    if i > 0 and i % 3 == 0:
+        field_list.append(
+            ("parent", fields.ForeignKeyField(f"app.Model{i - 1}", related_name=f"ch_{i}")),
+        )
+    return CreateModel(name=f"Model{i}", fields=field_list, options={"table": f"model_{i}"})
+
+
+def _build_migrations(num_models: int, batch_size: int = 20) -> list[Migration]:
+    all_ops: list[Operation] = [_make_create_model_op(i) for i in range(num_models)]
+    migrations: list[Migration] = []
+    for start in range(0, len(all_ops), batch_size):
+        batch = all_ops[start : start + batch_size]
+
+        class Mig(Migration):
+            pass
+
+        Mig.operations = batch
+        migrations.append(Mig(name=f"mig_{start // batch_size:04d}", app_label="app"))
+    return migrations
+
+
+def test_state_building_200_models(benchmark):
+    """State building from 200 CreateModel operations with FK relations."""
+    loop = asyncio.get_event_loop()
+    migrations = _build_migrations(200)
+
+    @benchmark
+    def bench():
+        async def _bench():
+            state = State(models={}, apps=StateApps())
+            for migration in migrations:
+                await migration.apply(state, dry_run=True, schema_editor=None)
+            assert len(state.models) == 200
+
+        loop.run_until_complete(_bench())

--- a/tortoise/backends/base/executor.py
+++ b/tortoise/backends/base/executor.py
@@ -108,6 +108,8 @@ class BaseExecutor:
     ) -> list:
         _, raw_results = await self.db.execute_query(sql, values)
         instance_list = []
+        if self.select_related_idx:
+            _split_cache: dict[str, str] = {}
         for row_idx, row in enumerate(raw_results):
             if row_idx != 0 and row_idx % CHUNK_SIZE == 0:
                 # Forcibly yield to the event loop to avoid blocking the event loop
@@ -123,7 +125,13 @@ class BaseExecutor:
                     (*path, attr) = full_path
                     related_items = row_items[current_idx : current_idx + index]
                     if any(v for _, v in related_items):
-                        obj = model._init_from_db(**{k.split(".")[1]: v for k, v in related_items})
+                        related_kwargs = {}
+                        for k, v in related_items:
+                            fname = _split_cache.get(k)
+                            if fname is None:
+                                fname = _split_cache[k] = k.split(".", 1)[1]
+                            related_kwargs[fname] = v
+                        obj = model._init_from_db(**related_kwargs)
                     elif index == 0:
                         # 0 signals that an empty "filler" object should be created in the case
                         # where a field of related model is selected but model itself isn't,
@@ -133,7 +141,7 @@ class BaseExecutor:
                         obj = None
                     target = instances.get(tuple(path))
                     if target is not None:
-                        setattr(target, f"_{attr}", obj)
+                        object.__setattr__(target, f"_{attr}", obj)
                     if obj is not None:
                         instances[(*path, attr)] = obj
                     current_idx += index
@@ -141,7 +149,7 @@ class BaseExecutor:
                 instance = self.model._init_from_db(**row)
             if custom_fields:
                 for field in custom_fields:
-                    setattr(instance, field, row[field])
+                    object.__setattr__(instance, field, row[field])
             instance_list.append(instance)
         await self._execute_prefetch_queries(instance_list)
         return instance_list

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -213,6 +213,7 @@ class MetaInfo:
         "db_complex_fields",
         "_default_ordering",
         "_ordering_validated",
+        "_python_value_cache",
     )
 
     def __init__(self, meta: Model.Meta) -> None:
@@ -252,6 +253,7 @@ class MetaInfo:
         self.db_native_fields: list[tuple[str, str, Field]] = []
         self.db_default_fields: list[tuple[str, str, Field]] = []
         self.db_complex_fields: list[tuple[str, str, Field]] = []
+        self._python_value_cache: dict[str, Callable] = {}
 
     @property
     def full_name(self) -> str:
@@ -734,7 +736,11 @@ class Model(metaclass=ModelMeta):
             elif callable(field_default):
                 setattr(self, key, field_default())
             else:
-                setattr(self, key, deepcopy(field_object.default))
+                default = field_object.default
+                if default is None or isinstance(default, (int, float, str, bool, bytes)):
+                    setattr(self, key, default)
+                else:
+                    setattr(self, key, deepcopy(default))
 
     def __setattr__(self, key, value) -> None:
         # set field value override async default function
@@ -795,44 +801,40 @@ class Model(metaclass=ModelMeta):
         self._await_when_save = {}
 
         meta = self._meta
-        inited_keys: set[str] = set()
+        _setattr = object.__setattr__  # bypass __setattr__ override for performance
         try:
             # This is like so for performance reasons.
             #  We want to avoid conditionals and calling .to_python_value()
             # Native fields are fields that are already converted to/from python to DB type
             #  by the DB driver
             for key, model_field, field in meta.db_native_fields:
-                setattr(self, model_field, kwargs[key])
-                inited_keys.add(key)
+                _setattr(self, model_field, kwargs[key])
             # Fields that don't override .to_python_value() are converted without a call
             #  as we already know what we will be doing.
             for key, model_field, field in meta.db_default_fields:
                 if (value := kwargs[key]) is not None:
                     value = field.field_type(value)
-                setattr(self, model_field, value)
-                inited_keys.add(key)
+                _setattr(self, model_field, value)
             # These fields need manual .to_python_value()
             for key, model_field, field in meta.db_complex_fields:
-                setattr(self, model_field, field.to_python_value(kwargs[key]))
-                inited_keys.add(key)
+                _setattr(self, model_field, field.to_python_value(kwargs[key]))
         except KeyError:
+            # Partial model (.only() query) — slower but correct fallback
             self._partial = True
-            native_fields: list[Field] = [f for *_, f in meta.db_native_fields]
-            default_fields = complex_fields = None
+            native_keys = {k for k, _, _ in meta.db_native_fields}
+            default_keys = {k for k, _, _ in meta.db_default_fields}
             for key, value in kwargs.items():
-                if key in inited_keys or key not in meta.fields_map:
+                if key not in meta.fields_map:
                     continue
-                if (field := meta.fields_map[key]) not in native_fields:
-                    if default_fields is None:
-                        default_fields = [f for *_, f in meta.db_default_fields]
-                    if field in default_fields:
+                field = meta.fields_map[key]
+                if key not in native_keys:
+                    if key in default_keys:
                         if value is not None:
                             value = field.field_type(value)
                     else:
-                        if complex_fields is None:
-                            complex_fields = [f for *_, f in meta.db_complex_fields]
                         value = field.to_python_value(value)
-                setattr(self, key, value)
+                model_field = meta.fields_db_projection_reverse.get(key, key)
+                _setattr(self, model_field, value)
 
         return self
 

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -213,7 +213,6 @@ class MetaInfo:
         "db_complex_fields",
         "_default_ordering",
         "_ordering_validated",
-        "_python_value_cache",
     )
 
     def __init__(self, meta: Model.Meta) -> None:
@@ -253,7 +252,6 @@ class MetaInfo:
         self.db_native_fields: list[tuple[str, str, Field]] = []
         self.db_default_fields: list[tuple[str, str, Field]] = []
         self.db_complex_fields: list[tuple[str, str, Field]] = []
-        self._python_value_cache: dict[str, Callable] = {}
 
     @property
     def full_name(self) -> str:

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -375,23 +375,23 @@ class QuerySet(AwaitableQuery[MODEL]):
         queryset.model = self.model
         queryset.query = self.query
         queryset.capabilities = self.capabilities
-        queryset._prefetch_map = copy(self._prefetch_map) if self._prefetch_map else {}
-        queryset._prefetch_queries = copy(self._prefetch_queries) if self._prefetch_queries else {}
+        queryset._prefetch_map = copy(self._prefetch_map)
+        queryset._prefetch_queries = copy(self._prefetch_queries)
         queryset._single = self._single
         queryset._raise_does_not_exist = self._raise_does_not_exist
         queryset._db = self._db
         queryset._limit = self._limit
         queryset._offset = self._offset
         queryset._fields_for_select = self._fields_for_select
-        queryset._filter_kwargs = copy(self._filter_kwargs) if self._filter_kwargs else {}
-        queryset._orderings = copy(self._orderings) if self._orderings else []
-        queryset._joined_tables = copy(self._joined_tables) if self._joined_tables else []
-        queryset._q_objects = copy(self._q_objects) if self._q_objects else []
+        queryset._filter_kwargs = copy(self._filter_kwargs)
+        queryset._orderings = copy(self._orderings)
+        queryset._joined_tables = copy(self._joined_tables)
+        queryset._q_objects = copy(self._q_objects)
         queryset._distinct = self._distinct
-        queryset._annotations = copy(self._annotations) if self._annotations else {}
-        queryset._having = copy(self._having) if self._having else {}
-        queryset._custom_filters = copy(self._custom_filters) if self._custom_filters else {}
-        queryset._group_bys = copy(self._group_bys) if self._group_bys else ()
+        queryset._annotations = copy(self._annotations)
+        queryset._having = copy(self._having)
+        queryset._custom_filters = copy(self._custom_filters)
+        queryset._group_bys = copy(self._group_bys)
         queryset._select_for_update = self._select_for_update
         queryset._select_for_update_nowait = self._select_for_update_nowait
         queryset._select_for_update_skip_locked = self._select_for_update_skip_locked
@@ -1572,7 +1572,13 @@ class FieldSelectQuery(AwaitableQuery):
         raise FieldError(f'Unknown field "{field}" for model "{self.model.__name__}"')
 
     def resolve_to_python_value(self, model: type[MODEL], field: str) -> Callable:
-        # Check annotation-dependent lookups first (not cacheable on model)
+        if field in model._meta.fetch_fields:
+            # return as is to get whole model objects
+            return lambda x: x
+
+        if field in (x[1] for x in model._meta.db_native_fields):
+            return lambda x: x
+
         if field in self._annotations:
             annotation = self._annotations[field]
             field_object = getattr(annotation, "field_object", None)
@@ -1580,34 +1586,13 @@ class FieldSelectQuery(AwaitableQuery):
                 return field_object.to_python_value
             return lambda x: x
 
-        # Model-level lookups are cacheable
-        cache = model._meta._python_value_cache
-        cached = cache.get(field)
-        if cached is not None:
-            return cached
-
-        if field in model._meta.fetch_fields:
-            # return as is to get whole model objects
-            result: Callable = lambda x: x
-            cache[field] = result
-            return result
-
-        if field in (x[1] for x in model._meta.db_native_fields):
-            result = lambda x: x
-            cache[field] = result
-            return result
-
         if field in model._meta.fields_map:
-            result = model._meta.fields_map[field].to_python_value
-            cache[field] = result
-            return result
+            return model._meta.fields_map[field].to_python_value
 
         field_, __, forwarded_fields = field.partition("__")
         if field_ in model._meta.fetch_fields:
             new_model = model._meta.fields_map[field_].related_model  # type: ignore
-            result = self.resolve_to_python_value(new_model, forwarded_fields)
-            cache[field] = result
-            return result
+            return self.resolve_to_python_value(new_model, forwarded_fields)
 
         raise FieldError(f'Unknown field "{field}" for model "{model}"')
 

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -375,23 +375,23 @@ class QuerySet(AwaitableQuery[MODEL]):
         queryset.model = self.model
         queryset.query = self.query
         queryset.capabilities = self.capabilities
-        queryset._prefetch_map = copy(self._prefetch_map)
-        queryset._prefetch_queries = copy(self._prefetch_queries)
+        queryset._prefetch_map = copy(self._prefetch_map) if self._prefetch_map else {}
+        queryset._prefetch_queries = copy(self._prefetch_queries) if self._prefetch_queries else {}
         queryset._single = self._single
         queryset._raise_does_not_exist = self._raise_does_not_exist
         queryset._db = self._db
         queryset._limit = self._limit
         queryset._offset = self._offset
         queryset._fields_for_select = self._fields_for_select
-        queryset._filter_kwargs = copy(self._filter_kwargs)
-        queryset._orderings = copy(self._orderings)
-        queryset._joined_tables = copy(self._joined_tables)
-        queryset._q_objects = copy(self._q_objects)
+        queryset._filter_kwargs = copy(self._filter_kwargs) if self._filter_kwargs else {}
+        queryset._orderings = copy(self._orderings) if self._orderings else []
+        queryset._joined_tables = copy(self._joined_tables) if self._joined_tables else []
+        queryset._q_objects = copy(self._q_objects) if self._q_objects else []
         queryset._distinct = self._distinct
-        queryset._annotations = copy(self._annotations)
-        queryset._having = copy(self._having)
-        queryset._custom_filters = copy(self._custom_filters)
-        queryset._group_bys = copy(self._group_bys)
+        queryset._annotations = copy(self._annotations) if self._annotations else {}
+        queryset._having = copy(self._having) if self._having else {}
+        queryset._custom_filters = copy(self._custom_filters) if self._custom_filters else {}
+        queryset._group_bys = copy(self._group_bys) if self._group_bys else ()
         queryset._select_for_update = self._select_for_update
         queryset._select_for_update_nowait = self._select_for_update_nowait
         queryset._select_for_update_skip_locked = self._select_for_update_skip_locked
@@ -1572,13 +1572,7 @@ class FieldSelectQuery(AwaitableQuery):
         raise FieldError(f'Unknown field "{field}" for model "{self.model.__name__}"')
 
     def resolve_to_python_value(self, model: type[MODEL], field: str) -> Callable:
-        if field in model._meta.fetch_fields:
-            # return as is to get whole model objects
-            return lambda x: x
-
-        if field in (x[1] for x in model._meta.db_native_fields):
-            return lambda x: x
-
+        # Check annotation-dependent lookups first (not cacheable on model)
         if field in self._annotations:
             annotation = self._annotations[field]
             field_object = getattr(annotation, "field_object", None)
@@ -1586,13 +1580,34 @@ class FieldSelectQuery(AwaitableQuery):
                 return field_object.to_python_value
             return lambda x: x
 
+        # Model-level lookups are cacheable
+        cache = model._meta._python_value_cache
+        cached = cache.get(field)
+        if cached is not None:
+            return cached
+
+        if field in model._meta.fetch_fields:
+            # return as is to get whole model objects
+            result: Callable = lambda x: x
+            cache[field] = result
+            return result
+
+        if field in (x[1] for x in model._meta.db_native_fields):
+            result = lambda x: x
+            cache[field] = result
+            return result
+
         if field in model._meta.fields_map:
-            return model._meta.fields_map[field].to_python_value
+            result = model._meta.fields_map[field].to_python_value
+            cache[field] = result
+            return result
 
         field_, __, forwarded_fields = field.partition("__")
         if field_ in model._meta.fetch_fields:
             new_model = model._meta.fields_map[field_].related_model  # type: ignore
-            return self.resolve_to_python_value(new_model, forwarded_fields)
+            result = self.resolve_to_python_value(new_model, forwarded_fields)
+            cache[field] = result
+            return result
 
         raise FieldError(f'Unknown field "{field}" for model "{model}"')
 


### PR DESCRIPTION
This pull request micro performance improvements and new benchmarking tools for the ORM's model hydration and migration state building, along with targeted optimizations in model initialization and related object hydration. The changes focus on making object construction and attribute assignment faster and more efficient, especially during bulk operations, and provide new benchmarks to measure these improvements.

**Performance optimizations:**

* Improved performance of model initialization by bypassing `__setattr__` in `Model._init_from_db` and using `object.__setattr__` for direct attribute assignment. This reduces overhead during hydration of models from database rows.
* Optimized handling of default field values in model `__init__` to avoid unnecessary deep copies for immutable types, further improving initialization speed.
* In the select executor, switched to using `object.__setattr__` instead of `setattr` for setting related and custom fields, and added a field name split cache to speed up hydration of related models. [[1]](diffhunk://#diff-ea831f53334901c1e3a70d1649242f03f436cf2f61cc01d39f16e14b1ef85149R111-R112) [[2]](diffhunk://#diff-ea831f53334901c1e3a70d1649242f03f436cf2f61cc01d39f16e14b1ef85149L126-R134) [[3]](diffhunk://#diff-ea831f53334901c1e3a70d1649242f03f436cf2f61cc01d39f16e14b1ef85149L136-R152)

**Benchmarking improvements:**

* Added `tests/benchmarks/test_hydration.py` with comprehensive benchmarks for model hydration, query building, and related object fetching, amplifying Python-level overhead to better measure performance.
* Added `tests/benchmarks/test_state_building.py` to benchmark migration state building performance, exercising `State.apply()` over 200 `CreateModel` operations with foreign key relations.

**Developer tooling:**

* Added a `test_fast` target to the `Makefile` for running tests in parallel with minimal output, enabling faster feedback during development.