### PR TITLE
Improve QuerySet integer-indexing error guidance

### DIFF
--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -129,6 +129,20 @@ def test_slicing_negative_values(db):
         _ = IntFields.all()[:-1]
 
 
+def test_integer_indexing_not_supported(db):
+    with pytest.raises(
+        ParamsError,
+        match=(
+            r"QuerySet indices must be slices, not integers\. "
+            r"QuerySets are lazy and do not support random access\. "
+            r"Use await queryset\.first\(\), await queryset\.offset\(n\)\.first\(\), "
+            r"or await queryset\.all\(\) and index the returned list\."
+        ),
+    ):
+        # Use an index way outside reasonable bounds for the dataset, so we don't accidentally support it.
+        _ = IntFields.all()[1000]
+
+
 def test_slicing_stop_before_start(db):
     with pytest.raises(
         ParamsError,

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -554,6 +554,13 @@ class QuerySet(AwaitableQuery[MODEL]):
         or None.
         """
         if not isinstance(key, slice):
+            if isinstance(key, int):
+                raise ParamsError(
+                    "QuerySet indices must be slices, not integers. "
+                    "QuerySets are lazy and do not support random access. "
+                    "Use await queryset.first(), await queryset.offset(n).first(), "
+                    "or await queryset.all() and index the returned list."
+                )
             raise ParamsError("QuerySet indices must be slices.")
 
         if not (key.step is None or (isinstance(key.step, int) and key.step == 1)):


### PR DESCRIPTION
## Description
Add a dedicated `ParamsError` message for integer indexing on `QuerySet` and cover it with a regression test.

## Motivation and Context
`QuerySet` is lazy and supports slicing, but `queryset[5]` currently raises a generic message. This change makes that failure mode clearer and tells users how to evaluate/query for a single item correctly.

## How Has This Been Tested?
- `uv run --frozen --group test --group contrib --extra psycopg pytest -q tests/test_queryset.py`
- `uv run --frozen --group dev ruff check tests/test_queryset.py tortoise/queryset.py`

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
