### PR TITLE
Add Model.construct() method for tests

### DIFF
--- a/docs/contrib/unittest.rst
+++ b/docs/contrib/unittest.rst
@@ -148,6 +148,53 @@ a ``TortoiseLoopSwitchWarning`` when the loop changes. Suppress it with:
     from tortoise.warnings import TortoiseLoopSwitchWarning
     warnings.filterwarnings("ignore", category=TortoiseLoopSwitchWarning)
 
+Unit Testing Without a Database
+================================
+
+For testing pure business logic that reads model attributes and iterates relations
+without making queries, use ``Model.construct()`` to create model instances in memory:
+
+.. code-block:: python
+
+    from myapp.models import User, Organization, Membership
+
+    def test_user_has_active_membership():
+        org = Organization.construct(id=1, name="Corp")
+        membership = Membership.construct(
+            organization=org,
+            role="admin",
+            is_active=True,
+        )
+        user = User.construct(
+            id=1,
+            email="test@example.com",
+            memberships=[membership],
+        )
+
+        # Pure business logic -- no database needed
+        active = [m for m in user.memberships if m.is_active]
+        assert len(active) == 1
+        assert active[0].role == "admin"
+
+``construct()`` creates "detached" instances that behave like ORM-loaded objects:
+
+- Reverse FK fields (e.g., ``user.memberships``) accept lists and wrap them in
+  ``ReverseRelation``, so ``len()``, ``in``, iteration, and ``bool()`` all work.
+- M2M fields work the same way, wrapped in ``ManyToManyRelation``.
+- FK fields populate the source field automatically
+  (e.g., ``event.tournament_id`` is set from ``tournament.pk``).
+- No validation is performed -- null checks, type checks, and ``_saved_in_db``
+  guards are all skipped.
+
+.. note::
+
+    ``construct()`` requires Tortoise to be initialized (via ``tortoise_test_context``
+    or ``Tortoise.init()``) for relation fields to work, because relation metadata is
+    resolved during initialization. For simple data-only fields, it works without
+    initialization.
+
+See :meth:`tortoise.models.Model.construct` for the full API reference.
+
 Testing Database Capabilities
 =============================
 

