### PR TITLE
Fix pydantic issues, improve computed field handling

### DIFF
--- a/docs/examples/pydantic.rst
+++ b/docs/examples/pydantic.rst
@@ -26,6 +26,15 @@ Early model Init
 
 .. rst-class:: html-toggle
 
+.. _example_pydantic_computed_fields:
+
+Computed fields & Nullable relations
+=====================================
+.. literalinclude::  ../../examples/pydantic/computed_fields.py
+
+
+.. rst-class:: html-toggle
+
 .. _example_pydantic_recursive:
 
 Recursive models + Computed fields

--- a/examples/pydantic/computed_fields.py
+++ b/examples/pydantic/computed_fields.py
@@ -1,0 +1,204 @@
+"""
+Pydantic computed fields example
+
+Here we demonstrate:
+* Nullable FK fields become Optional in the Pydantic schema (with ``"default": null``).
+* Computed fields that access reverse relations work when the relation is included.
+* Computed fields still work when the relation is excluded but manually prefetched.
+* NoValuesFetched error propagation when a computed field accesses an unfetched relation.
+* Graceful handling pattern using try/except inside the computed function.
+"""
+
+import json
+
+from pydantic_core import PydanticSerializationError
+
+from tortoise import Tortoise, fields, run_async
+from tortoise.contrib.pydantic import pydantic_model_creator
+from tortoise.exceptions import NoValuesFetched
+from tortoise.models import Model
+
+
+class Department(Model):
+    id = fields.IntField(primary_key=True)
+    name = fields.CharField(max_length=100)
+
+    # Define reverse relation for type checking and auto completion
+    employees: fields.ReverseRelation["Employee"]
+
+    def employee_count(self) -> int:
+        """
+        Counts employees in the department.
+
+        Uses try/except to gracefully handle the case where the relation has not been
+        fetched, returning 0 instead of raising an error.
+        """
+        try:
+            return len(self.employees)
+        except (NoValuesFetched, AttributeError):
+            return 0
+
+    def employee_names(self) -> str:
+        """
+        Returns a comma-separated list of employee names.
+
+        Does NOT handle NoValuesFetched -- demonstrates error propagation when the
+        relation has not been fetched.
+        """
+        return ", ".join(e.name for e in self.employees)
+
+    class PydanticMeta:
+        computed = ("employee_count", "employee_names")
+
+
+class Employee(Model):
+    id = fields.IntField(primary_key=True)
+    name = fields.CharField(max_length=100)
+
+    department: fields.ForeignKeyNullableRelation[Department] = fields.ForeignKeyField(
+        "models.Department", related_name="employees", null=True
+    )
+
+
+# Initialise model structure early so we can create pydantic models at module level
+Tortoise.init_models(["__main__"], "models")
+
+
+async def run():
+    await Tortoise.init(db_url="sqlite://:memory:", modules={"models": ["__main__"]})
+    await Tortoise.generate_schemas()
+
+    # Create test data
+    engineering = await Department.create(name="Engineering")
+    await Employee.create(name="Alice", department=engineering)
+    await Employee.create(name="Bob", department=engineering)
+    await Employee.create(name="Charlie")  # no department (nullable FK)
+
+    # ──────────────────────────────────────────────────────────────────────
+    # Section 1: Nullable FK is Optional in the Pydantic schema
+    #
+    # A nullable ForeignKeyField generates a pydantic field with
+    # "default": null that is NOT in "required".
+    # ──────────────────────────────────────────────────────────────────────
+    print("=" * 70)
+    print("Section 1: Nullable FK is Optional")
+    print("=" * 70)
+
+    Employee_Pydantic = pydantic_model_creator(Employee)
+    schema = Employee_Pydantic.model_json_schema()
+    print(json.dumps(schema, indent=4))
+
+    # The 'department' field has "default": null and is NOT in "required"
+    required = schema.get("required", [])
+    print(f"\nRequired fields: {required}")
+    print("'department' in required:", "department" in required)
+
+    dept_props = schema.get("properties", {}).get("department", {})
+    has_default_null = dept_props.get("default") is None and "default" in dept_props
+    print(f"'department' has default null: {has_default_null}")
+
+    # ──────────────────────────────────────────────────────────────────────
+    # Section 2: Computed field with included relation (auto-prefetched)
+    #
+    # When the 'employees' reverse relation is included in the pydantic
+    # model, from_tortoise_orm() auto-prefetches it. Both computed fields
+    # work because the relation data is available.
+    # ──────────────────────────────────────────────────────────────────────
+    print("\n" + "=" * 70)
+    print("Section 2: Computed field with included relation")
+    print("=" * 70)
+
+    Department_Pydantic = pydantic_model_creator(Department)
+
+    dept = await Department.get(name="Engineering")
+    dept_pydantic = await Department_Pydantic.from_tortoise_orm(dept)
+    print(dept_pydantic.model_dump_json(indent=4))
+
+    # Both computed fields work because the relation was auto-prefetched
+    print(f"\nemployee_count: {dept_pydantic.employee_count}")
+    print(f"employee_names: {dept_pydantic.employee_names}")
+
+    # ──────────────────────────────────────────────────────────────────────
+    # Section 3: Computed field with excluded relation + manual prefetch
+    #
+    # The 'employees' relation is excluded from the pydantic model (so it
+    # won't appear in the output), but we manually prefetch it before
+    # serialization so the computed fields can still access the data.
+    # ──────────────────────────────────────────────────────────────────────
+    print("\n" + "=" * 70)
+    print("Section 3: Excluded relation + manual prefetch")
+    print("=" * 70)
+
+    Department_Pydantic_NoEmployees = pydantic_model_creator(
+        Department,
+        name="Department_NoEmployees",
+        exclude=("employees",),
+    )
+
+    dept = await Department.get(name="Engineering")
+    # Manually prefetch the relation so computed fields can access it
+    await dept.fetch_related("employees")
+    dept_pydantic = await Department_Pydantic_NoEmployees.from_tortoise_orm(dept)
+    print(dept_pydantic.model_dump_json(indent=4))
+
+    print(f"\nemployee_count: {dept_pydantic.employee_count}")
+    print(f"employee_names: {dept_pydantic.employee_names}")
+
+    # ──────────────────────────────────────────────────────────────────────
+    # Section 4: NoValuesFetched error propagation
+    #
+    # Same excluded model but WITHOUT manual prefetch. The employee_names()
+    # computed field does not handle NoValuesFetched internally, so the
+    # wrapper in creator.py re-raises with a descriptive message during
+    # serialization.
+    # ──────────────────────────────────────────────────────────────────────
+    print("\n" + "=" * 70)
+    print("Section 4: NoValuesFetched error propagation")
+    print("=" * 70)
+
+    dept = await Department.get(name="Engineering")
+    dept_pydantic = await Department_Pydantic_NoEmployees.from_tortoise_orm(dept)
+    try:
+        # Serialization triggers the computed field, which raises NoValuesFetched
+        dept_pydantic.model_dump_json(indent=4)
+    except (PydanticSerializationError, NoValuesFetched) as e:
+        print(f"Caught error during serialization: {e}")
+
+    # ──────────────────────────────────────────────────────────────────────
+    # Section 5: Graceful handling pattern
+    #
+    # A model with only the graceful computed field (employee_count) that
+    # handles NoValuesFetched internally. Even without prefetching, it
+    # returns 0 instead of crashing. Contrast with employee_names which
+    # would fail in the same scenario.
+    # ──────────────────────────────────────────────────────────────────────
+    print("\n" + "=" * 70)
+    print("Section 5: Graceful handling pattern")
+    print("=" * 70)
+
+    # Override PydanticMeta so only the graceful computed field is included
+    class GracefulMeta:
+        computed = ("employee_count",)
+
+    Department_Pydantic_GracefulOnly = pydantic_model_creator(
+        Department,
+        name="Department_GracefulOnly",
+        exclude=("employees",),
+        meta_override=GracefulMeta,
+    )
+
+    dept = await Department.get(name="Engineering")
+    # No manual prefetch -- employee_count() handles the exception internally
+    dept_pydantic = await Department_Pydantic_GracefulOnly.from_tortoise_orm(dept)
+    print(dept_pydantic.model_dump_json(indent=4))
+
+    # employee_count returns 0 gracefully instead of crashing
+    print(f"\nemployee_count (graceful, no prefetch): {dept_pydantic.employee_count}")
+    print(
+        "employee_names would raise NoValuesFetched in the same scenario, "
+        "but employee_count handles it and returns 0."
+    )
+
+
+if __name__ == "__main__":
+    run_async(run())

