### PR TITLE
Auto-recreate connection on loop change

### DIFF
--- a/docs/connections.rst
+++ b/docs/connections.rst
@@ -162,6 +162,54 @@ providing isolation between different contexts (useful for testing).
     conn3 = Tortoise.get_connection("default")
     assert conn is not conn3
 
+Event Loop Handling
+===================
+
+Some database drivers (asyncpg, aiomysql) bind their connection pools to the event loop
+that created them. If the loop changes -- for example, when using function-scoped pytest
+fixtures or Starlette's ``TestClient`` -- the old pool becomes unusable.
+
+Tortoise handles this automatically: when ``ConnectionHandler.get()`` detects that the
+current event loop differs from the one the connection was created on, it transparently
+creates a fresh connection.
+
+**In production**, a loop change usually indicates a bug (e.g., mixing sync/async code).
+A ``TortoiseLoopSwitchWarning`` is emitted so you can investigate:
+
+.. code-block:: python
+
+    import warnings
+    from tortoise.warnings import TortoiseLoopSwitchWarning
+
+    # Suppress if you know what you're doing
+    warnings.filterwarnings("ignore", category=TortoiseLoopSwitchWarning)
+
+**In tests**, ``tortoise_test_context()`` suppresses this warning automatically.
+No special configuration needed.
+
+.. list-table:: Backend Loop Binding
+   :header-rows: 1
+   :widths: 30 20 50
+
+   * - Backend
+     - Bound?
+     - Notes
+   * - asyncpg
+     - Yes
+     - Pool stores loop at creation time
+   * - aiomysql/asyncmy
+     - Yes
+     - Pool stores loop at creation time
+   * - psycopg
+     - No
+     - Uses running loop per-operation
+   * - aiosqlite
+     - Partial
+     - Grabs loop per-operation, not at creation
+   * - asyncodbc (MSSQL/Oracle)
+     - No
+     - Per-operation loop resolution
+
 API Reference
 =============
 

--- a/docs/contrib/unittest.rst
+++ b/docs/contrib/unittest.rst
@@ -123,6 +123,31 @@ For tests that require multiple database connections:
             await ctx.generate_schemas()
             yield ctx
 
+Event Loop Isolation
+====================
+
+Some backends (asyncpg, aiomysql) bind connection pools to the event loop that created
+them. ``tortoise_test_context()`` handles this transparently -- if the event loop changes
+between tests, connections are automatically recreated.
+
+This means you **don't** need ``loop_scope="session"`` or any special pytest-asyncio
+configuration. The simplest setup works:
+
+.. code-block:: toml
+
+    # pyproject.toml -- no loop_scope overrides needed
+    [tool.pytest.ini_options]
+    asyncio_mode = "auto"
+
+If you use ``TortoiseContext`` directly (without ``tortoise_test_context``), you may see
+a ``TortoiseLoopSwitchWarning`` when the loop changes. Suppress it with:
+
+.. code-block:: python
+
+    import warnings
+    from tortoise.warnings import TortoiseLoopSwitchWarning
+    warnings.filterwarnings("ignore", category=TortoiseLoopSwitchWarning)
+
 Testing Database Capabilities
 =============================
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -332,6 +332,6 @@ def test_get_reconnects_on_loop_change(mocked_create_connection, conn_handler):
     assert ret_val is fresh_conn
     assert conn_handler._storage["default"] is fresh_conn
     mocked_create_connection.assert_called_once_with("default")
-    assert len(w) == 1
-    assert issubclass(w[0].category, TortoiseLoopSwitchWarning)
-    assert "different event loop" in str(w[0].message)
+    loop_warnings = [x for x in w if issubclass(x.category, TortoiseLoopSwitchWarning)]
+    assert len(loop_warnings) == 1
+    assert "different event loop" in str(loop_warnings[0].message)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,9 +1,12 @@
+import asyncio
+import warnings
 from unittest.mock import AsyncMock, Mock, PropertyMock, call, patch
 
 import pytest
 
 from tortoise import BaseDBAsyncClient, ConfigurationError
 from tortoise.connection import ConnectionHandler
+from tortoise.warnings import TortoiseLoopSwitchWarning
 
 
 @pytest.fixture
