### PR TITLE
Fix m2m double filtering alias

### DIFF
--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -5,7 +5,9 @@ import pytest
 from tests.testmodels import (
     DateFields,
     DatetimeFields,
+    Drink,
     Event,
+    Flavor,
     IntFields,
     Reporter,
     Team,
@@ -603,3 +605,33 @@ async def test_f_annotation_custom_filter_requiring_nested_joins(db):
         pname__startswith="Fir"
     )
     assert res == [tournament]
+
+
+@pytest.mark.asyncio
+async def test_m2m_filter_multiple_relations_to_same_table(db):
+    """Two M2M relations from same model to same target should produce correct results."""
+    vanilla = await Flavor.create(name="vanilla")
+    chocolate = await Flavor.create(name="chocolate")
+    mint = await Flavor.create(name="mint")
+
+    latte = await Drink.create(name="Latte")
+    await latte.flavors.add(vanilla, chocolate)
+    await latte.toppings.add(mint)
+
+    mocha = await Drink.create(name="Mocha")
+    await mocha.flavors.add(chocolate)
+    await mocha.toppings.add(chocolate, vanilla)
+
+    # Filter on both M2M relations — different values
+    result = await Drink.filter(flavors__name="vanilla", toppings__name="mint")
+    assert len(result) == 1
+    assert result[0].name == "Latte"
+
+    # Filter on both M2M relations — same value through different relations
+    result = await Drink.filter(flavors__name="chocolate", toppings__name="chocolate")
+    assert len(result) == 1
+    assert result[0].name == "Mocha"
+
+    # Filter that should return no results
+    result = await Drink.filter(flavors__name="mint", toppings__name="vanilla")
+    assert len(result) == 0

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -2,7 +2,7 @@ import re
 
 import pytest
 
-from tests.testmodels import CharPkModel, Event, IntFields
+from tests.testmodels import CharPkModel, Drink, Event, IntFields
 from tortoise import connections
 from tortoise.backends.psycopg.client import PsycopgClient
 from tortoise.expressions import F
@@ -268,3 +268,22 @@ async def test_bulk_create_specified_pk(sql_context):
     else:
         expected = 'INSERT INTO "intfields" ("id","intnum","intnum_null") VALUES (?,?,?)'
     assert sql == expected
+
+
+def test_m2m_filter_two_relations_same_target_produces_aliased_joins(sql_context):
+    """Filtering on two M2M relations to the same target table should produce distinct aliased JOINs."""
+    db, dialect, is_psycopg = sql_context
+    sql = Drink.filter(flavors__name="vanilla", toppings__name="mint").sql()
+
+    if dialect == "mysql":
+        # MySQL uses backtick quoting
+        assert "`drink_flavor`" in sql
+        assert "`drink_topping`" in sql
+        assert "`drink__flavors`" in sql
+        assert "`drink__toppings`" in sql
+    else:
+        # Postgres and SQLite use double-quote quoting
+        assert '"drink_flavor"' in sql
+        assert '"drink_topping"' in sql
+        assert '"drink__flavors"' in sql
+        assert '"drink__toppings"' in sql

--- a/tests/testmodels.py
+++ b/tests/testmodels.py
@@ -1064,3 +1064,17 @@ class ModelWithIndexes(Model):
             Index(fields=["f3"], name="model_with_indexes__f3"),
         ]
         unique_together = [("u1", "u2")]
+
+
+class Flavor(Model):
+    id = fields.IntField(pk=True)
+    name = fields.CharField(max_length=50)
+
+
+class Drink(Model):
+    id = fields.IntField(pk=True)
+    name = fields.CharField(max_length=100)
+    flavors = fields.ManyToManyField("models.Flavor", related_name="drinks", through="drink_flavor")
+    toppings = fields.ManyToManyField(
+        "models.Flavor", related_name="topping_drinks", through="drink_topping"
+    )

--- a/tortoise/query_utils.py
+++ b/tortoise/query_utils.py
@@ -37,6 +37,7 @@ def get_joins_for_related_field(
     related_table: Table = related_field.related_model._meta.basetable
     if isinstance(related_field, ManyToManyFieldInstance):
         through_table = Table(related_field.through)
+        related_table = related_table.as_(f"{table.get_table_name()}__{related_field_name}")
         required_joins.append(
             (
                 through_table,
@@ -119,8 +120,7 @@ def resolve_nested_field(
 
         model = related_field.related_model
         related_table: Table = related_field.related_model._meta.basetable
-        if isinstance(related_field, ForeignKeyFieldInstance):
-            # Only FK's can be to same table, so we only auto-alias FK join tables
+        if isinstance(related_field, (ForeignKeyFieldInstance, ManyToManyFieldInstance)):
             related_table = related_table.as_(
                 f"{table.get_table_name()}__{iter_field.model_field_name}"
             )
@@ -141,6 +141,10 @@ def resolve_nested_field(
                 related_table = related_table.as_(
                     f"{table.get_table_name()}__{related_field.model_field_name}"
                 )
+        elif isinstance(related_field, ManyToManyFieldInstance):
+            related_table = related_table.as_(
+                f"{table.get_table_name()}__{related_field.model_field_name}"
+            )
 
         term = related_table[related_field_meta.db_pk_column]
     else:


### PR DESCRIPTION
Fixed bug where Model had 2 m2m fields to same model, so that filtering by both at the same time was improssible due to alias issues

Repacked version https://github.com/tortoise/tortoise-orm/pull/1972
Fixes issue https://github.com/tortoise/tortoise-orm/issues/1969

AI Summary:
This pull request improves support for filtering across multiple many-to-many (M2M) relationships to the same target table in the ORM. It ensures that queries involving multiple M2M relations from a single model to the same target produce correct and distinct SQL JOINs by introducing proper aliasing. The changes are validated with new tests and model definitions.

**Query building and aliasing improvements:**
* Updated `get_joins_for_related_field` and `resolve_nested_field` in `tortoise/query_utils.py` to ensure that when filtering or joining on multiple M2M relations to the same target table, the generated SQL uses distinct aliases for each join, preventing conflicts and ensuring correct query results. [[1]](diffhunk://#diff-1a219c1598b0c40816dd7d172fa60868724d90b103b66b1903216ec5f6fd66c2R40) [[2]](diffhunk://#diff-1a219c1598b0c40816dd7d172fa60868724d90b103b66b1903216ec5f6fd66c2L122-R123) [[3]](diffhunk://#diff-1a219c1598b0c40816dd7d172fa60868724d90b103b66b1903216ec5f6fd66c2R144-R147)

**Testing for M2M filtering and SQL generation:**
* Added new models `Flavor` and `Drink` to `tests/testmodels.py`, with `Drink` having two separate M2M relations to `Flavor` via `flavors` and `toppings`.
* Added a test `test_m2m_filter_multiple_relations_to_same_table` in `tests/test_filtering.py` to verify that filtering on both M2M relations returns the correct results.
* Added a test `test_m2m_filter_two_relations_same_target_produces_aliased_joins` in `tests/test_sql.py` to assert that the generated SQL contains the expected aliased JOINs for both MySQL and Postgres/SQLite dialects.

**Test imports and setup:**
* Updated test imports in `tests/test_filtering.py` and `tests/test_sql.py` to include the new `Drink` and `Flavor` models. [[1]](diffhunk://#diff-c28e5aded18e676963cc22c6cef5adb2090f64d8d95c71df30e555095479c7fbR8-R10) [[2]](diffhunk://#diff-630ef22b41ba1bef411cba565ddd2c1c10ffad3ae232afc5297f98dbdd369606L5-R5)

