### PR TITLE
fix: set global fallback default in Sanic register_tortoise

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Changelog
 Fixed
 ^^^^^
 - Type checking of None assignment to nullable fields (#2089)
+- Fix set global fallback default in Sanic register_tortoise (#2090)
 
 
 1.0.0

--- a/examples/sanic/_tests.py
+++ b/examples/sanic/_tests.py
@@ -2,7 +2,7 @@ import re
 from pathlib import Path
 
 import pytest
-from sanic_testing import TestManager
+from sanic_testing.reusable import ReusableClient
 
 try:
     import main
@@ -21,18 +21,21 @@ def anyio_backend() -> str:
 
 
 @pytest.fixture
-def app():
+def client():
     sanic_app = main.app
-    TestManager(sanic_app)
-    return sanic_app
+
+    # make register_tortoise treat this as sanic-testing (ReusableClient doesn't set this flag)
+    sanic_app._test_manager = True
+    client = ReusableClient(sanic_app)
+    with client:
+        yield client
 
 
-@pytest.mark.anyio
-async def test_basic_asgi_client(app):
-    request, response = await app.asgi_client.get("/")
+def test_basic_test_client(client):
+    request, response = client.get("/")
     assert response.status == 200
     assert b'{"users":[' in response.body
 
-    request, response = await app.asgi_client.post("/user")
+    request, response = client.post("/user")
     assert response.status == 200
     assert re.match(rb'{"user":"User \d+: New User"}$', response.body)

--- a/tortoise/contrib/sanic/__init__.py
+++ b/tortoise/contrib/sanic/__init__.py
@@ -17,6 +17,7 @@ def register_tortoise(
     db_url: str | None = None,
     modules: dict[str, Iterable[str | ModuleType]] | None = None,
     generate_schemas: bool = False,
+    _enable_global_fallback: bool = True,
 ) -> None:
     """
     Registers ``before_server_start`` and ``after_server_stop`` hooks to set-up and tear-down
@@ -81,7 +82,13 @@ def register_tortoise(
     """
 
     async def tortoise_init() -> None:
-        await Tortoise.init(config=config, config_file=config_file, db_url=db_url, modules=modules)
+        await Tortoise.init(
+            config=config,
+            config_file=config_file,
+            db_url=db_url,
+            modules=modules,
+            _enable_global_fallback=_enable_global_fallback,
+        )
         logger.info("Tortoise-ORM started, %s, %s", get_connections()._get_storage(), Tortoise.apps)  # pylint: disable=W0212
 
     if generate_schemas:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updates the Sanic integration to enable the global fallback by default when calling register_tortoise.

Without this, Sanic applications hit `RuntimeError: No TortoiseContext is currently active` when models are accessed in request context.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

