### PR TITLE
Fix pydantic_model_creator incorrectly marking fields as Optional

### DIFF
--- a/tests/contrib/test_pydantic.py
+++ b/tests/contrib/test_pydantic.py
@@ -262,7 +262,7 @@ async def test_event_schema(db, pydantic_setup):
                 "title": "Modified",
                 "type": "string",
             },
-            "token": {"anyOf": [{"type": "string"}, {"type": "null"}], "title": "Token"},
+            "token": {"title": "Token", "type": "string"},
             "alias": {
                 "anyOf": [
                     {"maximum": 2147483647, "minimum": -2147483648, "type": "integer"},
@@ -300,7 +300,7 @@ async def test_eventlist_schema(db, pydantic_setup):
     Event_Pydantic_List = pydantic_setup["Event_Pydantic_List"]
     assert Event_Pydantic_List.model_json_schema() == {
         "$defs": {
-            "Event_bx6qaa": {
+            "Event_rgfzbr": {
                 "additionalProperties": False,
                 "description": "Events on the calendar",
                 "properties": {
@@ -336,8 +336,8 @@ async def test_eventlist_schema(db, pydantic_setup):
                         "type": "string",
                     },
                     "token": {
-                        "anyOf": [{"type": "string"}, {"type": "null"}],
                         "title": "Token",
+                        "type": "string",
                     },
                     "alias": {
                         "anyOf": [
@@ -483,7 +483,7 @@ async def test_eventlist_schema(db, pydantic_setup):
             },
         },
         "description": "Events on the calendar",
-        "items": {"$ref": "#/$defs/Event_bx6qaa"},
+        "items": {"$ref": "#/$defs/Event_rgfzbr"},
         "title": "Event_list",
         "type": "array",
     }
@@ -494,7 +494,7 @@ async def test_address_schema(db, pydantic_setup):
     Address_Pydantic = pydantic_setup["Address_Pydantic"]
     assert Address_Pydantic.model_json_schema() == {
         "$defs": {
-            "Event_lkfyxk_leaf": {
+            "Event_bhjepe_leaf": {
                 "additionalProperties": False,
                 "description": "Events on the calendar",
                 "properties": {
@@ -530,8 +530,8 @@ async def test_address_schema(db, pydantic_setup):
                         "type": "string",
                     },
                     "token": {
-                        "anyOf": [{"type": "string"}, {"type": "null"}],
                         "title": "Token",
+                        "type": "string",
                     },
                     "alias": {
                         "anyOf": [
@@ -655,7 +655,7 @@ async def test_address_schema(db, pydantic_setup):
                 "title": "M2Mwitho2Opks",
                 "type": "array",
             },
-            "event": {"$ref": "#/$defs/Event_lkfyxk_leaf"},
+            "event": {"$ref": "#/$defs/Event_bhjepe_leaf"},
             "event_id": {
                 "maximum": 9223372036854775807,
                 "minimum": -9223372036854775808,
@@ -674,7 +674,7 @@ async def test_tournament_schema(db, pydantic_setup):
     Tournament_Pydantic = pydantic_setup["Tournament_Pydantic"]
     assert Tournament_Pydantic.model_json_schema() == {
         "$defs": {
-            "Event_xsdgtc_leaf": {
+            "Event_tymecz_leaf": {
                 "additionalProperties": False,
                 "description": "Events on the calendar",
                 "properties": {
@@ -706,8 +706,8 @@ async def test_tournament_schema(db, pydantic_setup):
                         "type": "string",
                     },
                     "token": {
-                        "anyOf": [{"type": "string"}, {"type": "null"}],
                         "title": "Token",
+                        "type": "string",
                     },
                     "alias": {
                         "anyOf": [
@@ -842,7 +842,7 @@ async def test_tournament_schema(db, pydantic_setup):
             },
             "events": {
                 "description": "What tournaments is a happenin'",
-                "items": {"$ref": "#/$defs/Event_xsdgtc_leaf"},
+                "items": {"$ref": "#/$defs/Event_tymecz_leaf"},
                 "title": "Events",
                 "type": "array",
             },
@@ -858,7 +858,7 @@ async def test_team_schema(db, pydantic_setup):
     Team_Pydantic = pydantic_setup["Team_Pydantic"]
     assert Team_Pydantic.model_json_schema() == {
         "$defs": {
-            "Event_xx2apk_leaf": {
+            "Event_3zjun4_leaf": {
                 "additionalProperties": False,
                 "description": "Events on the calendar",
                 "properties": {
@@ -889,8 +889,8 @@ async def test_team_schema(db, pydantic_setup):
                         "type": "string",
                     },
                     "token": {
-                        "anyOf": [{"type": "string"}, {"type": "null"}],
                         "title": "Token",
+                        "type": "string",
                     },
                     "alias": {
                         "anyOf": [
@@ -1025,7 +1025,7 @@ async def test_team_schema(db, pydantic_setup):
                 "title": "Alias",
             },
             "events": {
-                "items": {"$ref": "#/$defs/Event_xx2apk_leaf"},
+                "items": {"$ref": "#/$defs/Event_3zjun4_leaf"},
                 "title": "Events",
                 "type": "array",
             },

--- a/tests/test_issue_1977.py
+++ b/tests/test_issue_1977.py
@@ -1,0 +1,64 @@
+"""Test for issue #1977 - pydantic_model_creator incorrectly marks fields as Optional."""
+import pytest
+from tortoise import fields
+from tortoise.contrib.pydantic import pydantic_model_creator
+from tortoise.models import Model
+
+
+class ModelWithDefaultField(Model):
+    """Model with a field that has a default value but is not nullable."""
+
+    id = fields.IntField(pk=True)
+    altitude = fields.FloatField(default=0, null=False)
+    name = fields.CharField(max_length=50)
+
+    class Meta:
+        app = "models"
+        table = "model_with_default_field"
+
+
+@pytest.mark.asyncio
+async def test_pydantic_model_with_default_not_optional(db):
+    """Test that fields with default values but null=False are not marked as Optional."""
+    # Create Pydantic schema
+    Schema = pydantic_model_creator(
+        ModelWithDefaultField,
+        name="ModelWithDefaultFieldSchema",
+    )
+
+    # Check the field annotations
+    field_info = Schema.model_fields["altitude"]
+
+    # The field should NOT be Optional (Union with None)
+    # It should just be float since it's not nullable
+    annotation = field_info.annotation
+
+    # Get the origin and args to check if it's Optional
+    import typing
+    if hasattr(typing, 'get_origin'):
+        origin = typing.get_origin(annotation)
+        args = typing.get_args(annotation)
+    else:
+        origin = getattr(annotation, '__origin__', None)
+        args = getattr(annotation, '__args__', ())
+
+    # If it's a Union type with NoneType, it's Optional
+    is_optional = (
+        origin is typing.Union and
+        type(None) in args
+    )
+
+    # This should NOT be optional - the bug makes it optional
+    assert not is_optional, (
+        f"Field 'altitude' should not be Optional. "
+        f"It has default=0 and null=False, so None should not be accepted. "
+        f"Got annotation: {annotation}"
+    )
+
+    # Test that validation rejects None
+    from pydantic import ValidationError
+    with pytest.raises(ValidationError) as exc_info:
+        Schema(id=1, altitude=None, name="test")
+
+    # Should fail on altitude field
+    assert "altitude" in str(exc_info.value)

--- a/tortoise/contrib/pydantic/creator.py
+++ b/tortoise/contrib/pydantic/creator.py
@@ -486,7 +486,7 @@ class PydanticModelCreator:
         if field.null:
             json_schema_extra["nullable"] = True
         if not field.pk and (
-            field_name in self._optional or field.default is not None or field.null
+            field_name in self._optional or field.null
         ):
             ptype = ptype | None
         if not (self._exclude_read_only and json_schema_extra.get("readOnly") is True):


### PR DESCRIPTION
## Summary
Fixes #1977 

Fields with default values but `null=False` were incorrectly marked as `Optional` in the Pydantic schema generated by `pydantic_model_creator`. This caused schema validation to accept `None` values that would later fail at the ORM level with a `ValueError`.

## Changes
- Removed the `field.default is not None` condition from the Optional check in `tortoise/contrib/pydantic/creator.py`
- Fields are now only Optional if:
  - Explicitly listed in the `optional` parameter, OR
  - Have `null=True` set on the field
- Updated test expectations to reflect correct behavior
- Added test case demonstrating the fix

## Test Plan
- Added new test `test_pydantic_model_with_default_not_optional` that verifies fields with `default=0` and `null=False` reject `None` values
- All existing pydantic tests pass with updated expectations
- Manually verified that the generated schema no longer incorrectly marks such fields as Optional

## Before
```python
# Field with default=0 and null=False
altitude = fields.FloatField(default=0, null=False)

# Generated schema INCORRECTLY allowed None
Schema.model_fields["altitude"].annotation  # Union[float, NoneType]
Schema(altitude=None)  # Accepted by Pydantic, but fails at ORM level
```

## After
```python
# Same field
altitude = fields.FloatField(default=0, null=False)

# Generated schema correctly rejects None
Schema.model_fields["altitude"].annotation  # float
Schema(altitude=None)  # Rejected by Pydantic validation
```