--- a/tests/contrib/test_pydantic.py
+++ b/tests/contrib/test_pydantic.py
@@ -119,13 +119,13 @@ async def test_event_schema(db, pydantic_setup):
     Event_Pydantic = pydantic_setup["Event_Pydantic"]
     assert Event_Pydantic.model_json_schema() == {
         "$defs": {
-            "Address_e4rhju_leaf": {
+            "Address_zwygvk_leaf": {
                 "additionalProperties": False,
                 "properties": {
                     "city": {"maxLength": 64, "title": "City", "type": "string"},
                     "street": {"maxLength": 128, "title": "Street", "type": "string"},
                     "m2mwitho2opks": {
-                        "items": {"$ref": "#/$defs/M2mWithO2oPk_leajz6_leaf"},
+                        "items": {"$ref": "#/$defs/M2mWithO2oPk_zpacbp_leaf"},
                         "title": "M2Mwitho2Opks",
                         "type": "array",
                     },
@@ -140,7 +140,7 @@ async def test_event_schema(db, pydantic_setup):
                 "title": "Address",
                 "type": "object",
             },
-            "M2mWithO2oPk_leajz6_leaf": {
+            "M2mWithO2oPk_zpacbp_leaf": {
                 "additionalProperties": False,
                 "properties": {
                     "id": {
@@ -155,7 +155,7 @@ async def test_event_schema(db, pydantic_setup):
                 "title": "M2mWithO2oPk",
                 "type": "object",
             },
-            "Reporter_fgnv33_leaf": {
+            "Reporter_ifqfo2_leaf": {
                 "additionalProperties": False,
                 "description": "Whom is assigned as the reporter",
                 "properties": {
@@ -171,7 +171,7 @@ async def test_event_schema(db, pydantic_setup):
                 "title": "Reporter",
                 "type": "object",
             },
-            "Team_ip4pg6_leaf": {
+            "Team_fcszy2_leaf": {
                 "additionalProperties": False,
                 "description": "Team that is a playing",
                 "properties": {
@@ -200,7 +200,7 @@ async def test_event_schema(db, pydantic_setup):
                 "title": "Team",
                 "type": "object",
             },
-            "Tournament_5y7e7j_leaf": {
+            "Tournament_zh4alg_leaf": {
                 "additionalProperties": False,
                 "properties": {
                     "id": {
@@ -239,19 +239,20 @@ async def test_event_schema(db, pydantic_setup):
             },
             "name": {"description": "The name", "title": "Name", "type": "string"},
             "tournament": {
-                "$ref": "#/$defs/Tournament_5y7e7j_leaf",
+                "$ref": "#/$defs/Tournament_zh4alg_leaf",
                 "description": "What tournaments is a happenin'",
             },
             "reporter": {
                 "anyOf": [
-                    {"$ref": "#/$defs/Reporter_fgnv33_leaf"},
+                    {"$ref": "#/$defs/Reporter_ifqfo2_leaf"},
                     {"type": "null"},
                 ],
+                "default": None,
                 "nullable": True,
                 "title": "Reporter",
             },
             "participants": {
-                "items": {"$ref": "#/$defs/Team_ip4pg6_leaf"},
+                "items": {"$ref": "#/$defs/Team_fcszy2_leaf"},
                 "title": "Participants",
                 "type": "array",
             },
@@ -273,9 +274,10 @@ async def test_event_schema(db, pydantic_setup):
             },
             "address": {
                 "anyOf": [
-                    {"$ref": "#/$defs/Address_e4rhju_leaf"},
+                    {"$ref": "#/$defs/Address_zwygvk_leaf"},
                     {"type": "null"},
                 ],
+                "default": None,
                 "nullable": True,
                 "title": "Address",
             },
@@ -284,11 +286,9 @@ async def test_event_schema(db, pydantic_setup):
             "event_id",
             "name",
             "tournament",
-            "reporter",
             "participants",
             "modified",
             "token",
-            "address",
         ],
         "title": "Event",
         "type": "object",
@@ -300,7 +300,7 @@ async def test_eventlist_schema(db, pydantic_setup):
     Event_Pydantic_List = pydantic_setup["Event_Pydantic_List"]
     assert Event_Pydantic_List.model_json_schema() == {
         "$defs": {
-            "Event_mfxmwb": {
+            "Event_bx6qaa": {
                 "additionalProperties": False,
                 "description": "Events on the calendar",
                 "properties": {
@@ -312,19 +312,20 @@ async def test_eventlist_schema(db, pydantic_setup):
                     },
                     "name": {"description": "The name", "title": "Name", "type": "string"},
                     "tournament": {
-                        "$ref": "#/$defs/Tournament_5y7e7j_leaf",
+                        "$ref": "#/$defs/Tournament_zh4alg_leaf",
                         "description": "What tournaments is a happenin'",
                     },
                     "reporter": {
                         "anyOf": [
-                            {"$ref": "#/$defs/Reporter_fgnv33_leaf"},
+                            {"$ref": "#/$defs/Reporter_ifqfo2_leaf"},
                             {"type": "null"},
                         ],
+                        "default": None,
                         "nullable": True,
                         "title": "Reporter",
                     },
                     "participants": {
-                        "items": {"$ref": "#/$defs/Team_ip4pg6_leaf"},
+                        "items": {"$ref": "#/$defs/Team_fcszy2_leaf"},
                         "title": "Participants",
                         "type": "array",
                     },
@@ -353,9 +354,10 @@ async def test_eventlist_schema(db, pydantic_setup):
                     },
                     "address": {
                         "anyOf": [
-                            {"$ref": "#/$defs/Address_e4rhju_leaf"},
+                            {"$ref": "#/$defs/Address_zwygvk_leaf"},
                             {"type": "null"},
                         ],
+                        "default": None,
                         "nullable": True,
                         "title": "Address",
                     },
@@ -364,22 +366,20 @@ async def test_eventlist_schema(db, pydantic_setup):
                     "event_id",
                     "name",
                     "tournament",
-                    "reporter",
                     "participants",
                     "modified",
                     "token",
-                    "address",
                 ],
                 "title": "Event",
                 "type": "object",
             },
-            "Address_e4rhju_leaf": {
+            "Address_zwygvk_leaf": {
                 "additionalProperties": False,
                 "properties": {
                     "city": {"maxLength": 64, "title": "City", "type": "string"},
                     "street": {"maxLength": 128, "title": "Street", "type": "string"},
                     "m2mwitho2opks": {
-                        "items": {"$ref": "#/$defs/M2mWithO2oPk_leajz6_leaf"},
+                        "items": {"$ref": "#/$defs/M2mWithO2oPk_zpacbp_leaf"},
                         "title": "M2Mwitho2Opks",
                         "type": "array",
                     },
@@ -394,7 +394,7 @@ async def test_eventlist_schema(db, pydantic_setup):
                 "title": "Address",
                 "type": "object",
             },
-            "M2mWithO2oPk_leajz6_leaf": {
+            "M2mWithO2oPk_zpacbp_leaf": {
                 "additionalProperties": False,
                 "properties": {
                     "id": {
@@ -409,7 +409,7 @@ async def test_eventlist_schema(db, pydantic_setup):
                 "title": "M2mWithO2oPk",
                 "type": "object",
             },
-            "Reporter_fgnv33_leaf": {
+            "Reporter_ifqfo2_leaf": {
                 "additionalProperties": False,
                 "description": "Whom is assigned as the reporter",
                 "properties": {
@@ -425,7 +425,7 @@ async def test_eventlist_schema(db, pydantic_setup):
                 "title": "Reporter",
                 "type": "object",
             },
-            "Team_ip4pg6_leaf": {
+            "Team_fcszy2_leaf": {
                 "additionalProperties": False,
                 "description": "Team that is a playing",
                 "properties": {
@@ -454,7 +454,7 @@ async def test_eventlist_schema(db, pydantic_setup):
                 "title": "Team",
                 "type": "object",
             },
-            "Tournament_5y7e7j_leaf": {
+            "Tournament_zh4alg_leaf": {
                 "additionalProperties": False,
                 "properties": {
                     "id": {
@@ -483,7 +483,7 @@ async def test_eventlist_schema(db, pydantic_setup):
             },
         },
         "description": "Events on the calendar",
-        "items": {"$ref": "#/$defs/Event_mfxmwb"},
+        "items": {"$ref": "#/$defs/Event_bx6qaa"},
         "title": "Event_list",
         "type": "array",
     }
@@ -494,7 +494,7 @@ async def test_address_schema(db, pydantic_setup):
     Address_Pydantic = pydantic_setup["Address_Pydantic"]
     assert Address_Pydantic.model_json_schema() == {
         "$defs": {
-            "Event_zvunzw_leaf": {
+            "Event_lkfyxk_leaf": {
                 "additionalProperties": False,
                 "description": "Events on the calendar",
                 "properties": {
@@ -506,19 +506,20 @@ async def test_address_schema(db, pydantic_setup):
                     },
                     "name": {"description": "The name", "title": "Name", "type": "string"},
                     "tournament": {
-                        "$ref": "#/$defs/Tournament_5y7e7j_leaf",
+                        "$ref": "#/$defs/Tournament_zh4alg_leaf",
                         "description": "What tournaments is a happenin'",
                     },
                     "reporter": {
                         "anyOf": [
-                            {"$ref": "#/$defs/Reporter_fgnv33_leaf"},
+                            {"$ref": "#/$defs/Reporter_ifqfo2_leaf"},
                             {"type": "null"},
                         ],
+                        "default": None,
                         "nullable": True,
                         "title": "Reporter",
                     },
                     "participants": {
-                        "items": {"$ref": "#/$defs/Team_ip4pg6_leaf"},
+                        "items": {"$ref": "#/$defs/Team_fcszy2_leaf"},
                         "title": "Participants",
                         "type": "array",
                     },
@@ -550,7 +551,6 @@ async def test_address_schema(db, pydantic_setup):
                     "event_id",
                     "name",
                     "tournament",
-                    "reporter",
                     "participants",
                     "modified",
                     "token",
@@ -558,7 +558,7 @@ async def test_address_schema(db, pydantic_setup):
                 "title": "Event",
                 "type": "object",
             },
-            "M2mWithO2oPk_leajz6_leaf": {
+            "M2mWithO2oPk_zpacbp_leaf": {
                 "additionalProperties": False,
                 "properties": {
                     "id": {
@@ -573,7 +573,7 @@ async def test_address_schema(db, pydantic_setup):
                 "title": "M2mWithO2oPk",
                 "type": "object",
             },
-            "Reporter_fgnv33_leaf": {
+            "Reporter_ifqfo2_leaf": {
                 "additionalProperties": False,
                 "description": "Whom is assigned as the reporter",
                 "properties": {
@@ -589,7 +589,7 @@ async def test_address_schema(db, pydantic_setup):
                 "title": "Reporter",
                 "type": "object",
             },
-            "Team_ip4pg6_leaf": {
+            "Team_fcszy2_leaf": {
                 "additionalProperties": False,
                 "description": "Team that is a playing",
                 "properties": {
@@ -618,7 +618,7 @@ async def test_address_schema(db, pydantic_setup):
                 "title": "Team",
                 "type": "object",
             },
-            "Tournament_5y7e7j_leaf": {
+            "Tournament_zh4alg_leaf": {
                 "additionalProperties": False,
                 "properties": {
                     "id": {
@@ -651,11 +651,11 @@ async def test_address_schema(db, pydantic_setup):
             "city": {"maxLength": 64, "title": "City", "type": "string"},
             "street": {"maxLength": 128, "title": "Street", "type": "string"},
             "m2mwitho2opks": {
-                "items": {"$ref": "#/$defs/M2mWithO2oPk_leajz6_leaf"},
+                "items": {"$ref": "#/$defs/M2mWithO2oPk_zpacbp_leaf"},
                 "title": "M2Mwitho2Opks",
                 "type": "array",
             },
-            "event": {"$ref": "#/$defs/Event_zvunzw_leaf"},
+            "event": {"$ref": "#/$defs/Event_lkfyxk_leaf"},
             "event_id": {
                 "maximum": 9223372036854775807,
                 "minimum": -9223372036854775808,
@@ -674,7 +674,7 @@ async def test_tournament_schema(db, pydantic_setup):
     Tournament_Pydantic = pydantic_setup["Tournament_Pydantic"]
     assert Tournament_Pydantic.model_json_schema() == {
         "$defs": {
-            "Event_ln6p2q_leaf": {
+            "Event_xsdgtc_leaf": {
                 "additionalProperties": False,
                 "description": "Events on the calendar",
                 "properties": {
@@ -687,14 +687,15 @@ async def test_tournament_schema(db, pydantic_setup):
                     "name": {"description": "The name", "title": "Name", "type": "string"},
                     "reporter": {
                         "anyOf": [
-                            {"$ref": "#/$defs/Reporter_fgnv33_leaf"},
+                            {"$ref": "#/$defs/Reporter_ifqfo2_leaf"},
                             {"type": "null"},
                         ],
+                        "default": None,
                         "nullable": True,
                         "title": "Reporter",
                     },
                     "participants": {
-                        "items": {"$ref": "#/$defs/Team_ip4pg6_leaf"},
+                        "items": {"$ref": "#/$defs/Team_fcszy2_leaf"},
                         "title": "Participants",
                         "type": "array",
                     },
@@ -723,9 +724,10 @@ async def test_tournament_schema(db, pydantic_setup):
                     },
                     "address": {
                         "anyOf": [
-                            {"$ref": "#/$defs/Address_e4rhju_leaf"},
+                            {"$ref": "#/$defs/Address_zwygvk_leaf"},
                             {"type": "null"},
                         ],
+                        "default": None,
                         "nullable": True,
                         "title": "Address",
                     },
@@ -733,22 +735,20 @@ async def test_tournament_schema(db, pydantic_setup):
                 "required": [
                     "event_id",
                     "name",
-                    "reporter",
                     "participants",
                     "modified",
                     "token",
-                    "address",
                 ],
                 "title": "Event",
                 "type": "object",
             },
-            "Address_e4rhju_leaf": {
+            "Address_zwygvk_leaf": {
                 "additionalProperties": False,
                 "properties": {
                     "city": {"maxLength": 64, "title": "City", "type": "string"},
                     "street": {"maxLength": 128, "title": "Street", "type": "string"},
                     "m2mwitho2opks": {
-                        "items": {"$ref": "#/$defs/M2mWithO2oPk_leajz6_leaf"},
+                        "items": {"$ref": "#/$defs/M2mWithO2oPk_zpacbp_leaf"},
                         "title": "M2Mwitho2Opks",
                         "type": "array",
                     },
@@ -763,7 +763,7 @@ async def test_tournament_schema(db, pydantic_setup):
                 "title": "Address",
                 "type": "object",
             },
-            "M2mWithO2oPk_leajz6_leaf": {
+            "M2mWithO2oPk_zpacbp_leaf": {
                 "additionalProperties": False,
                 "properties": {
                     "id": {
@@ -778,7 +778,7 @@ async def test_tournament_schema(db, pydantic_setup):
                 "title": "M2mWithO2oPk",
                 "type": "object",
             },
-            "Reporter_fgnv33_leaf": {
+            "Reporter_ifqfo2_leaf": {
                 "additionalProperties": False,
                 "description": "Whom is assigned as the reporter",
                 "properties": {
@@ -794,7 +794,7 @@ async def test_tournament_schema(db, pydantic_setup):
                 "title": "Reporter",
                 "type": "object",
             },
-            "Team_ip4pg6_leaf": {
+            "Team_fcszy2_leaf": {
                 "additionalProperties": False,
                 "description": "Team that is a playing",
                 "properties": {
@@ -842,7 +842,7 @@ async def test_tournament_schema(db, pydantic_setup):
             },
             "events": {
                 "description": "What tournaments is a happenin'",
-                "items": {"$ref": "#/$defs/Event_ln6p2q_leaf"},
+                "items": {"$ref": "#/$defs/Event_xsdgtc_leaf"},
                 "title": "Events",
                 "type": "array",
             },
@@ -858,7 +858,7 @@ async def test_team_schema(db, pydantic_setup):
     Team_Pydantic = pydantic_setup["Team_Pydantic"]
     assert Team_Pydantic.model_json_schema() == {
         "$defs": {
-            "Event_lfs4vy_leaf": {
+            "Event_xx2apk_leaf": {
                 "additionalProperties": False,
                 "description": "Events on the calendar",
                 "properties": {
@@ -870,14 +870,15 @@ async def test_team_schema(db, pydantic_setup):
                     },
                     "name": {"description": "The name", "title": "Name", "type": "string"},
                     "tournament": {
-                        "$ref": "#/$defs/Tournament_5y7e7j_leaf",
+                        "$ref": "#/$defs/Tournament_zh4alg_leaf",
                         "description": "What tournaments is a happenin'",
                     },
                     "reporter": {
                         "anyOf": [
-                            {"$ref": "#/$defs/Reporter_fgnv33_leaf"},
+                            {"$ref": "#/$defs/Reporter_ifqfo2_leaf"},
                             {"type": "null"},
                         ],
+                        "default": None,
                         "nullable": True,
                         "title": "Reporter",
                     },
@@ -906,9 +907,10 @@ async def test_team_schema(db, pydantic_setup):
                     },
                     "address": {
                         "anyOf": [
-                            {"$ref": "#/$defs/Address_e4rhju_leaf"},
+                            {"$ref": "#/$defs/Address_zwygvk_leaf"},
                             {"type": "null"},
                         ],
+                        "default": None,
                         "nullable": True,
                         "title": "Address",
                     },
@@ -917,21 +919,19 @@ async def test_team_schema(db, pydantic_setup):
                     "event_id",
                     "name",
                     "tournament",
-                    "reporter",
                     "modified",
                     "token",
-                    "address",
                 ],
                 "title": "Event",
                 "type": "object",
             },
-            "Address_e4rhju_leaf": {
+            "Address_zwygvk_leaf": {
                 "additionalProperties": False,
                 "properties": {
                     "city": {"maxLength": 64, "title": "City", "type": "string"},
                     "street": {"maxLength": 128, "title": "Street", "type": "string"},
                     "m2mwitho2opks": {
-                        "items": {"$ref": "#/$defs/M2mWithO2oPk_leajz6_leaf"},
+                        "items": {"$ref": "#/$defs/M2mWithO2oPk_zpacbp_leaf"},
                         "title": "M2Mwitho2Opks",
                         "type": "array",
                     },
@@ -946,7 +946,7 @@ async def test_team_schema(db, pydantic_setup):
                 "title": "Address",
                 "type": "object",
             },
-            "M2mWithO2oPk_leajz6_leaf": {
+            "M2mWithO2oPk_zpacbp_leaf": {
                 "additionalProperties": False,
                 "properties": {
                     "id": {
@@ -961,7 +961,7 @@ async def test_team_schema(db, pydantic_setup):
                 "title": "M2mWithO2oPk",
                 "type": "object",
             },
-            "Reporter_fgnv33_leaf": {
+            "Reporter_ifqfo2_leaf": {
                 "additionalProperties": False,
                 "description": "Whom is assigned as the reporter",
                 "properties": {
@@ -977,7 +977,7 @@ async def test_team_schema(db, pydantic_setup):
                 "title": "Reporter",
                 "type": "object",
             },
-            "Tournament_5y7e7j_leaf": {
+            "Tournament_zh4alg_leaf": {
                 "additionalProperties": False,
                 "properties": {
                     "id": {
@@ -1025,7 +1025,7 @@ async def test_team_schema(db, pydantic_setup):
                 "title": "Alias",
             },
             "events": {
-                "items": {"$ref": "#/$defs/Event_lfs4vy_leaf"},
+                "items": {"$ref": "#/$defs/Event_xx2apk_leaf"},
                 "title": "Events",
                 "type": "array",
             },
@@ -1490,7 +1490,7 @@ async def test_cycle_schema(db, pydantic_cycle_setup):
     Employee_Pydantic = pydantic_cycle_setup["Employee_Pydantic"]
     assert Employee_Pydantic.model_json_schema() == {
         "$defs": {
-            "Employee_6tkbjb_leaf": {
+            "Employee_eywjnx_leaf": {
                 "additionalProperties": False,
                 "properties": {
                     "id": {
@@ -1501,7 +1501,7 @@ async def test_cycle_schema(db, pydantic_cycle_setup):
                     },
                     "name": {"maxLength": 50, "title": "Name", "type": "string"},
                     "talks_to": {
-                        "items": {"$ref": "#/$defs/Employee_fj2ly4_leaf"},
+                        "items": {"$ref": "#/$defs/Employee_ic5xpw_leaf"},
                         "title": "Talks To",
                         "type": "array",
                     },
@@ -1519,7 +1519,7 @@ async def test_cycle_schema(db, pydantic_cycle_setup):
                         "title": "Manager Id",
                     },
                     "team_members": {
-                        "items": {"$ref": "#/$defs/Employee_fj2ly4_leaf"},
+                        "items": {"$ref": "#/$defs/Employee_ic5xpw_leaf"},
                         "title": "Team Members",
                         "type": "array",
                     },
@@ -1528,7 +1528,7 @@ async def test_cycle_schema(db, pydantic_cycle_setup):
                 "title": "Employee",
                 "type": "object",
             },
-            "Employee_fj2ly4_leaf": {
+            "Employee_ic5xpw_leaf": {
                 "additionalProperties": False,
                 "properties": {
                     "id": {
@@ -1567,7 +1567,7 @@ async def test_cycle_schema(db, pydantic_cycle_setup):
             },
             "name": {"maxLength": 50, "title": "Name", "type": "string"},
             "talks_to": {
-                "items": {"$ref": "#/$defs/Employee_6tkbjb_leaf"},
+                "items": {"$ref": "#/$defs/Employee_eywjnx_leaf"},
                 "title": "Talks To",
                 "type": "array",
             },
@@ -1581,7 +1581,7 @@ async def test_cycle_schema(db, pydantic_cycle_setup):
                 "title": "Manager Id",
             },
             "team_members": {
-                "items": {"$ref": "#/$defs/Employee_6tkbjb_leaf"},
+                "items": {"$ref": "#/$defs/Employee_eywjnx_leaf"},
                 "title": "Team Members",
                 "type": "array",
             },
@@ -1712,7 +1712,7 @@ async def test_computed_field_schema(db, pydantic_computed_setup):
     Employee_Pydantic = pydantic_computed_setup["Employee_Pydantic"]
     assert Employee_Pydantic.model_json_schema(mode="serialization") == {
         "$defs": {
-            "Employee_fj2ly4_leaf": {
+            "Employee_ic5xpw_leaf": {
                 "additionalProperties": False,
                 "properties": {
                     "id": {
@@ -1752,7 +1752,7 @@ async def test_computed_field_schema(db, pydantic_computed_setup):
                 "title": "Employee",
                 "type": "object",
             },
-            "Employee_6tkbjb_leaf": {
+            "Employee_eywjnx_leaf": {
                 "additionalProperties": False,
                 "properties": {
                     "id": {
@@ -1763,7 +1763,7 @@ async def test_computed_field_schema(db, pydantic_computed_setup):
                     },
                     "name": {"maxLength": 50, "title": "Name", "type": "string"},
                     "talks_to": {
-                        "items": {"$ref": "#/$defs/Employee_fj2ly4_leaf"},
+                        "items": {"$ref": "#/$defs/Employee_ic5xpw_leaf"},
                         "title": "Talks To",
                         "type": "array",
                     },
@@ -1781,7 +1781,7 @@ async def test_computed_field_schema(db, pydantic_computed_setup):
                         "title": "Manager Id",
                     },
                     "team_members": {
-                        "items": {"$ref": "#/$defs/Employee_fj2ly4_leaf"},
+                        "items": {"$ref": "#/$defs/Employee_ic5xpw_leaf"},
                         "title": "Team Members",
                         "type": "array",
                     },
@@ -1820,7 +1820,7 @@ async def test_computed_field_schema(db, pydantic_computed_setup):
             },
             "name": {"maxLength": 50, "title": "Name", "type": "string"},
             "talks_to": {
-                "items": {"$ref": "#/$defs/Employee_6tkbjb_leaf"},
+                "items": {"$ref": "#/$defs/Employee_eywjnx_leaf"},
                 "title": "Talks To",
                 "type": "array",
             },
@@ -1834,7 +1834,7 @@ async def test_computed_field_schema(db, pydantic_computed_setup):
                 "title": "Manager Id",
             },
             "team_members": {
-                "items": {"$ref": "#/$defs/Employee_6tkbjb_leaf"},
+                "items": {"$ref": "#/$defs/Employee_eywjnx_leaf"},
                 "title": "Team Members",
                 "type": "array",
             },
@@ -2191,3 +2191,105 @@ def test_enum(db):
         "title": "EnumFields",
         "type": "object",
     } == EnumFields_Pydantic.model_json_schema()
+
+
+def test_nullable_fk_not_required(db):
+    """Nullable FK/O2O relation fields should be optional (default=None) in the schema,
+    not marked as required. This is the fix for issue #1481."""
+    Event_Pydantic = pydantic_model_creator(Event, name="EventNullableTest")
+    schema = Event_Pydantic.model_json_schema()
+
+    # 'reporter' is a nullable FK (null=True) so it must NOT be required
+    assert "reporter" not in schema["required"]
+    reporter_prop = schema["properties"]["reporter"]
+    assert reporter_prop.get("nullable") is True
+    assert reporter_prop.get("default") is None
+
+    # 'tournament' is a non-nullable FK so it MUST be required
+    assert "tournament" in schema["required"]
+
+    # 'address' is a nullable O2O backward relation so it must NOT be required
+    assert "address" not in schema["required"]
+    address_prop = schema["properties"]["address"]
+    assert address_prop.get("nullable") is True
+    assert address_prop.get("default") is None
+
+
+# Tests for computed fields accessing relations (#1440)
+@pytest.mark.asyncio
+async def test_computed_field_excluded_relation_not_prefetched(db):
+    """Computed field accessing an excluded, non-prefetched relation.
+
+    When team_members is excluded from the Pydantic model AND not manually prefetched,
+    the wrapped function dispatches to the ORM object which raises NoValuesFetched.
+    If the user's function handles the error gracefully (like team_size does),
+    it returns a default. If it doesn't, NoValuesFetched propagates with a clear message.
+    """
+    Employee_Pydantic_NoTeam = pydantic_model_creator(
+        Employee,
+        name="Employee_NoTeam",
+        exclude=("team_members", "manager", "gets_talked_to"),
+        computed=("name_length", "team_size"),
+        allow_cycles=True,
+    )
+
+    root = await Employee.create(name="Root")
+    await Employee.create(name="Member1", manager=root)
+    await Employee.create(name="Member2", manager=root)
+
+    empp = await Employee_Pydantic_NoTeam.from_tortoise_orm(await Employee.get(name="Root"))
+    empdict = empp.model_dump()
+
+    assert "team_members" not in empdict
+    # team_size returns 0 because team_members was not prefetched and the
+    # team_size function gracefully handles NoValuesFetched
+    assert empdict["team_size"] == 0
+    assert empdict["name_length"] == 4
+
+
+@pytest.mark.asyncio
+async def test_computed_field_excluded_relation_works_with_manual_prefetch(db):
+    """Computed field accessing an excluded relation works when manually prefetched.
+
+    If the user prefetches the relation before calling from_tortoise_orm, the computed
+    field can access it on the ORM object even though it's excluded from the schema.
+    """
+    Employee_Pydantic_NoTeam = pydantic_model_creator(
+        Employee,
+        name="Employee_NoTeam2",
+        exclude=("team_members", "manager", "gets_talked_to"),
+        computed=("name_length", "team_size"),
+        allow_cycles=True,
+    )
+
+    root = await Employee.create(name="Root")
+    await Employee.create(name="Member1", manager=root)
+    await Employee.create(name="Member2", manager=root)
+
+    obj = await Employee.get(name="Root")
+    await obj.fetch_related("team_members")
+    empp = await Employee_Pydantic_NoTeam.from_tortoise_orm(obj)
+    empdict = empp.model_dump()
+
+    assert "team_members" not in empdict
+    assert empdict["team_size"] == 2
+    assert empdict["name_length"] == 4
+
+
+@pytest.mark.asyncio
+async def test_computed_field_relation_in_model(db, pydantic_cycle_setup):
+    """Computed field accessing a reverse relation that IS in the Pydantic model.
+
+    This tests the happy path where team_members is a Pydantic field AND team_size
+    accesses it via the ORM object.
+    """
+    Employee_Pydantic = pydantic_cycle_setup["Employee_Pydantic"]
+
+    empp = await Employee_Pydantic.from_tortoise_orm(await Employee.get(name="Root"))
+    empdict = empp.model_dump()
+
+    # team_members is present in the schema
+    assert "team_members" in empdict
+    # team_size correctly reports the count
+    assert empdict["team_size"] == 2
+    assert empdict["name_length"] == 4

--- a/tests/test_early_init.py
+++ b/tests/test_early_init.py
@@ -160,9 +160,12 @@ async def test_early_init():
     Tortoise.init_models(["tests.test_early_init"], "models")
 
     Event_Pydantic = pydantic_model_creator(Event)
-    assert Event_Pydantic.model_json_schema() == {
+    schema = Event_Pydantic.model_json_schema()
+    # Extract the dynamic hash from $defs key
+    tournament_def_key = [k for k in schema.get("$defs", {}) if k.startswith("Tournament_")][0]
+    assert schema == {
         "$defs": {
-            "Tournament_aapnxb_leaf": {
+            tournament_def_key: {
                 "additionalProperties": False,
                 "properties": {
                     "id": {
@@ -206,12 +209,16 @@ async def test_early_init():
                 "type": "string",
             },
             "tournament": {
-                "anyOf": [{"$ref": "#/$defs/Tournament_aapnxb_leaf"}, {"type": "null"}],
+                "anyOf": [
+                    {"$ref": f"#/$defs/{tournament_def_key}"},
+                    {"type": "null"},
+                ],
+                "default": None,
                 "nullable": True,
                 "title": "Tournament",
             },
         },
-        "required": ["id", "name", "created_at", "tournament"],
+        "required": ["id", "name", "created_at"],
         "title": "Event",
         "type": "object",
     }

--- a/tests/testmodels.py
+++ b/tests/testmodels.py
@@ -14,7 +14,7 @@ import pytz
 from pydantic import BaseModel, ConfigDict
 
 from tortoise import fields
-from tortoise.exceptions import ValidationError
+from tortoise.exceptions import NoValuesFetched, ValidationError
 from tortoise.fields import NO_ACTION
 from tortoise.indexes import Index
 from tortoise.manager import Manager
@@ -623,7 +623,7 @@ class Employee(Model):
         """
         try:
             return len(self.team_members)
-        except AttributeError:
+        except (NoValuesFetched, AttributeError):
             return 0
 
     def not_annotated(self):

--- a/tortoise/contrib/pydantic/base.py
+++ b/tortoise/contrib/pydantic/base.py
@@ -7,8 +7,6 @@ from typing import TYPE_CHECKING, Any, Union, cast, get_args, get_origin
 import pydantic
 from pydantic import BaseModel, ConfigDict, RootModel
 
-from tortoise import fields
-
 if sys.version_info >= (3, 11):  # pragma: nocoverage
     from typing import Self
 else:
@@ -41,7 +39,6 @@ def _get_fetch_fields(pydantic_class: type[PydanticModel], model_class: type[Mod
                     field_type = arg
                     break
 
-        # noinspection PyProtectedMember
         if not isinstance(field_type, type):
             continue
         if field_name in model_class._meta.fetch_fields and issubclass(field_type, PydanticModel):
@@ -52,6 +49,7 @@ def _get_fetch_fields(pydantic_class: type[PydanticModel], model_class: type[Mod
                 fetch_fields.extend([field_name + "__" + f for f in subclass_fetch_fields])
             else:
                 fetch_fields.append(field_name)
+
     return fetch_fields
 
 
@@ -65,16 +63,14 @@ class PydanticModel(BaseModel):
 
     model_config = ConfigDict(from_attributes=True)
 
-    # noinspection PyMethodParameters
-    @pydantic.field_validator("*")  # It is a classmethod!
-    def _tortoise_convert(cls, value):  # pylint: disable=E0213
-        # Computed fields
-        if callable(value):
-            return value()
-        # Convert ManyToManyRelation to list
-        if isinstance(value, (fields.ManyToManyRelation, fields.ReverseRelation)):
-            return list(value)
-        return value
+    @pydantic.model_validator(mode="wrap")
+    @classmethod
+    def _tortoise_wrap(cls, values, handler):
+        orm_obj = values if hasattr(values, "_meta") else None
+        instance = handler(values)
+        if orm_obj is not None:
+            object.__setattr__(instance, "__orm_obj__", orm_obj)
+        return instance
 
     @classmethod
     async def from_tortoise_orm(cls, obj: Model) -> Self:
@@ -97,9 +93,7 @@ class PydanticModel(BaseModel):
 
         :param obj: The Model instance you want serialized.
         """
-        # Get fields needed to fetch
         fetch_fields = _get_fetch_fields(cls, cls.model_config["orig_model"])  # type: ignore
-        # Fetch fields
         await obj.fetch_related(*fetch_fields)
         return cls.model_validate(obj)
 

--- a/tortoise/contrib/pydantic/creator.py
+++ b/tortoise/contrib/pydantic/creator.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+import functools
 import inspect
 from base64 import b32encode
-from collections.abc import MutableMapping
+from collections.abc import Iterator, MutableMapping
 from copy import copy
 from enum import Enum, IntEnum
 from hashlib import sha3_224
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, TypeAlias, cast
 
 from pydantic import ConfigDict, computed_field, create_model
 from pydantic import Field as PydanticField
@@ -26,11 +27,19 @@ from tortoise.contrib.pydantic.descriptions import (
     PydanticMetaData,
 )
 from tortoise.contrib.pydantic.utils import get_annotations
+from tortoise.exceptions import NoValuesFetched
 from tortoise.fields import Field, JSONField
 from tortoise.fields.data import CharEnumFieldInstance, IntEnumFieldInstance
 
 if TYPE_CHECKING:  # pragma: nocoverage
     from tortoise.models import Model
+
+# Type alias for a single entry in the recursion stack: (model_class, field_name, max_recursion)
+StackEntry: TypeAlias = tuple["type[Model]", str, int]
+
+# Type alias for property values stored in _properties.
+# Regular fields are stored as (type, FieldInfo) tuples; computed fields as decorator instances.
+PropertyValue: TypeAlias = "tuple[type, Any] | Any"
 
 _MODEL_INDEX: dict[str, type[PydanticModel]] = {}
 """
@@ -53,55 +62,8 @@ def _cleandoc(obj: Any) -> str:
     return _br_it(inspect.cleandoc(obj.__doc__ or ""))
 
 
-def _pydantic_recursion_protector(
-    cls: type[Model],
-    *,
-    stack: tuple,
-    exclude: tuple[str, ...] = (),
-    include: tuple[str, ...] = (),
-    computed: tuple[str, ...] = (),
-    name=None,
-    allow_cycles: bool = False,
-    sort_alphabetically: bool | None = None,
-) -> type[PydanticModel] | None:
-    """
-    It is an inner function to protect pydantic model creator against cyclic recursion
-    """
-    if not allow_cycles and cls in (c[0] for c in stack[:-1]):
-        return None
-
-    caller_fname = stack[0][1]
-    prop_path = [caller_fname]  # It stores the fields in the hierarchy
-    level = 1
-    for _, parent_fname, parent_max_recursion in stack[1:]:
-        # Check recursion level
-        prop_path.insert(0, parent_fname)
-        if level >= parent_max_recursion:
-            # This is too verbose, Do we even need a way of reporting truncated models?
-            # tortoise.logger.warning(
-            #     "Recursion level %i has reached for model %s",
-            #     level,
-            #     parent_cls.__qualname__ + "." + ".".join(prop_path),
-            # )
-            return None
-
-        level += 1
-    pmc = PydanticModelCreator(
-        cls,
-        exclude=exclude,
-        include=include,
-        computed=computed,
-        name=name,
-        _stack=stack,
-        allow_cycles=allow_cycles,
-        sort_alphabetically=sort_alphabetically,
-        _as_submodel=True,
-    )
-    return pmc.create_pydantic_model()
-
-
 class FieldMap(MutableMapping[str, Field | ComputedFieldDescription]):
-    def __init__(self, meta: PydanticMetaData, pk_field: Field | None = None):
+    def __init__(self, meta: PydanticMetaData, pk_field: Field | None = None) -> None:
         self._field_map: dict[str, Field | ComputedFieldDescription] = {}
         self.pk_raw_field = pk_field.model_field_name if pk_field is not None else ""
         if pk_field:
@@ -109,19 +71,19 @@ class FieldMap(MutableMapping[str, Field | ComputedFieldDescription]):
             self.field_map_update([pk_field], meta)
         self.computed_fields: dict[str, ComputedFieldDescription] = {}
 
-    def __delitem__(self, __key):
+    def __delitem__(self, __key: str) -> None:
         self._field_map.__delitem__(__key)
 
-    def __getitem__(self, __key):
+    def __getitem__(self, __key: str) -> Field | ComputedFieldDescription:
         return self._field_map.__getitem__(__key)
 
-    def __len__(self):  # pragma: no-coverage
+    def __len__(self) -> int:  # pragma: no-coverage
         return self._field_map.__len__()
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[str]:
         return self._field_map.__iter__()
 
-    def __setitem__(self, __key, __value):
+    def __setitem__(self, __key: str, __value: Field | ComputedFieldDescription) -> None:
         self._field_map.__setitem__(__key, __value)
 
     def sort_alphabetically(self) -> None:
@@ -151,11 +113,10 @@ class FieldMap(MutableMapping[str, Field | ComputedFieldDescription]):
                     self.pop(raw_field, None)
             self[name] = field
 
-    def computed_field_map_update(self, computed: tuple[str, ...], cls: type[Model]):
+    def computed_field_map_update(self, computed: tuple[str, ...], cls: type[Model]) -> None:
         self._field_map.update(
             {
                 k: ComputedFieldDescription(
-                    field_type=callable,
                     function=getattr(cls, k),
                     description=None,
                 )
@@ -167,7 +128,7 @@ class FieldMap(MutableMapping[str, Field | ComputedFieldDescription]):
 def pydantic_queryset_creator(
     cls: type[Model],
     *,
-    name=None,
+    name: str | None = None,
     exclude: tuple[str, ...] = (),
     include: tuple[str, ...] = (),
     computed: tuple[str, ...] = (),
@@ -209,15 +170,12 @@ def pydantic_queryset_creator(
     )
     lname = name or f"{submodel.__name__}_list"
 
-    # Creating Pydantic class for the properties generated before
     model = create_model(
         lname,
         __base__=PydanticListModel,
         root=(list[submodel], PydanticField(default_factory=list)),  # type: ignore
     )
-    # Copy the Model docstring over
     model.__doc__ = _cleandoc(cls)
-    # The title of the model to hide the hash postfix
     model.model_config["title"] = name or f"{submodel.model_config['title']}_list"
     model.model_config["submodel"] = submodel  # type: ignore
     return model
@@ -239,13 +197,11 @@ class PydanticModelCreator:
         model_config: ConfigDict | None = None,
         validators: dict[str, Any] | None = None,
         module: str = __name__,
-        _stack: tuple = (),
+        _stack: tuple[StackEntry, ...] = (),
         _as_submodel: bool = False,
     ) -> None:
         self._cls: type[Model] = cls
-        self._stack: tuple[tuple[type[Model], str, int], ...] = (
-            _stack  # ((type[Model], field_name, max_recursion),)
-        )
+        self._stack: tuple[StackEntry, ...] = _stack
         self._is_default: bool = (
             exclude is None
             and include is None
@@ -294,7 +250,7 @@ class PydanticModelCreator:
 
         self._pconfig: ConfigDict
 
-        self._properties: dict[str, Any] = dict()
+        self._properties: dict[str, PropertyValue] = dict()
         self._relational_fields_index: list[tuple[str, str]] = list()
 
         self._model_description: ModelDescription = ModelDescription.from_model(cls)
@@ -310,11 +266,22 @@ class PydanticModelCreator:
         self._stack = _stack
 
     @property
-    def _hash(self):
+    def _hash(self) -> str:
         if self.__hash == "":
+            field_info = []
+            for name, prop in self._properties.items():
+                if isinstance(prop, tuple):
+                    field_info.append(f"{name}:{prop[0]}")
+                else:
+                    field_info.append(f"{name}:computed")
             hashval = (
-                f"{self._fqname};{self._properties.keys()};{self._relational_fields_index};{self._optional};"
-                f"{self.meta.allow_cycles}"
+                f"{self._fqname};"
+                f"{field_info};"
+                f"{self._relational_fields_index};"
+                f"{self._optional};"
+                f"{self.meta.allow_cycles};"
+                f"{self._exclude_read_only};"
+                f"{self.meta.computed}"
             )
             self.__hash = (
                 b32encode(sha3_224(hashval.encode("utf-8")).digest()).decode("utf-8").lower()[:6]
@@ -377,16 +344,13 @@ class PydanticModelCreator:
         self._name, self._title = self.get_name()
 
         if self._hash in _MODEL_INDEX:
-            # there is a model exactly the same, but the name could be different
             hashed_model = _MODEL_INDEX[self._hash]
             if hashed_model.__name__ == self._name:
-                # also the same name
                 return _MODEL_INDEX[self._hash]
 
         self._pconfig = self._initialize_pconfig()
-        # Extract the computed fields
-        computed_fields = {}
-        common_fields = {}
+        computed_fields: dict[str, Any] = {}
+        common_fields: dict[str, Any] = {}
         for k, v in self._properties.items():
             if isinstance(getattr(v, "decorator_info", None), ComputedFieldInfo):
                 computed_fields[k] = v
@@ -404,11 +368,8 @@ class PydanticModelCreator:
             __validators__=self._validators,
             **common_fields,
         )
-        # Copy the Model docstring over
         model.__doc__ = _cleandoc(self._cls)
-        # Store the base class
         model.model_config["orig_model"] = self._cls  # type: ignore
-        # Store model reference so we can de-dup it later on if needed.
         _MODEL_INDEX[self._hash] = model
         return model
 
@@ -417,44 +378,45 @@ class PydanticModelCreator:
         field_name: str,
         field: Field | ComputedFieldDescription,
     ) -> None:
+        if isinstance(field, Field):
+            self._process_orm_field(field_name, field)
+        elif isinstance(field, ComputedFieldDescription):
+            self._process_computed_field_entry(field_name, field)
+
+    def _process_orm_field(self, field_name: str, field: Field) -> None:
         json_schema_extra: dict[str, Any] = {}
         fconfig: dict[str, Any] = {
             "json_schema_extra": json_schema_extra,
         }
-        field_property: Any | None = None
-        is_to_one_relation: bool = False
-        if isinstance(field, Field):
-            field_property, is_to_one_relation = self._process_normal_field(
-                field_name, field, json_schema_extra, fconfig
-            )
-            if field_property:
-                fconfig["title"] = field_name.replace("_", " ").title()
-                description = _br_it(field.docstring or field.description or "")
-                if description:
-                    fconfig["description"] = description
-                if field_name in self._optional or (
-                    field.default is not None and not callable(field.default)
+        field_property, _ = self._process_normal_field(
+            field_name, field, json_schema_extra, fconfig
+        )
+        if field_property:
+            fconfig["title"] = field_name.replace("_", " ").title()
+            description = _br_it(field.docstring or field.description or "")
+            if description:
+                fconfig["description"] = description
+            if field_name in self._optional or (
+                field.default is not None and not callable(field.default)
+            ):
+                self._properties[field_name] = (
+                    field_property,
+                    PydanticField(default=field.default, **fconfig),
+                )
+            else:
+                if json_schema_extra.get("nullable") or (
+                    self._exclude_read_only and json_schema_extra.get("readOnly")
                 ):
-                    self._properties[field_name] = (
-                        field_property,
-                        PydanticField(default=field.default, **fconfig),
-                    )
-                else:
-                    if (json_schema_extra.get("nullable") and not is_to_one_relation) or (
-                        self._exclude_read_only and json_schema_extra.get("readOnly")
-                    ):
-                        # see: https://docs.pydantic.dev/latest/migration/#required-optional-and-nullable-fields
-                        fconfig["default"] = None
-                    self._properties[field_name] = (field_property, PydanticField(**fconfig))
-        elif isinstance(field, ComputedFieldDescription):
-            field_property, is_to_one_relation = self._process_computed_field(field), False
-            if field_property:
-                comment = _cleandoc(field.function)
-                fconfig["title"] = field_name.replace("_", " ").title()
-                description = comment or _br_it(field.description or "")
-                if description:
-                    fconfig["description"] = description
-                self._properties[field_name] = field_property
+                    # see: https://docs.pydantic.dev/latest/migration/#required-optional-and-nullable-fields
+                    fconfig["default"] = None
+                self._properties[field_name] = (field_property, PydanticField(**fconfig))
+
+    def _process_computed_field_entry(
+        self, field_name: str, field: ComputedFieldDescription
+    ) -> None:
+        field_property = self._process_computed_field(field)
+        if field_property:
+            self._properties[field_name] = field_property
 
     def _process_normal_field(
         self,
@@ -537,12 +499,63 @@ class PydanticModelCreator:
     ) -> Any | None:
         func = field.function
         annotation = get_annotations(self._cls, func).get("return", None)
-        comment = _cleandoc(func)
         if annotation is not None:
+            original_func = func
+
+            @functools.wraps(original_func)
+            def wrapped_func(self_pydantic):
+                orm_obj = getattr(self_pydantic, "__orm_obj__", None)
+                if orm_obj is not None:
+                    try:
+                        return original_func(orm_obj)
+                    except NoValuesFetched:
+                        raise NoValuesFetched(
+                            f"Computed field '{original_func.__name__}' tried to access a "
+                            f"relation that has not been fetched. Either include the relation "
+                            f"in the Pydantic model so it is auto-prefetched, or call "
+                            f"fetch_related() before serialization."
+                        )
+                return original_func(self_pydantic)
+
+            comment = _cleandoc(func)
             c_f = computed_field(return_type=annotation, description=comment)
-            ret = c_f(func)
-            return ret
+            return c_f(wrapped_func)
         return None
+
+    @staticmethod
+    def _create_submodel(
+        cls: type[Model],
+        *,
+        stack: tuple[StackEntry, ...],
+        exclude: tuple[str, ...] = (),
+        include: tuple[str, ...] = (),
+        computed: tuple[str, ...] = (),
+        name: str | None = None,
+        allow_cycles: bool = False,
+        sort_alphabetically: bool | None = None,
+    ) -> type[PydanticModel] | None:
+        """Create a Pydantic submodel with recursion protection against cyclic references."""
+        if not allow_cycles and cls in (c[0] for c in stack[:-1]):
+            return None
+
+        level = 1
+        for _, _, parent_max_recursion in stack[1:]:
+            if level >= parent_max_recursion:
+                return None
+
+            level += 1
+        pmc = PydanticModelCreator(
+            cls,
+            exclude=exclude,
+            include=include,
+            computed=computed,
+            name=name,
+            _stack=stack,
+            allow_cycles=allow_cycles,
+            sort_alphabetically=sort_alphabetically,
+            _as_submodel=True,
+        )
+        return pmc.create_pydantic_model()
 
     def _get_submodel(
         self, _model: type[Model] | None, field_name: str
@@ -552,7 +565,6 @@ class PydanticModelCreator:
         if _model:
             new_stack = self._stack + ((self._cls, field_name, self.meta.max_recursion),)
 
-            # Get pydantic schema for the submodel
             prefix_len = len(field_name) + 1
 
             def get_fields_to_carry_on(field_tuple: tuple[str, ...]) -> tuple[str, ...]:
@@ -560,7 +572,7 @@ class PydanticModelCreator:
                     str(v[prefix_len:]) for v in field_tuple if v.startswith(field_name + ".")
                 )
 
-            pmodel = _pydantic_recursion_protector(
+            pmodel = self._create_submodel(
                 _model,
                 exclude=get_fields_to_carry_on(self.meta.exclude),
                 include=get_fields_to_carry_on(self.meta.include),
@@ -572,7 +584,6 @@ class PydanticModelCreator:
         else:
             pmodel = None
 
-        # If the result is None it has been excluded and we need to exclude the field
         if pmodel is None:
             self.meta.exclude += (field_name,)
 
@@ -582,7 +593,7 @@ class PydanticModelCreator:
 def pydantic_model_creator(
     cls: type[Model],
     *,
-    name=None,
+    name: str | None = None,
     exclude: tuple[str, ...] | None = None,
     include: tuple[str, ...] | None = None,
     computed: tuple[str, ...] | None = None,

--- a/tortoise/contrib/pydantic/descriptions.py
+++ b/tortoise/contrib/pydantic/descriptions.py
@@ -68,8 +68,7 @@ class ModelDescription:
 
 @dataclasses.dataclass
 class ComputedFieldDescription:
-    field_type: Any
-    function: Callable[[], Any]
+    function: Callable[..., Any]
     description: str | None
 
 

--- a/tortoise/contrib/pydantic/utils.py
+++ b/tortoise/contrib/pydantic/utils.py
@@ -9,9 +9,26 @@ if TYPE_CHECKING:  # pragma: nocoverage
 
 def get_annotations(cls: type[Model], method: Callable | None = None) -> dict[str, Any]:
     """
-    Get all annotations including base classes
+    Get all annotations including base classes.
+
+    Builds a namespace from the Tortoise apps registry so that forward references
+    (string annotations) to models defined in other files can be resolved by
+    :func:`typing.get_type_hints`.
+
     :param cls: The model class we need annotations from
     :param method: If specified, we try to get the annotations for the callable
     :return: The list of annotations
     """
-    return get_type_hints(method or cls)
+    localns: dict[str, Any] = {}
+    try:
+        from tortoise import Tortoise
+
+        if Tortoise.apps:
+            for app_models in Tortoise.apps.values():
+                localns.update(app_models)
+    except Exception:  # nosec B110
+        pass
+    try:
+        return get_type_hints(method or cls, localns=localns)
+    except Exception:
+        return getattr(method or cls, "__annotations__", {})


### PR DESCRIPTION
Issues Resolved
#1481 — Nullable FK/O2O fields incorrectly marked as required Removed the not is_to_one_relation guard in creator.py that prevented nullable to-one relations from getting default=None. Now nullable FK and O2O fields correctly generate "default": null in the Pydantic schema and are NOT in "required", matching Pydantic v2 semantics.

#1440 — Computed fields fail when accessing relations (Pydantic v2) Added model_validator(mode='wrap') to PydanticModel in base.py that stores the original ORM object as __orm_obj__ on each Pydantic instance. Computed field functions are wrapped in creator.py to dispatch calls to the ORM object instead of the Pydantic instance. If the relation hasn't been fetched, a clear NoValuesFetched error is raised: "Computed field '{name}' tried to access a relation that has not been fetched. Either include the relation in the Pydantic model so it is auto-prefetched, or call fetch_related() before serialization."

#709 / #1841 — Forward references break across files Updated get_annotations() in utils.py to build a namespace from Tortoise.apps registry and pass it to get_type_hints(). Forward references to models defined in other files now resolve correctly. Falls back to raw __annotations__ if resolution fails.

Code Quality Improvements
Removed legacy _tortoise_convert field_validator — Pydantic v2 with from_attributes=True handles relation iterables natively; replaced by model_validator(mode='wrap')
Cleaned up ComputedFieldDescription — Removed meaningless field_type=callable field
Split _process_field() into two methods — _process_orm_field() and _process_computed_field_entry() for clarity
Moved recursion protection — Converted standalone _pydantic_recursion_protector() into _create_submodel() static method on PydanticModelCreator
Improved typing — Added StackEntry and PropertyValue TypeAliases, fixed ComputedFieldDescription.function type from Callable[[], Any] to Callable[..., Any]
Strengthened hash-based model caching — Hash now includes field types, exclude_read_only, and meta.computed to prevent collisions