### PR TITLE
Fix UnicodeEncodeError by using UTF-8 encoding for migration files (closes #2096)

### DIFF
--- a/tortoise/migrations/writer.py
+++ b/tortoise/migrations/writer.py
@@ -263,7 +263,7 @@ class MigrationWriter:
 
     def write(self) -> Path:
         path = self.path()
-        path.write_text(self.as_string(), encoding='utf-8')
+        path.write_text(self.as_string(), encoding="utf-8")
         return path
 
     def as_string(self) -> str:

--- a/tortoise/migrations/writer.py
+++ b/tortoise/migrations/writer.py
@@ -263,7 +263,7 @@ class MigrationWriter:
 
     def write(self) -> Path:
         path = self.path()
-        path.write_text(self.as_string())
+        path.write_text(self.as_string(), encoding='utf-8')
         return path
 
     def as_string(self) -> str:

--- a/tortoise/migrations/writer.py
+++ b/tortoise/migrations/writer.py
@@ -263,7 +263,7 @@ class MigrationWriter:
 
     def write(self) -> Path:
         path = self.path()
-        path.write_text(self.as_string(), encoding="ascii")
+        path.write_text(self.as_string())
         return path
 
     def as_string(self) -> str:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR updates migration file writing to explicitly use UTF-8 encoding instead of ASCII.

Previously, migration files were written with:

```
path.write_text(self.as_string(), encoding="ascii")
```

This prevented writing non-ASCII characters and could raise:

```
UnicodeEncodeError: 'ascii' codec can't encode characters
```

The implementation now uses:

```
path.write_text(self.as_string(), encoding="utf-8")
```

------

## Motivation and Context

Fixes #2096.

Migration files may contain non-ASCII characters (e.g. verbose names, comments, or field descriptions).
 Using a hard-coded ASCII encoding makes such content impossible to write.

UTF-8 is the standard encoding for Python source files and ensures:

- Cross-platform consistency
- Deterministic migration output
- No reliance on system locale defaults

This change removes the unnecessary ASCII restriction and improves robustness.

------

## How Has This Been Tested?

Tested locally with:

- Python 3.12
- Windows 10 environment

Steps performed:

1. Created a model containing non-ASCII characters (e.g. Chinese verbose_name).
2. Ran `tortoise makemigrations`.
3. Confirmed that migration files are generated successfully.
4. Verified that no encoding errors occur.
5. Ensured existing migrations continue to work correctly.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