@@ -206,9 +209,10 @@ def test_create_connection_db_info_not_str(
 
 
 def test_get_alias_present(conn_handler):
-    conn_handler._storage = {"default": "some_connection"}
+    mock_conn = Mock(_check_loop=Mock(return_value=True))
+    conn_handler._storage = {"default": mock_conn}
     ret_val = conn_handler.get("default")
-    assert ret_val == "some_connection"
+    assert ret_val is mock_conn
 
 
 @patch("tortoise.connection.ConnectionHandler._create_connection")
@@ -246,10 +250,12 @@ def test_reset(conn_handler):
 
 @patch("tortoise.connection.ConnectionHandler.db_config", new_callable=PropertyMock)
 def test_all(mocked_db_config, conn_handler):
-    conn_handler._storage = {"default": "some_conn", "other": "some_other_conn"}
+    mock_conn_1 = Mock(_check_loop=Mock(return_value=True))
+    mock_conn_2 = Mock(_check_loop=Mock(return_value=True))
+    conn_handler._storage = {"default": mock_conn_1, "other": mock_conn_2}
     mocked_db_config.return_value = {"default": {}, "other": {}}
     ret_val = conn_handler.all()
-    assert set(ret_val) == {"some_conn", "some_other_conn"}
+    assert set(ret_val) == {mock_conn_1, mock_conn_2}
 
 
 @pytest.mark.asyncio
@@ -282,3 +288,50 @@ async def test_close_all_without_discard(mocked_db_config, conn_handler):
     conn_1.close.assert_awaited_once()
     conn_2.close.assert_awaited_once()
     assert conn_handler._storage == {"default": conn_1, "other": conn_2}
+
+
+# --- Event loop validation tests ---
+
+
+@pytest.mark.asyncio
+async def test_check_loop_returns_true_when_not_bound():
+    client = Mock(spec=BaseDBAsyncClient)
+    client._bound_loop = None
+    client._check_loop = BaseDBAsyncClient._check_loop.__get__(client)
+    assert client._check_loop() is True
+
+
+@pytest.mark.asyncio
+async def test_check_loop_returns_true_on_same_loop():
+    client = Mock(spec=BaseDBAsyncClient)
+    client._bound_loop = asyncio.get_running_loop()
+    client._check_loop = BaseDBAsyncClient._check_loop.__get__(client)
+    assert client._check_loop() is True
+
+
+@pytest.mark.asyncio
+async def test_check_loop_returns_false_on_different_loop():
+    client = Mock(spec=BaseDBAsyncClient)
+    client._bound_loop = asyncio.new_event_loop()
+    client._check_loop = BaseDBAsyncClient._check_loop.__get__(client)
+    assert client._check_loop() is False
+
+
+@patch("tortoise.connection.ConnectionHandler._create_connection")
+def test_get_reconnects_on_loop_change(mocked_create_connection, conn_handler):
+    """When _check_loop() returns False, get() should warn and create a new connection."""
+    stale_conn = Mock(_check_loop=Mock(return_value=False))
+    fresh_conn = Mock(_check_loop=Mock(return_value=True))
+    mocked_create_connection.return_value = fresh_conn
+    conn_handler._storage = {"default": stale_conn}
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        ret_val = conn_handler.get("default")
+
+    assert ret_val is fresh_conn
+    assert conn_handler._storage["default"] is fresh_conn
+    mocked_create_connection.assert_called_once_with("default")
+    assert len(w) == 1
+    assert issubclass(w[0].category, TortoiseLoopSwitchWarning)
+    assert "different event loop" in str(w[0].message)

--- a/tests/test_query_api.py
+++ b/tests/test_query_api.py
@@ -278,6 +278,10 @@ async def test_execute_pypika_explicit_connection_with_multiple_configured() -> 
 
     class DummyClient:
         query_class = type("QueryClass", (), {"SQL_CONTEXT": None})
+        _bound_loop = None
+
+        def _check_loop(self) -> bool:
+            return True
 
         async def execute_query_dict_with_affected(self, query, values=None):
             return [], 0

--- a/tortoise/backends/asyncpg/client.py
+++ b/tortoise/backends/asyncpg/client.py
@@ -59,6 +59,7 @@ class AsyncpgDBClient(BasePostgresClient):
         }
         try:
             self._pool = await self.create_pool(password=self.password, **self._template)