--- a/tests/test_model_construct.py
+++ b/tests/test_model_construct.py
@@ -1,0 +1,340 @@
+"""
+Tests for Model.construct() classmethod.
+
+This method creates model instances without validation, DB checks, or FK restrictions.
+All tests use the ``db`` fixture to ensure Tortoise is initialized and _meta is fully populated.
+"""
+
+import pytest
+
+from tests.testmodels import (
+    Author,
+    Book,
+    Dest_null,
+    Event,
+    O2O_null,
+    Reporter,
+    Team,
+    Tournament,
+)
+from tortoise.fields.relational import ManyToManyRelation, ReverseRelation
+
+# ---------------------------------------------------------------------------
+# Basic data field construction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_construct_simple_fields(db):
+    instance = Tournament.construct(id=1, name="Test")
+    assert instance.id == 1
+    assert instance.name == "Test"
+    assert instance._saved_in_db is False
+
+
+@pytest.mark.asyncio
+async def test_construct_saved_in_db_flag(db):
+    instance = Tournament.construct(id=1, name="Test", _saved_in_db=True)
+    assert instance._saved_in_db is True
+
+
+@pytest.mark.asyncio
+async def test_construct_defaults_applied(db):
+    instance = Tournament.construct(name="Test")
+    # id was not provided so should default to None
+    assert instance.id is None
+
+
+@pytest.mark.asyncio
+async def test_construct_partial_and_custom_pk_flags(db):
+    instance = Tournament.construct(id=1, name="Test")
+    assert instance._partial is False
+    assert instance._custom_generated_pk is False
+
+
+# ---------------------------------------------------------------------------
+# Forward FK field construction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_construct_with_fk_object(db):
+    tournament = Tournament.construct(id=1, name="T")
+    event = Event.construct(name="E", tournament=tournament)
+    assert event.tournament is tournament
+    assert event.tournament.name == "T"
+    assert event.tournament_id == 1
+
+
+@pytest.mark.asyncio
+async def test_construct_with_fk_none(db):
+    event = Event.construct(name="E", tournament=None)
+    assert event.tournament_id is None
+
+
+@pytest.mark.asyncio
+async def test_construct_with_fk_unsaved_allowed(db):
+    """Unlike __init__, construct() does NOT check _saved_in_db on FK values."""
+    tournament = Tournament.construct(name="T")
+    # This should NOT raise even though tournament is not saved
+    event = Event.construct(name="E", tournament=tournament)
+    assert event.tournament is tournament
+
+
+@pytest.mark.asyncio
+async def test_construct_with_source_field_directly(db):
+    event = Event.construct(name="E", tournament_id=42)
+    assert event.tournament_id == 42
+
+
+# ---------------------------------------------------------------------------
+# Reverse FK (backward FK) field construction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_construct_backward_fk_as_list(db):
+    e1 = Event.construct(name="E1")
+    e2 = Event.construct(name="E2")
+    tournament = Tournament.construct(id=1, name="T", events=[e1, e2])
+    assert len(tournament.events) == 2
+    assert [e.name for e in tournament.events] == ["E1", "E2"]
+
+
+@pytest.mark.asyncio
+async def test_construct_backward_fk_is_reverse_relation(db):
+    tournament = Tournament.construct(id=1, name="T", events=[Event.construct(name="E")])
+    assert isinstance(tournament.events, ReverseRelation)
+
+
+@pytest.mark.asyncio
+async def test_construct_backward_fk_fetched(db):
+    tournament = Tournament.construct(id=1, name="T", events=[])
+    assert tournament.events._fetched is True
+
+
+@pytest.mark.asyncio
+async def test_construct_backward_fk_empty_list(db):
+    tournament = Tournament.construct(id=1, name="T", events=[])
+    assert len(tournament.events) == 0
+    assert bool(tournament.events) is False
+
+
+@pytest.mark.asyncio
+async def test_construct_backward_fk_contains(db):
+    event = Event.construct(name="E1")
+    tournament = Tournament.construct(id=1, name="T", events=[event])
+    assert event in tournament.events
+
+
+# ---------------------------------------------------------------------------
+# M2M field construction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_construct_m2m_as_list(db):
+    t1 = Team.construct(id=1, name="T1")
+    t2 = Team.construct(id=2, name="T2")
+    event = Event.construct(name="E", participants=[t1, t2])
+    assert len(event.participants) == 2
+    assert [t.name for t in event.participants] == ["T1", "T2"]
+
+
+@pytest.mark.asyncio
+async def test_construct_m2m_is_m2m_relation(db):
+    event = Event.construct(name="E", participants=[Team.construct(name="T")])
+    assert isinstance(event.participants, ManyToManyRelation)
+
+
+@pytest.mark.asyncio
+async def test_construct_m2m_fetched(db):
+    event = Event.construct(name="E", participants=[])
+    assert event.participants._fetched is True
+
+
+@pytest.mark.asyncio
+async def test_construct_m2m_empty_list(db):
+    event = Event.construct(name="E", participants=[])
+    assert len(event.participants) == 0
+
+
+# ---------------------------------------------------------------------------
+# Backward O2O field construction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_construct_backward_o2o(db):
+    """Dest_null has backward O2O 'address_null' from O2O_null."""
+    o2o_instance = O2O_null.construct(name="test_o2o")
+    dest = Dest_null.construct(name="dest", address_null=o2o_instance)
+    assert dest.address_null is o2o_instance
+    assert dest.address_null.name == "test_o2o"
+
+
+# ---------------------------------------------------------------------------
+# Forward O2O field construction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_construct_forward_o2o(db):
+    """Address has a forward O2O field 'event' pointing to Event."""
+    from tests.testmodels import Address
+
+    event = Event.construct(event_id=10, name="E")
+    address = Address.construct(city="NYC", street="5th Ave", event=event)
+    assert address.event is event
+    assert address.event_id == 10
+
+
+# ---------------------------------------------------------------------------
+# Default values
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_construct_callable_default(db):
+    """Event has token field with default=generate_token (callable)."""
+    event = Event.construct(name="E")
+    assert event.token is not None
+    assert isinstance(event.token, str)
+    assert len(event.token) > 0
+
+
+@pytest.mark.asyncio
+async def test_construct_none_default(db):
+    """Fields without explicit defaults should get None."""
+    event = Event.construct(name="E")
+    # alias is IntField(null=True) with no explicit default
+    assert event.alias is None
+
+
+@pytest.mark.asyncio
+async def test_construct_unprovided_relation_fields_no_default(db):
+    """Backward FK/M2M fields not provided should not raise errors.
+    They are lazily created by the property getter."""
+    tournament = Tournament.construct(name="T")
+    # Accessing the events reverse FK should create a lazy ReverseRelation
+    events = tournament.events
+    assert isinstance(events, ReverseRelation)
+
+
+# ---------------------------------------------------------------------------
+# No validation enforcement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_construct_no_null_validation(db):
+    """Unlike __init__, construct() should NOT raise ValueError for null in non-nullable fields."""
+    # Event.name is a non-nullable TextField
+    event = Event.construct(name=None)
+    assert event.name is None
+
+
+@pytest.mark.asyncio
+async def test_construct_no_fk_saved_check(db):
+    """construct() should accept unsaved FK objects without raising."""
+    tournament = Tournament.construct(name="Unsaved")
+    assert tournament._saved_in_db is False
+    event = Event.construct(name="E", tournament=tournament)
+    assert event.tournament is tournament
+
+
+# ---------------------------------------------------------------------------
+# Without Tortoise initialization (no db fixture)
+# ---------------------------------------------------------------------------
+
+
+def test_construct_simple_fields_without_init():
+    """Simple data fields should work without Tortoise.init() / db fixture."""
+    instance = Tournament.construct(id=1, name="Test")
+    assert instance.id == 1
+    assert instance.name == "Test"
+    assert instance._saved_in_db is False
+    assert instance.pk == 1
+    assert repr(instance) == "<Tournament: 1>"
+    assert str(instance) == "Test"
+
+
+def test_construct_unknown_kwargs_without_init():
+    """Unknown kwargs should work without initialization."""
+    instance = Tournament.construct(name="T", custom_attr="hello")
+    assert instance.custom_attr == "hello"
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_construct_pk_accessible(db):
+    assert Tournament.construct(id=5, name="T").pk == 5
+
+
+@pytest.mark.asyncio
+async def test_construct_repr(db):
+    instance = Tournament.construct(id=5, name="T")
+    assert repr(instance) == "<Tournament: 5>"
+
+
+@pytest.mark.asyncio
+async def test_construct_str(db):
+    instance = Tournament.construct(name="MyTournament")
+    assert str(instance) == "MyTournament"
+
+
+@pytest.mark.asyncio
+async def test_construct_unknown_kwargs_stored(db):
+    """Unknown kwargs should be stored as instance attributes (no validation)."""
+    instance = Tournament.construct(name="T", nonexistent=42)
+    assert instance.nonexistent == 42
+
+
+@pytest.mark.asyncio
+async def test_construct_fk_source_field_not_overwritten_by_defaults(db):
+    """When tournament=obj is passed, tournament_id should not be overwritten to None by defaults."""
+    tournament = Tournament.construct(id=7, name="T")
+    event = Event.construct(name="E", tournament=tournament)
+    assert event.tournament_id == 7
+
+
+@pytest.mark.asyncio
+async def test_construct_nullable_fk(db):
+    """Nullable FK field set to None should work."""
+    event = Event.construct(name="E", reporter=None)
+    assert event.reporter_id is None
+
+
+@pytest.mark.asyncio
+async def test_construct_nullable_fk_with_object(db):
+    """Nullable FK field set to an object should work."""
+    reporter = Reporter.construct(id=1, name="R")
+    event = Event.construct(name="E", reporter=reporter)
+    assert event.reporter is reporter
+    assert event.reporter_id == 1
+
+
+@pytest.mark.asyncio
+async def test_construct_multiple_fks(db):
+    """Event has both tournament (required FK) and reporter (nullable FK)."""
+    tournament = Tournament.construct(id=1, name="T")
+    reporter = Reporter.construct(id=2, name="R")
+    event = Event.construct(name="E", tournament=tournament, reporter=reporter)
+    assert event.tournament is tournament
+    assert event.tournament_id == 1
+    assert event.reporter is reporter
+    assert event.reporter_id == 2
+
+
+@pytest.mark.asyncio
+async def test_construct_book_with_author_fk(db):
+    """Book has an FK to Author."""
+    author = Author.construct(id=1, name="Author")
+    book = Book.construct(name="Book", author=author, rating=4.5)
+    assert book.author is author
+    assert book.author_id == 1
+    assert book.rating == 4.5

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -920,6 +920,125 @@ class Model(metaclass=ModelMeta):
         obj._saved_in_db = False
         return obj
 
