### PR TITLE
Improve QuerySet integer indexing error guidance

### DIFF
--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -129,6 +129,20 @@ def test_slicing_negative_values(db):
         _ = IntFields.all()[:-1]
 
 
+def test_integer_indexing_not_supported(db):
+    with pytest.raises(
+        ParamsError,
+        match=(
+            r"QuerySet indices must be slices, not integers\. "
+            r"QuerySets are lazy and do not support random access\. "
+            r"Use await queryset\.first\(\), await queryset\.offset\(n\)\.first\(\), "
+            r"or await queryset\.all\(\) and index the returned list\."
+        ),
+    ):
+        # Use an index way outside reasonable bounds for the dataset, so we don't accidentally support it.
+        _ = IntFields.all()[1000]
+
+
 def test_slicing_stop_before_start(db):
     with pytest.raises(
         ParamsError,

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -554,6 +554,13 @@ class QuerySet(AwaitableQuery[MODEL]):
         or None.
         """
         if not isinstance(key, slice):
+            if isinstance(key, int):
+                raise ParamsError(
+                    "QuerySet indices must be slices, not integers. "
+                    "QuerySets are lazy and do not support random access. "
+                    "Use await queryset.first(), await queryset.offset(n).first(), "
+                    "or await queryset.all() and index the returned list."
+                )
             raise ParamsError("QuerySet indices must be slices.")
 
         if not (key.step is None or (isinstance(key.step, int) and key.step == 1)):


### PR DESCRIPTION
## Description
This PR improves the error guidance for invalid integer indexing on the lazy `QuerySet`.

- Adds a dedicated `ParamsError` branch in `QuerySet.__getitem__` for integer keys.
- Updates the error message to explain lazy evaluation and actionable alternatives:
  `await queryset.first()`, `await queryset.offset(n).first()`, or `await queryset.all()` and index the returned list.
- Adds `test_integer_indexing_not_supported` in `tests/test_queryset.py` to cover this behavior.

No functional change to valid slicing (`queryset[start:stop]`).

## Motivation and Context
`QuerySet` supports slicing but not list-style integer indexing.  
Before this change, users got a generic error that didn’t explain the async/lazy usage pattern clearly.  
This update makes the failure mode easier to understand and recover from.

## How Has This Been Tested?
- `uv run --frozen --group test --group contrib --extra psycopg pytest -q tests/test_queryset.py`
  - Result: `64 passed, 8 skipped`
- `uv run --frozen --group dev ruff check tests/test_queryset.py tortoise/queryset.py`
  - Result: `All checks passed`

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.