+            await self._post_connect()
             self.log.debug("Created connection pool %s with params: %s", self._pool, self._template)
         except asyncpg.InvalidCatalogNameError as ex:
             msg = "Can't establish connection to "

--- a/tortoise/backends/base/client.py
+++ b/tortoise/backends/base/client.py
@@ -118,6 +118,7 @@ class BaseDBAsyncClient(abc.ABC):
     _connection: Any
     _parent: BaseDBAsyncClient
     _pool: Any
+    _bound_loop: asyncio.AbstractEventLoop | None = None
     connection_name: str
     query_class: type[Query] = Query
     executor_class: type[BaseExecutor] = BaseExecutor
@@ -128,6 +129,20 @@ class BaseDBAsyncClient(abc.ABC):
         self.log = db_client_logger
         self.connection_name = connection_name
         self.fetch_inserted = fetch_inserted
+
+    def _check_loop(self) -> bool:
+        """Check if the current event loop matches the one this client was created on."""
+        try:
+            current = asyncio.get_running_loop()
+        except RuntimeError:
+            return True  # No running loop — can't validate
+        if self._bound_loop is None:
+            return True  # Not yet bound (pool not created yet)
+        return self._bound_loop is current
+
+    async def _post_connect(self) -> None:
+        """Called after pool/connection is created. Records the bound loop."""
+        self._bound_loop = asyncio.get_running_loop()
 
     async def create_connection(self, with_db: bool) -> None:
         """

--- a/tortoise/backends/mysql/client.py
+++ b/tortoise/backends/mysql/client.py
@@ -140,6 +140,7 @@ class MySQLClient(BaseDBAsyncClient):
                             hours = timezone.now().utcoffset().seconds / 3600  # type: ignore
                             tz = f"{int(hours):+d}:{int((hours % 1) * 60):02d}"
                             await cursor.execute(f"SET time_zone='{tz}';")
+            await self._post_connect()
             self.log.debug("Created connection %s pool with params: %s", self._pool, self._template)
         except errors.OperationalError:
             raise DBConnectionError(f"Can't connect to MySQL server: {self._template}")

--- a/tortoise/backends/odbc/client.py
+++ b/tortoise/backends/odbc/client.py
@@ -91,6 +91,7 @@ class ODBCClient(BaseDBAsyncClient, ABC):
             self._pool = await asyncodbc.create_pool(
                 **self._template,
             )
+            await self._post_connect()
             self.log.debug("Created connection %s pool with params: %s", self._pool, self._template)
         except pyodbc.InterfaceError:
             raise DBConnectionError(f"Can't establish connection to database {self.database}")

--- a/tortoise/backends/psycopg/client.py
+++ b/tortoise/backends/psycopg/client.py
@@ -104,6 +104,7 @@ class PsycopgClient(postgres_client.BasePostgresClient):
             # Immediately test the connection because the test suite expects it to check if the
             # connection is valid.
             await self._pool.open(wait=True, timeout=extra["timeout"])
+            await self._post_connect()
             self.log.debug("Created connection pool %s with params: %s", self._pool, self._template)
         except (psycopg.errors.InvalidCatalogName, psycopg_pool.PoolTimeout):
             raise exceptions.DBConnectionError(

--- a/tortoise/backends/sqlite/client.py
+++ b/tortoise/backends/sqlite/client.py
@@ -84,6 +84,7 @@ class SqliteClient(BaseDBAsyncClient):
             for pragma, val in self.pragmas.items():
                 cursor = await self._connection.execute(f"PRAGMA {pragma}={val}")
                 await cursor.close()
+            await self._post_connect()
             self.log.debug(
                 "Created connection %s with params: filename=%s %s",
                 self._connection,

--- a/tortoise/connection.py
+++ b/tortoise/connection.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import contextvars
 import importlib
+import warnings
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -156,6 +157,11 @@ class ConnectionHandler:
         """
         Return the connection object for the given alias, creating it if needed.
 
+        If the connection's event loop has changed (e.g., in a test with a new event loop),
+        the connection is transparently replaced with a fresh one and a
+        :class:`TortoiseLoopSwitchWarning<tortoise.warnings.TortoiseLoopSwitchWarning>`
+        is emitted.
+
         Used for accessing the low-level connection object
         (:class:`BaseDBAsyncClient<tortoise.backends.base.client.BaseDBAsyncClient>`) for the
         given alias.