+    @classmethod
+    def construct(cls: type[MODEL], _saved_in_db: bool = False, **kwargs: Any) -> MODEL:
+        """
+        Create a model instance without validation, DB checks, or FK restrictions.
+
+        This creates a "detached" instance that has the right shape for reading
+        attributes and iterating relations, but is not part of the ORM lifecycle.
+        Useful for unit testing and serialization without a database connection.
+
+        Unlike ``__init__``, this method:
+        - Does NOT validate field values (nullability, type checks)
+        - Does NOT require FK objects to be saved to the database
+        - Does NOT prevent setting backward FK, backward O2O, or M2M fields
+        - Does NOT call ``to_python_value`` on data fields
+        - Skips async defaults (sets them to ``None``)
+
+        Backward FK and M2M fields are wrapped in ``ReverseRelation`` and
+        ``ManyToManyRelation`` respectively with ``_fetched=True`` so that
+        iteration, ``len()``, ``in``, and ``bool()`` work without raising
+        ``NoValuesFetched``.
+
+        Example::
+
+            tournament = Tournament.construct(id=1, name="Test")
+            event = Event.construct(
+                name="Game",
+                tournament=tournament,
+                participants=[
+                    Team.construct(id=1, name="Team A"),
+                    Team.construct(id=2, name="Team B"),
+                ],
+            )
+            assert event.tournament.name == "Test"
+            assert event.tournament_id == 1
+            assert len(event.participants) == 2
+
+        :param _saved_in_db: Whether to mark the instance as saved in DB.
+            Defaults to ``False``.
+        :param kwargs: Field values to set on the instance.
+        :return: A new model instance with the given field values.
+        """
+        self = cls.__new__(cls)
+        meta = self._meta
+        _setattr = object.__setattr__
+
+        _setattr(self, "_partial", False)
+        _setattr(self, "_saved_in_db", _saved_in_db)
+        _setattr(self, "_custom_generated_pk", False)
+        _setattr(self, "_await_when_save", {})
+
+        # Track source fields that are auto-populated from FK/O2O objects
+        # so that the default-setting loop doesn't overwrite them with None.
+        populated_source_fields: set[str] = set()
+
+        for key, value in kwargs.items():
+            if key in meta.backward_fk_fields:
+                # Backward FK: wrap in ReverseRelation with _fetched=True
+                backward_fk: BackwardFKRelation = meta.fields_map[key]  # type: ignore
+                rel = ReverseRelation(
+                    backward_fk.related_model,
+                    backward_fk.relation_field,
+                    self,
+                    backward_fk.to_field_instance.model_field_name,
+                )
+                rel._fetched = True
+                rel.related_objects = list(value)
+                _setattr(self, f"_{key}", rel)
+            elif key in meta.m2m_fields:
+                # M2M: wrap in ManyToManyRelation with _fetched=True
+                field_object: ManyToManyFieldInstance = meta.fields_map[key]  # type: ignore
+                m2m_rel = ManyToManyRelation(self, field_object)
+                m2m_rel._fetched = True
+                m2m_rel.related_objects = list(value)
+                _setattr(self, f"_{key}", m2m_rel)
+            elif key in meta.backward_o2o_fields:
+                # Backward O2O: store at _{key} for property getter
+                _setattr(self, f"_{key}", value)
+            elif key in meta.fk_fields or key in meta.o2o_fields:
+                # FK/O2O: store at _{key} for property getter, also set source field
+                _setattr(self, f"_{key}", value)
+                fk_field = meta.fields_map[key]
+                if (
+                    hasattr(fk_field, "to_field_instance")
+                    and fk_field.to_field_instance is not None
+                ):
+                    source_field = fk_field.source_field
+                    if value is not None:
+                        _setattr(
+                            self,
+                            source_field,
+                            getattr(value, fk_field.to_field_instance.model_field_name, None),
+                        )
+                    else:
+                        _setattr(self, source_field, None)
+                    populated_source_fields.add(source_field)
+            else:
+                # Data fields, source fields, or unknown fields: store directly
+                _setattr(self, key, value)
+
+        # Set defaults for unprovided non-relational fields
+        for key in meta.fields.difference(kwargs.keys()):
+            if key in meta.fetch_fields:
+                continue
+            if key in populated_source_fields:
+                continue
+            field_object = meta.fields_map[key]
+            field_default = field_object.default
+            if inspect.iscoroutinefunction(field_default):
+                # Async defaults are skipped in construct() since it is synchronous
+                _setattr(self, key, None)
+            elif callable(field_default):
+                _setattr(self, key, field_default())
+            elif field_default is not None:
+                _setattr(self, key, field_default)
+            else:
+                _setattr(self, key, None)
+
+        return self
+
     def update_from_dict(self: MODEL, data: dict) -> MODEL:
         """
         Updates the current model with the provided dict.

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -1006,15 +1006,16 @@ class Model(metaclass=ModelMeta):
                     and fk_field.to_field_instance is not None
                 ):
                     source_field = fk_field.source_field
-                    if value is not None:
-                        _setattr(
-                            self,
-                            source_field,
-                            getattr(value, fk_field.to_field_instance.model_field_name, None),
-                        )
-                    else:
-                        _setattr(self, source_field, None)
-                    populated_source_fields.add(source_field)
+                    if source_field is not None:
+                        if value is not None:
+                            _setattr(
+                                self,
+                                source_field,
+                                getattr(value, fk_field.to_field_instance.model_field_name, None),
+                            )
+                        else:
+                            _setattr(self, source_field, None)
+                        populated_source_fields.add(source_field)
             else:
                 # Data fields, source fields, or unknown fields: store directly
                 _setattr(self, key, value)
@@ -1025,8 +1026,8 @@ class Model(metaclass=ModelMeta):
                 continue
             if key in populated_source_fields:
                 continue
-            field_object = meta.fields_map[key]
-            field_default = field_object.default
+            default_field = meta.fields_map[key]
+            field_default = default_field.default
             if inspect.iscoroutinefunction(field_default):
                 # Async defaults are skipped in construct() since it is synchronous
                 _setattr(self, key, None)


### PR DESCRIPTION
Added new method to Model, allowing construction of objects without validations and constraints, for usage in tests without db