@@ -166,7 +172,22 @@ class ConnectionHandler:
         """
         storage = self._get_storage()
         try:
-            return storage[conn_alias]
+            conn = storage[conn_alias]
+            if not conn._check_loop():
+                from tortoise.warnings import TortoiseLoopSwitchWarning
+
+                warnings.warn(
+                    f"Tortoise connection '{conn_alias}' was created on a different "
+                    f"event loop and will be reconnected. If this is expected (e.g., "
+                    f"in tests), use tortoise_test_context() or suppress with: "
+                    f"warnings.filterwarnings('ignore', "
+                    f"category=TortoiseLoopSwitchWarning)",
+                    TortoiseLoopSwitchWarning,
+                    stacklevel=2,
+                )
+                conn = self._create_connection(conn_alias)
+                storage[conn_alias] = conn
+            return conn
         except KeyError:
             connection: BaseDBAsyncClient = self._create_connection(conn_alias)
             storage[conn_alias] = connection

--- a/tortoise/context.py
+++ b/tortoise/context.py
@@ -573,23 +573,29 @@ async def tortoise_test_context(
     Yields:
         An initialized TortoiseContext ready for use.
     """
-    ctx = TortoiseContext()
-    async with ctx:
-        config = generate_config(
-            db_url,
-            app_modules={app_label: modules},
-            connection_label=connection_label,
-            testing=True,
-        )
-        await ctx.init(
-            config=config,
-            _create_db=True,
-            use_tz=use_tz,
-            timezone=timezone,
-            routers=routers,
-        )
-        await ctx.generate_schemas(safe=False)
-        yield ctx
+    import warnings
+
+    from tortoise.warnings import TortoiseLoopSwitchWarning
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=TortoiseLoopSwitchWarning)
+        ctx = TortoiseContext()
+        async with ctx:
+            config = generate_config(
+                db_url,
+                app_modules={app_label: modules},
+                connection_label=connection_label,
+                testing=True,
+            )
+            await ctx.init(
+                config=config,
+                _create_db=True,
+                use_tz=use_tz,
+                timezone=timezone,
+                routers=routers,
+            )
+            await ctx.generate_schemas(safe=False)
+            yield ctx
 
 
 __all__ = [

--- a/tortoise/warnings.py
+++ b/tortoise/warnings.py
@@ -1,0 +1,18 @@
+class TortoiseLoopSwitchWarning(UserWarning):
+    """Emitted when a Tortoise connection detects an event loop change.
+
+    This typically means the connection pool was created on one event loop,
+    but is now being used on a different one. Tortoise will transparently
+    create a fresh connection for the new loop.
+
+    In **test environments**, this is expected (e.g., function-scoped fixtures,
+    Starlette TestClient). Use ``tortoise_test_context()`` to suppress this
+    warning automatically, or suppress it manually::
+
+        import warnings
+        from tortoise.warnings import TortoiseLoopSwitchWarning
+        warnings.filterwarnings("ignore", category=TortoiseLoopSwitchWarning)
+
+    In **production**, this warning usually indicates a bug -- investigate why
+    the event loop changed between connection creation and use.
+    """


### PR DESCRIPTION
Fixed issue that forced you to implement hacks and use session scoped fixtures in tests

Now we automatically recreate pool on loop change, which is not a problem for tests. For prod we issue warning in such case, as it indicates that something has gone wrong

AI Summary:
This pull request introduces robust handling for event loop changes in database connections, especially relevant for async backends that bind connection pools to the event loop at creation time. Now, if a connection is accessed from a different event loop than it was created on, Tortoise will automatically recreate the connection and emit a warning. This behavior is documented, tested, and can be suppressed as needed (especially in test environments). The changes also add a dedicated warning class and update backend clients to track their bound event loop.

**Event Loop Handling and Connection Safety:**

* Added a `_bound_loop` attribute and `_check_loop`/`_post_connect` methods to `BaseDBAsyncClient` and all backend clients (e.g., asyncpg, aiomysql, sqlite, psycopg, odbc). These ensure each connection knows which event loop it was created on and can verify loop consistency. (`tortoise/backends/base/client.py` [[1]](diffhunk://#diff-6bec75e94486a1001822aa9227f104b3129ce4990722cc92ef7f856a170f096cR121) [[2]](diffhunk://#diff-6bec75e94486a1001822aa9227f104b3129ce4990722cc92ef7f856a170f096cR133-R146); `tortoise/backends/asyncpg/client.py` [[3]](diffhunk://#diff-8282889a15d0959a2c2dc624757f15d846e6fcb0cd4df3c8c58e26ea60b7b743R62); `tortoise/backends/mysql/client.py` [[4]](diffhunk://#diff-0e33c641fe8013df524150e05e4826a2eedc81aa4143b69887de814069dff03bR143); `tortoise/backends/odbc/client.py` [[5]](diffhunk://#diff-d020cfe4e09771556302df9e2e8dc5b3837de8c26e11969b19752399c3e4e1e5R94); `tortoise/backends/psycopg/client.py` [[6]](diffhunk://#diff-a0e0918409d2dc40819bede82c8cb1dce8d021f3ef34005a983f863fa070c593R107); `tortoise/backends/sqlite/client.py` [[7]](diffhunk://#diff-c40bda9c1f9564f1606365c84f5e003948d6db279f2667bcd683bddd4a43690aR87)

* Modified `ConnectionHandler.get()` to check for event loop changes using `_check_loop()`. If a change is detected, a new connection is transparently created, and a `TortoiseLoopSwitchWarning` is emitted. This prevents subtle bugs when test frameworks or application code switch event loops. (`tortoise/connection.py` [[1]](diffhunk://#diff-e7081627a18c3c7d83e3354e5651cf7e0326109bf990a5909bb1dea2f819bc65R160-R164) [[2]](diffhunk://#diff-e7081627a18c3c7d83e3354e5651cf7e0326109bf990a5909bb1dea2f819bc65L169-R190)

**Testing and Warning Suppression:**

* Added comprehensive tests for event loop validation and reconnection logic, ensuring that connections are properly recreated and warnings are emitted or suppressed as appropriate. (`tests/test_connection.py` [[1]](diffhunk://#diff-5871d4c569454db5e625383975462132da0bd03d32df145d8d72d8fafd86d952R1-R9) [[2]](diffhunk://#diff-5871d4c569454db5e625383975462132da0bd03d32df145d8d72d8fafd86d952L209-R215) [[3]](diffhunk://#diff-5871d4c569454db5e625383975462132da0bd03d32df145d8d72d8fafd86d952L249-R258) [[4]](diffhunk://#diff-5871d4c569454db5e625383975462132da0bd03d32df145d8d72d8fafd86d952R291-R337); `tests/test_query_api.py` [[5]](diffhunk://#diff-87fb5a578cdb5652d24615a92a701ff1b41bd69d7274be889eacb8dfdce76749R281-R284)

* Updated `tortoise_test_context()` to automatically suppress `TortoiseLoopSwitchWarning` in test environments, simplifying test setup. (`tortoise/context.py` [tortoise/context.pyR576-R581](diffhunk://#diff-b3b38d27c7034fad740610007207f6b81f88c045084e58327e89d649f95b1f2bR576-R581))

**Documentation and Developer Guidance:**

* Expanded documentation to explain event loop binding, how Tortoise handles loop changes, the new warning, and best practices for both production and testing scenarios. Includes backend-specific notes and suppression instructions. (`docs/connections.rst` [[1]](diffhunk://#diff-22610db9239c5a71087e85ed7146da70604c52eba27747a664999729d6797076R165-R212); `docs/contrib/unittest.rst` [[2]](diffhunk://#diff-441adfab61395aa9a27bd340926d3da3494fd939c497fe46a8bfb96157e13419R126-R150)

**Warnings and Developer Experience:**

* Introduced `TortoiseLoopSwitchWarning`, a dedicated warning class with clear docstrings and usage guidance, to help developers identify and address event loop issues. (`tortoise/warnings.py` [tortoise/warnings.pyR1-R18](diffhunk://#diff-dca3e96887aa707efd540aab7ad72901a09da52fee1571e9cdc96e5d018c9c08R1-R18))

Overall, these changes make Tortoise ORM safer and more predictable in async environments, especially when dealing with test frameworks or mixed sync/async code.