### PR TITLE
Introduce SqlDefault for using expression as db_default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,19 @@ Changelog
 1.1
 ===
 
+1.1.1
+-----
+
+Added
+^^^^^
+- **``SqlDefault`` and ``Now`` expressions for ``db_default``** — use ``db_default=SqlDefault("...")`` to emit raw SQL expressions (e.g. ``CURRENT_TIMESTAMP``) as database defaults. ``Now()`` is a convenience shorthand for ``SqlDefault("CURRENT_TIMESTAMP")``. (#2104)
+
+
+Changed
+^^^^^^^
+- ``Field(default=...)`` and ``auto_now`` / ``auto_now_add`` no longer emits a ``DEFAULT`` clause in ``generate_schemas()``. The ``default`` parameter is Python-only; use ``db_default`` for database-level defaults. This aligns ``generate_schemas()`` with migrations, which don't emitted ``DEFAULT`` for ``default=``. (#2104)
+
+
 1.1.0
 -----
 

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -49,6 +49,12 @@ Relational Fields
     :members: ForeignKeyField, OneToOneField, ManyToManyField
     :exclude-members: to_db_value, to_python_value
 
+DB Default Expressions
+----------------------
+
+.. automodule:: tortoise.fields.db_defaults
+    :members:
+
 DB Specific Fields
 ------------------
 

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -71,7 +71,18 @@ Every model should be derived from ``Model`` or its subclasses. Custom ``Model``
 This model will not affect the schema, but it will be available for inheritance.
 
 
-Further we have field ``fields.DatetimeField(auto_now=True)``. Options ``auto_now`` and ``auto_now_add`` work like Django's options.
+Further we have field ``fields.DatetimeField(auto_now=True)``. Options ``auto_now`` and ``auto_now_add`` work like Django's options — they are handled purely in Python and do **not** add a ``DEFAULT`` clause to the database schema. If you need a database-level default timestamp, use ``db_default``:
+
+.. code-block:: python3
+
+    from tortoise.fields import DatetimeField, Now
+
+    class MyModel(Model):
+        # Python-only: value set by ORM on save, no DB DEFAULT
+        modified = DatetimeField(auto_now=True)
+
+        # DB-level: emits DEFAULT CURRENT_TIMESTAMP in the schema
+        created_at = DatetimeField(db_default=Now())
 
 Use of ``__models__``
 ---------------------

--- a/examples/comprehensive_migrations_project/migrations/0021_add_sql_default_expressions.py
+++ b/examples/comprehensive_migrations_project/migrations/0021_add_sql_default_expressions.py
@@ -1,0 +1,24 @@
+from tortoise import fields, migrations
+from tortoise.fields.db_defaults import Now, SqlDefault
+from tortoise.migrations import operations as ops
+
+
+class Migration(migrations.Migration):
+    dependencies = [("erp", "0020_drop_db_default")]
+
+    initial = False
+
+    operations = [
+        ops.AlterField(
+            model_name="Product",
+            name="created_at",
+            field=fields.DatetimeField(db_default=Now(), auto_now=False, auto_now_add=False),
+        ),
+        ops.AddField(
+            model_name="Product",
+            name="tracking_id",
+            field=fields.CharField(
+                null=True, db_default=SqlDefault("(lower(hex(randomblob(16))))"), max_length=36
+            ),
+        ),
+    ]

--- a/examples/comprehensive_migrations_project/models.py
+++ b/examples/comprehensive_migrations_project/models.py
@@ -11,6 +11,7 @@ from decimal import Decimal
 from enum import Enum, IntEnum
 
 from tortoise import fields, models
+from tortoise.fields import Now, SqlDefault
 
 
 class OrderStatus(IntEnum):
@@ -117,7 +118,12 @@ class Product(models.Model):
     processing_time = fields.TimeDeltaField(null=True, description="Average time to fulfill")
     is_active = fields.BooleanField(default=True)
     stock_quantity = fields.IntField(db_default=10)
-    created_at = fields.DatetimeField(auto_now_add=True)
+    tracking_id = fields.CharField(
+        max_length=36,
+        null=True,
+        db_default=SqlDefault("(lower(hex(randomblob(16))))"),
+    )
+    created_at = fields.DatetimeField(db_default=Now())
 
     def __str__(self) -> str:
         return f"{self.product_code}: {self.name}"

--- a/tests/fields/test_db_default.py
+++ b/tests/fields/test_db_default.py
@@ -534,3 +534,266 @@ async def test_add_field_without_db_default_no_default_clause():
     sql = client.executed[0]
     assert "ADD COLUMN" in sql
     assert "DEFAULT" not in sql
+
+
+# ============================================================================
+# SqlDefault and Now expression tests
+# ============================================================================
+
+
+def test_sql_default_construction_and_get_sql():
+    """SqlDefault construction and get_sql."""
+    from tortoise.fields.db_defaults import SqlDefault
+
+    sd = SqlDefault("CURRENT_TIMESTAMP")
+    assert sd.get_sql() == "CURRENT_TIMESTAMP"
+    assert sd.get_sql("some_context") == "CURRENT_TIMESTAMP"
+
+
+def test_now_construction():
+    """Now construction."""
+    from tortoise.fields.db_defaults import Now
+
+    n = Now()
+    assert n.get_sql() == "CURRENT_TIMESTAMP"
+
+
+def test_now_dialect_mysql():
+    """Now emits CURRENT_TIMESTAMP(6) for MySQL."""
+    from tortoise.fields.db_defaults import Now
+
+    n = Now()
+    assert n.get_sql(dialect="mysql") == "CURRENT_TIMESTAMP(6)"
+
+
+def test_now_dialect_other():
+    """Now emits plain CURRENT_TIMESTAMP for non-MySQL dialects."""
+    from tortoise.fields.db_defaults import Now
+
+    n = Now()
+    for dialect in ("sqlite", "postgres", "mssql", "oracle", "sql"):
+        assert n.get_sql(dialect=dialect) == "CURRENT_TIMESTAMP"
+
+
+def test_sql_default_equality_and_hashing():
+    """SqlDefault equality and hashing."""
+    from tortoise.fields.db_defaults import SqlDefault
+
+    a = SqlDefault("X")
+    b = SqlDefault("X")
+    c = SqlDefault("Y")
+    assert a == b
+    assert a != c
+    assert hash(a) == hash(b)
+    # Can be used in sets/dicts
+    s = {a, b, c}
+    assert len(s) == 2
+
+
+def test_sql_default_repr():
+    """SqlDefault repr."""
+    from tortoise.fields.db_defaults import SqlDefault
+
+    assert repr(SqlDefault("CURRENT_TIMESTAMP")) == "SqlDefault('CURRENT_TIMESTAMP')"
+
+
+def test_now_repr():
+    """Now repr."""
+    from tortoise.fields.db_defaults import Now
+
+    assert repr(Now()) == "Now()"
+
+
+def test_sql_default_passes_field_validation():
+    """SqlDefault is not callable -- passes field validation."""
+    from tortoise.fields.db_defaults import SqlDefault
+
+    # Should not raise
+    f = fields.DatetimeField(db_default=SqlDefault("CURRENT_TIMESTAMP"))
+    assert f.has_db_default() is True
+
+
+def test_callable_still_raises_with_updated_message():
+    """Callable still raises with SqlDefault in message."""
+    with pytest.raises(ConfigurationError, match="SqlDefault"):
+        fields.IntField(db_default=lambda: 1)
+
+
+# ============================================================================
+# Schema generation with SqlDefault / Now
+# ============================================================================
+
+
+def test_schema_generation_with_sql_default():
+    """Schema generation with SqlDefault."""
+    from tortoise.fields.db_defaults import SqlDefault
+
+    f = fields.DatetimeField(db_default=SqlDefault("CURRENT_TIMESTAMP"))
+    sql = _get_sqlite_default_sql(f)
+    assert sql == " DEFAULT CURRENT_TIMESTAMP"
+
+
+def test_schema_generation_with_now():
+    """Schema generation with Now()."""
+    from tortoise.fields.db_defaults import Now
+
+    f = fields.DatetimeField(db_default=Now())
+    sql = _get_sqlite_default_sql(f)
+    assert sql == " DEFAULT CURRENT_TIMESTAMP"
+
+
+def test_schema_generation_with_custom_sql_expression():
+    """Schema generation with custom SQL expression."""
+    from tortoise.fields.db_defaults import SqlDefault
+
+    f = fields.CharField(max_length=100, db_default=SqlDefault("'unknown'"))
+    sql = _get_sqlite_default_sql(f)
+    assert sql == " DEFAULT 'unknown'"
+
+
+def test_schema_generation_literal_db_default_still_works():
+    """Literal db_default still works (no regression)."""
+    f = fields.IntField(db_default=42)
+    sql = _get_sqlite_default_sql(f)
+    assert "DEFAULT" in sql
+    assert "42" in sql
+
+
+# ============================================================================
+# Migration editor with SqlDefault / Now
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_add_field_with_sql_default():
+    """Migration add_field with SqlDefault."""
+    from tortoise.fields.db_defaults import Now
+
+    WidgetModel = _make_model(
+        "Widget",
+        "widget",
+        id=fields.IntField(pk=True),
+        created=fields.DatetimeField(db_default=Now()),
+    )
+
+    editor, client = _make_test_editor()
+    await editor.add_field(WidgetModel, "created")
+
+    assert len(client.executed) == 1
+    sql = client.executed[0]
+    assert "DEFAULT CURRENT_TIMESTAMP" in sql
+
+
+@pytest.mark.asyncio
+async def test_alter_field_set_default_with_sql_default():
+    """Migration alter_field SET DEFAULT with SqlDefault."""
+    from tortoise.fields.db_defaults import Now
+
+    OldModel = _make_model(
+        "Widget",
+        "widget",
+        id=fields.IntField(pk=True),
+        created=fields.DatetimeField(),
+    )
+    NewModel = _make_model(
+        "Widget",
+        "widget",
+        id=fields.IntField(pk=True),
+        created=fields.DatetimeField(db_default=Now()),
+    )
+
+    editor, client = _make_test_editor()
+    await editor.alter_field(OldModel, NewModel, "created")
+
+    assert len(client.executed) == 1
+    sql = client.executed[0]
+    assert "SET DEFAULT" in sql
+    assert "CURRENT_TIMESTAMP" in sql
+
+
+@pytest.mark.asyncio
+async def test_alter_field_change_from_literal_to_sql_default():
+    """Migration alter_field change from literal to SqlDefault."""
+    from tortoise.fields.db_defaults import SqlDefault
+
+    OldModel = _make_model(
+        "Widget",
+        "widget",
+        id=fields.IntField(pk=True),
+        score=fields.IntField(db_default=42),
+    )
+    NewModel = _make_model(
+        "Widget",
+        "widget",
+        id=fields.IntField(pk=True),
+        score=fields.IntField(db_default=SqlDefault("NOW()")),
+    )
+
+    editor, client = _make_test_editor()
+    await editor.alter_field(OldModel, NewModel, "score")
+
+    assert len(client.executed) == 1
+    sql = client.executed[0]
+    assert "SET DEFAULT" in sql
+    assert "NOW()" in sql
+
+
+# ============================================================================
+# describe() and deconstruct() with SqlDefault / Now
+# ============================================================================
+
+
+def test_describe_serializable_with_now():
+    """describe(serializable=True) with Now."""
+    from tortoise.fields.db_defaults import Now
+
+    f = fields.DatetimeField(db_default=Now())
+    f.model_field_name = "created"
+    desc = f.describe(serializable=True)
+    assert desc["db_default"] == "Now()"
+
+
+def test_describe_non_serializable_with_now():
+    """describe(serializable=False) with Now."""
+    from tortoise.fields.db_defaults import Now
+
+    n = Now()
+    f = fields.DatetimeField(db_default=n)
+    f.model_field_name = "created"
+    desc = f.describe(serializable=False)
+    assert desc["db_default"] is n
+
+
+def test_deconstruct_with_now():
+    """deconstruct() preserves Now instance."""
+    from tortoise.fields.db_defaults import Now
+
+    n = Now()
+    f = fields.DatetimeField(db_default=n)
+    f.model_field_name = "created"
+    path, args, kwargs = f.deconstruct()
+    assert kwargs["db_default"] is n
+
+
+def test_render_value_with_now():
+    """render_value() preserves Now() in migration files."""
+    from tortoise.fields.db_defaults import Now
+    from tortoise.migrations.writer import ImportManager, render_value
+
+    imports = ImportManager()
+    n = Now()
+    result = render_value(n, imports)
+    assert result == "Now()"
+    assert "Now" in str(imports)
+
+
+def test_render_value_with_sql_default():
+    """render_value() preserves SqlDefault in migration files."""
+    from tortoise.fields.db_defaults import SqlDefault
+    from tortoise.migrations.writer import ImportManager, render_value
+
+    imports = ImportManager()
+    sd = SqlDefault("gen_random_uuid()")
+    result = render_value(sd, imports)
+    assert result == "SqlDefault('gen_random_uuid()')"
+    assert "SqlDefault" in str(imports)

--- a/tests/schema/test_generate_schema.py
+++ b/tests/schema/test_generate_schema.py
@@ -62,13 +62,13 @@ CREATE TABLE IF NOT EXISTS "teamaddress" (
 CREATE TABLE IF NOT EXISTS "tournament" (
     "tid" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     "name" VARCHAR(100) NOT NULL /* Tournament name */,
-    "created" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP /* Created *\\/'`\\/* datetime */
+    "created" TIMESTAMP NOT NULL /* Created *\\/'`\\/* datetime */
 ) /* What Tournaments *\\/'`\\/* we have */;
 CREATE INDEX IF NOT EXISTS "idx_tournament_name_6fe200" ON "tournament" ("name");
 CREATE TABLE IF NOT EXISTS "event" (
     "id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL /* Event ID */,
     "name" TEXT NOT NULL,
-    "modified" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "modified" TIMESTAMP NOT NULL,
     "prize" VARCHAR(40),
     "token" VARCHAR(100) NOT NULL UNIQUE /* Unique token */,
     "key" VARCHAR(100) NOT NULL,
@@ -380,13 +380,13 @@ CREATE INDEX "idx_team_manager_ef8f69" ON "team" ("manager_id", "name");
 CREATE TABLE "tournament" (
     "tid" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     "name" VARCHAR(100) NOT NULL /* Tournament name */,
-    "created" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP /* Created *\/'`\/* datetime */
+    "created" TIMESTAMP NOT NULL /* Created *\/'`\/* datetime */
 ) /* What Tournaments *\/'`\/* we have */;
 CREATE INDEX "idx_tournament_name_6fe200" ON "tournament" ("name");
 CREATE TABLE "event" (
     "id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL /* Event ID */,
     "name" TEXT NOT NULL,
-    "modified" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "modified" TIMESTAMP NOT NULL,
     "prize" VARCHAR(40),
     "token" VARCHAR(100) NOT NULL UNIQUE /* Unique token */,
     "key" VARCHAR(100) NOT NULL,
@@ -462,13 +462,13 @@ CREATE TABLE "teamaddress" (
 CREATE TABLE "tournament" (
     "tid" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     "name" VARCHAR(100) NOT NULL /* Tournament name */,
-    "created" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP /* Created *\\/'`\\/* datetime */
+    "created" TIMESTAMP NOT NULL /* Created *\\/'`\\/* datetime */
 ) /* What Tournaments *\\/'`\\/* we have */;
 CREATE INDEX "idx_tournament_name_6fe200" ON "tournament" ("name");
 CREATE TABLE "event" (
     "id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL /* Event ID */,
     "name" TEXT NOT NULL,
-    "modified" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "modified" TIMESTAMP NOT NULL,
     "prize" VARCHAR(40),
     "token" VARCHAR(100) NOT NULL UNIQUE /* Unique token */,
     "key" VARCHAR(100) NOT NULL,
@@ -533,13 +533,13 @@ CREATE INDEX "idx_team_manager_ef8f69" ON "team" ("manager_id", "name");
 CREATE TABLE "tournament" (
     "tid" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     "name" VARCHAR(100) NOT NULL /* Tournament name */,
-    "created" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP /* Created *\/'`\/* datetime */
+    "created" TIMESTAMP NOT NULL /* Created *\/'`\/* datetime */
 ) /* What Tournaments *\/'`\/* we have */;
 CREATE INDEX "idx_tournament_name_6fe200" ON "tournament" ("name");
 CREATE TABLE "event" (
     "id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL /* Event ID */,
     "name" TEXT NOT NULL,
-    "modified" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "modified" TIMESTAMP NOT NULL,
     "prize" VARCHAR(40),
     "token" VARCHAR(100) NOT NULL UNIQUE /* Unique token */,
     "key" VARCHAR(100) NOT NULL,
@@ -677,13 +677,13 @@ async def test_mysql_schema_no_db_constraint():
 CREATE TABLE `tournament` (
     `tid` SMALLINT NOT NULL PRIMARY KEY AUTO_INCREMENT,
     `name` VARCHAR(100) NOT NULL COMMENT 'Tournament name',
-    `created` DATETIME(6) NOT NULL COMMENT 'Created */\'`/* datetime' DEFAULT CURRENT_TIMESTAMP(6),
+    `created` DATETIME(6) NOT NULL COMMENT 'Created */\'`/* datetime',
     KEY `idx_tournament_name_6fe200` (`name`)
 ) CHARACTER SET utf8mb4 COMMENT='What Tournaments */\'`/* we have';
 CREATE TABLE `event` (
     `id` BIGINT NOT NULL PRIMARY KEY AUTO_INCREMENT COMMENT 'Event ID',
     `name` LONGTEXT NOT NULL,
-    `modified` DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    `modified` DATETIME(6) NOT NULL,
     `prize` DECIMAL(10,2),
     `token` VARCHAR(100) NOT NULL UNIQUE COMMENT 'Unique token',
     `key` VARCHAR(100) NOT NULL,
@@ -763,13 +763,13 @@ CREATE TABLE `teamaddress` (
 CREATE TABLE `tournament` (
     `tid` SMALLINT NOT NULL PRIMARY KEY AUTO_INCREMENT,
     `name` VARCHAR(100) NOT NULL COMMENT 'Tournament name',
-    `created` DATETIME(6) NOT NULL COMMENT 'Created */\\'`/* datetime' DEFAULT CURRENT_TIMESTAMP(6),
+    `created` DATETIME(6) NOT NULL COMMENT 'Created */\\'`/* datetime',
     KEY `idx_tournament_name_6fe200` (`name`)
 ) CHARACTER SET utf8mb4 COMMENT='What Tournaments */\\'`/* we have';
 CREATE TABLE `event` (
     `id` BIGINT NOT NULL PRIMARY KEY AUTO_INCREMENT COMMENT 'Event ID',
     `name` LONGTEXT NOT NULL,
-    `modified` DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    `modified` DATETIME(6) NOT NULL,
     `prize` DECIMAL(10,2),
     `token` VARCHAR(100) NOT NULL UNIQUE COMMENT 'Unique token',
     `key` VARCHAR(100) NOT NULL,
@@ -874,13 +874,13 @@ CREATE TABLE IF NOT EXISTS `teamaddress` (
 CREATE TABLE IF NOT EXISTS `tournament` (
     `tid` SMALLINT NOT NULL PRIMARY KEY AUTO_INCREMENT,
     `name` VARCHAR(100) NOT NULL COMMENT 'Tournament name',
-    `created` DATETIME(6) NOT NULL COMMENT 'Created */\\'`/* datetime' DEFAULT CURRENT_TIMESTAMP(6),
+    `created` DATETIME(6) NOT NULL COMMENT 'Created */\\'`/* datetime',
     KEY `idx_tournament_name_6fe200` (`name`)
 ) CHARACTER SET utf8mb4 COMMENT='What Tournaments */\\'`/* we have';
 CREATE TABLE IF NOT EXISTS `event` (
     `id` BIGINT NOT NULL PRIMARY KEY AUTO_INCREMENT COMMENT 'Event ID',
     `name` LONGTEXT NOT NULL,
-    `modified` DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    `modified` DATETIME(6) NOT NULL,
     `prize` DECIMAL(10,2),
     `token` VARCHAR(100) NOT NULL UNIQUE COMMENT 'Unique token',
     `key` VARCHAR(100) NOT NULL,
@@ -983,13 +983,13 @@ async def test_mysql_m2m_no_auto_create():
 CREATE TABLE `tournament` (
     `tid` SMALLINT NOT NULL PRIMARY KEY AUTO_INCREMENT,
     `name` VARCHAR(100) NOT NULL COMMENT 'Tournament name',
-    `created` DATETIME(6) NOT NULL COMMENT 'Created */\'`/* datetime' DEFAULT CURRENT_TIMESTAMP(6),
+    `created` DATETIME(6) NOT NULL COMMENT 'Created */\'`/* datetime',
     KEY `idx_tournament_name_6fe200` (`name`)
 ) CHARACTER SET utf8mb4 COMMENT='What Tournaments */\'`/* we have';
 CREATE TABLE `event` (
     `id` BIGINT NOT NULL PRIMARY KEY AUTO_INCREMENT COMMENT 'Event ID',
     `name` LONGTEXT NOT NULL,
-    `modified` DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    `modified` DATETIME(6) NOT NULL,
     `prize` DECIMAL(10,2),
     `token` VARCHAR(100) NOT NULL UNIQUE COMMENT 'Unique token',
     `key` VARCHAR(100) NOT NULL,
@@ -1099,7 +1099,7 @@ COMMENT ON TABLE "team" IS 'The TEAMS!';
 CREATE TABLE "tournament" (
     "tid" SMALLSERIAL NOT NULL PRIMARY KEY,
     "name" VARCHAR(100) NOT NULL,
-    "created" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    "created" TIMESTAMPTZ NOT NULL
 );
 CREATE INDEX "idx_tournament_name_6fe200" ON "tournament" ("name");
 COMMENT ON COLUMN "tournament"."name" IS 'Tournament name';
@@ -1108,7 +1108,7 @@ COMMENT ON TABLE "tournament" IS 'What Tournaments */''`/* we have';
 CREATE TABLE "event" (
     "id" BIGSERIAL NOT NULL PRIMARY KEY,
     "name" TEXT NOT NULL,
-    "modified" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "modified" TIMESTAMPTZ NOT NULL,
     "prize" DECIMAL(10,2),
     "token" VARCHAR(100) NOT NULL UNIQUE,
     "key" VARCHAR(100) NOT NULL,
@@ -1195,7 +1195,7 @@ COMMENT ON TABLE "teamaddress" IS 'The Team''s address';
 CREATE TABLE "tournament" (
     "tid" SMALLSERIAL NOT NULL PRIMARY KEY,
     "name" VARCHAR(100) NOT NULL,
-    "created" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    "created" TIMESTAMPTZ NOT NULL
 );
 CREATE INDEX "idx_tournament_name_6fe200" ON "tournament" ("name");
 COMMENT ON COLUMN "tournament"."name" IS 'Tournament name';
@@ -1204,7 +1204,7 @@ COMMENT ON TABLE "tournament" IS 'What Tournaments */''`/* we have';
 CREATE TABLE "event" (
     "id" BIGSERIAL NOT NULL PRIMARY KEY,
     "name" TEXT NOT NULL,
-    "modified" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "modified" TIMESTAMPTZ NOT NULL,
     "prize" DECIMAL(10,2),
     "token" VARCHAR(100) NOT NULL UNIQUE,
     "key" VARCHAR(100) NOT NULL,
@@ -1305,7 +1305,7 @@ COMMENT ON TABLE "teamaddress" IS 'The Team''s address';
 CREATE TABLE IF NOT EXISTS "tournament" (
     "tid" SMALLSERIAL NOT NULL PRIMARY KEY,
     "name" VARCHAR(100) NOT NULL,
-    "created" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    "created" TIMESTAMPTZ NOT NULL
 );
 CREATE INDEX IF NOT EXISTS "idx_tournament_name_6fe200" ON "tournament" ("name");
 COMMENT ON COLUMN "tournament"."name" IS 'Tournament name';
@@ -1314,7 +1314,7 @@ COMMENT ON TABLE "tournament" IS 'What Tournaments */''`/* we have';
 CREATE TABLE IF NOT EXISTS "event" (
     "id" BIGSERIAL NOT NULL PRIMARY KEY,
     "name" TEXT NOT NULL,
-    "modified" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "modified" TIMESTAMPTZ NOT NULL,
     "prize" DECIMAL(10,2),
     "token" VARCHAR(100) NOT NULL UNIQUE,
     "key" VARCHAR(100) NOT NULL,
@@ -1442,7 +1442,7 @@ COMMENT ON TABLE "team" IS 'The TEAMS!';
 CREATE TABLE "tournament" (
     "tid" SMALLSERIAL NOT NULL PRIMARY KEY,
     "name" VARCHAR(100) NOT NULL,
-    "created" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    "created" TIMESTAMPTZ NOT NULL
 );
 CREATE INDEX "idx_tournament_name_6fe200" ON "tournament" ("name");
 COMMENT ON COLUMN "tournament"."name" IS 'Tournament name';
@@ -1451,7 +1451,7 @@ COMMENT ON TABLE "tournament" IS 'What Tournaments */''`/* we have';
 CREATE TABLE "event" (
     "id" BIGSERIAL NOT NULL PRIMARY KEY,
     "name" TEXT NOT NULL,
-    "modified" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "modified" TIMESTAMPTZ NOT NULL,
     "prize" DECIMAL(10,2),
     "token" VARCHAR(100) NOT NULL UNIQUE,
     "key" VARCHAR(100) NOT NULL,
@@ -1493,10 +1493,10 @@ async def test_asyncpg_pgfields_unsafe():
             == """CREATE TABLE "postgres_fields" (
     "id" SERIAL NOT NULL PRIMARY KEY,
     "tsvector" TSVECTOR NOT NULL,
-    "text_array" TEXT[] NOT NULL DEFAULT '{"a","b","c"}',
-    "varchar_array" VARCHAR(32)[] NOT NULL DEFAULT '{"aa","bbb","cccc"}',
-    "int_array" INT[] DEFAULT '{1,2,3}',
-    "real_array" REAL[] NOT NULL DEFAULT '{1.1,2.2,3.3}'
+    "text_array" TEXT[] NOT NULL,
+    "varchar_array" VARCHAR(32)[] NOT NULL,
+    "int_array" INT[],
+    "real_array" REAL[] NOT NULL
 );
 COMMENT ON COLUMN "postgres_fields"."real_array" IS 'this is array of real numbers';"""
         )
@@ -1515,10 +1515,10 @@ async def test_asyncpg_pgfields_safe():
             == """CREATE TABLE IF NOT EXISTS "postgres_fields" (
     "id" SERIAL NOT NULL PRIMARY KEY,
     "tsvector" TSVECTOR NOT NULL,
-    "text_array" TEXT[] NOT NULL DEFAULT '{"a","b","c"}',
-    "varchar_array" VARCHAR(32)[] NOT NULL DEFAULT '{"aa","bbb","cccc"}',
-    "int_array" INT[] DEFAULT '{1,2,3}',
-    "real_array" REAL[] NOT NULL DEFAULT '{1.1,2.2,3.3}'
+    "text_array" TEXT[] NOT NULL,
+    "varchar_array" VARCHAR(32)[] NOT NULL,
+    "int_array" INT[],
+    "real_array" REAL[] NOT NULL
 );
 COMMENT ON COLUMN "postgres_fields"."real_array" IS 'this is array of real numbers';"""
         )
@@ -1605,7 +1605,7 @@ COMMENT ON TABLE "team" IS 'The TEAMS!';
 CREATE TABLE "tournament" (
     "tid" SMALLSERIAL NOT NULL PRIMARY KEY,
     "name" VARCHAR(100) NOT NULL,
-    "created" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    "created" TIMESTAMPTZ NOT NULL
 );
 CREATE INDEX "idx_tournament_name_6fe200" ON "tournament" ("name");
 COMMENT ON COLUMN "tournament"."name" IS 'Tournament name';
@@ -1614,7 +1614,7 @@ COMMENT ON TABLE "tournament" IS 'What Tournaments */''`/* we have';
 CREATE TABLE "event" (
     "id" BIGSERIAL NOT NULL PRIMARY KEY,
     "name" TEXT NOT NULL,
-    "modified" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "modified" TIMESTAMPTZ NOT NULL,
     "prize" DECIMAL(10,2),
     "token" VARCHAR(100) NOT NULL UNIQUE,
     "key" VARCHAR(100) NOT NULL,
@@ -1701,7 +1701,7 @@ COMMENT ON TABLE "teamaddress" IS 'The Team''s address';
 CREATE TABLE "tournament" (
     "tid" SMALLSERIAL NOT NULL PRIMARY KEY,
     "name" VARCHAR(100) NOT NULL,
-    "created" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    "created" TIMESTAMPTZ NOT NULL
 );
 CREATE INDEX "idx_tournament_name_6fe200" ON "tournament" ("name");
 COMMENT ON COLUMN "tournament"."name" IS 'Tournament name';
@@ -1710,7 +1710,7 @@ COMMENT ON TABLE "tournament" IS 'What Tournaments */''`/* we have';
 CREATE TABLE "event" (
     "id" BIGSERIAL NOT NULL PRIMARY KEY,
     "name" TEXT NOT NULL,
-    "modified" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "modified" TIMESTAMPTZ NOT NULL,
     "prize" DECIMAL(10,2),
     "token" VARCHAR(100) NOT NULL UNIQUE,
     "key" VARCHAR(100) NOT NULL,
@@ -1811,7 +1811,7 @@ COMMENT ON TABLE "teamaddress" IS 'The Team''s address';
 CREATE TABLE IF NOT EXISTS "tournament" (
     "tid" SMALLSERIAL NOT NULL PRIMARY KEY,
     "name" VARCHAR(100) NOT NULL,
-    "created" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    "created" TIMESTAMPTZ NOT NULL
 );
 CREATE INDEX IF NOT EXISTS "idx_tournament_name_6fe200" ON "tournament" ("name");
 COMMENT ON COLUMN "tournament"."name" IS 'Tournament name';
@@ -1820,7 +1820,7 @@ COMMENT ON TABLE "tournament" IS 'What Tournaments */''`/* we have';
 CREATE TABLE IF NOT EXISTS "event" (
     "id" BIGSERIAL NOT NULL PRIMARY KEY,
     "name" TEXT NOT NULL,
-    "modified" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "modified" TIMESTAMPTZ NOT NULL,
     "prize" DECIMAL(10,2),
     "token" VARCHAR(100) NOT NULL UNIQUE,
     "key" VARCHAR(100) NOT NULL,
@@ -1948,7 +1948,7 @@ COMMENT ON TABLE "team" IS 'The TEAMS!';
 CREATE TABLE "tournament" (
     "tid" SMALLSERIAL NOT NULL PRIMARY KEY,
     "name" VARCHAR(100) NOT NULL,
-    "created" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    "created" TIMESTAMPTZ NOT NULL
 );
 CREATE INDEX "idx_tournament_name_6fe200" ON "tournament" ("name");
 COMMENT ON COLUMN "tournament"."name" IS 'Tournament name';
@@ -1957,7 +1957,7 @@ COMMENT ON TABLE "tournament" IS 'What Tournaments */''`/* we have';
 CREATE TABLE "event" (
     "id" BIGSERIAL NOT NULL PRIMARY KEY,
     "name" TEXT NOT NULL,
-    "modified" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "modified" TIMESTAMPTZ NOT NULL,
     "prize" DECIMAL(10,2),
     "token" VARCHAR(100) NOT NULL UNIQUE,
     "key" VARCHAR(100) NOT NULL,
@@ -1999,10 +1999,10 @@ async def test_psycopg_pgfields_unsafe():
             == """CREATE TABLE "postgres_fields" (
     "id" SERIAL NOT NULL PRIMARY KEY,
     "tsvector" TSVECTOR NOT NULL,
-    "text_array" TEXT[] NOT NULL DEFAULT '{"a","b","c"}',
-    "varchar_array" VARCHAR(32)[] NOT NULL DEFAULT '{"aa","bbb","cccc"}',
-    "int_array" INT[] DEFAULT '{1,2,3}',
-    "real_array" REAL[] NOT NULL DEFAULT '{1.1,2.2,3.3}'
+    "text_array" TEXT[] NOT NULL,
+    "varchar_array" VARCHAR(32)[] NOT NULL,
+    "int_array" INT[],
+    "real_array" REAL[] NOT NULL
 );
 COMMENT ON COLUMN "postgres_fields"."real_array" IS 'this is array of real numbers';"""
         )
@@ -2021,10 +2021,10 @@ async def test_psycopg_pgfields_safe():
             == """CREATE TABLE IF NOT EXISTS "postgres_fields" (
     "id" SERIAL NOT NULL PRIMARY KEY,
     "tsvector" TSVECTOR NOT NULL,
-    "text_array" TEXT[] NOT NULL DEFAULT '{"a","b","c"}',
-    "varchar_array" VARCHAR(32)[] NOT NULL DEFAULT '{"aa","bbb","cccc"}',
-    "int_array" INT[] DEFAULT '{1,2,3}',
-    "real_array" REAL[] NOT NULL DEFAULT '{1.1,2.2,3.3}'
+    "text_array" TEXT[] NOT NULL,
+    "varchar_array" VARCHAR(32)[] NOT NULL,
+    "int_array" INT[],
+    "real_array" REAL[] NOT NULL
 );
 COMMENT ON COLUMN "postgres_fields"."real_array" IS 'this is array of real numbers';"""
         )

--- a/tests/testmodels.py
+++ b/tests/testmodels.py
@@ -831,14 +831,14 @@ class DefaultUpdate(Model):
 
 
 class DefaultModel(Model):
-    int_default = fields.IntField(default=1)
-    float_default = fields.FloatField(default=1.5)
-    decimal_default = fields.DecimalField(max_digits=8, decimal_places=2, default=Decimal(1))
-    bool_default = fields.BooleanField(default=True)
-    char_default = fields.CharField(max_length=20, default="tortoise")
-    date_default = fields.DateField(default=datetime.date(year=2020, month=5, day=21))
+    int_default = fields.IntField(db_default=1)
+    float_default = fields.FloatField(db_default=1.5)
+    decimal_default = fields.DecimalField(max_digits=8, decimal_places=2, db_default=Decimal(1))
+    bool_default = fields.BooleanField(db_default=True)
+    char_default = fields.CharField(max_length=20, db_default="tortoise")
+    date_default = fields.DateField(db_default=datetime.date(year=2020, month=5, day=21))
     datetime_default = fields.DatetimeField(
-        default=datetime.datetime(year=2020, month=5, day=20, tzinfo=UTC)
+        db_default=datetime.datetime(year=2020, month=5, day=20, tzinfo=UTC)
     )
 
 

--- a/tortoise/backends/base/schema_generator.py
+++ b/tortoise/backends/base/schema_generator.py
@@ -6,7 +6,6 @@ from hashlib import sha256
 from typing import TYPE_CHECKING, Any, cast
 
 from tortoise.exceptions import ConfigurationError
-from tortoise.fields import JSONField, TextField, UUIDField
 from tortoise.fields.relational import OneToOneFieldInstance
 from tortoise.indexes import Index
 from tortoise.schema_quoting import SchemaQuotingMixin
@@ -89,8 +88,6 @@ class BaseSchemaGenerator(SchemaQuotingMixin):
         table: str,
         column: str,
         default: Any,
-        auto_now_add: bool = False,
-        auto_now: bool = False,
     ) -> str:
         # Databases have their own way of supporting default for column level
         # needs to be implemented for each supported client
@@ -401,36 +398,24 @@ class BaseSchemaGenerator(SchemaQuotingMixin):
     ) -> str:
         if field_object.has_db_default():
             db_default = field_object.db_default
-            db_default = field_object.to_db_value(db_default, model)
-            try:
-                return self._column_default_generator(
-                    table_name,
-                    column_name,
-                    self._escape_default_value(db_default),
-                    False,
-                    False,
-                )
-            except NotImplementedError:
-                pass
-
-        auto_now_add = getattr(field_object, "auto_now_add", False)
-        auto_now = getattr(field_object, "auto_now", False)
-        default = field_object.default
-        if default is not None or auto_now or auto_now_add:
-            if not callable(default) and not isinstance(
-                field_object, (UUIDField, TextField, JSONField)
-            ):
-                default = field_object.to_db_value(default, model)
+            if hasattr(db_default, "get_sql"):
+                try:
+                    return self._column_default_generator(
+                        table_name, column_name, db_default.get_sql(dialect=self.DIALECT)
+                    )
+                except NotImplementedError:
+                    pass
+            else:
+                db_default = field_object.to_db_value(db_default, model)
                 try:
                     return self._column_default_generator(
                         table_name,
                         column_name,
-                        self._escape_default_value(default),
-                        auto_now_add,
-                        auto_now,
+                        self._escape_default_value(db_default),
                     )
                 except NotImplementedError:
                     pass
+
         return ""
 
     def _get_table_sql(self, model: type[Model], safe: bool = True) -> dict:

--- a/tortoise/backends/base_postgres/schema_generator.py
+++ b/tortoise/backends/base_postgres/schema_generator.py
@@ -63,12 +63,8 @@ class BasePostgresSchemaGenerator(BaseSchemaGenerator):
         table: str,
         column: str,
         default: Any,
-        auto_now_add: bool = False,
-        auto_now: bool = False,
     ) -> str:
-        default_str = " DEFAULT"
-        default_str += " CURRENT_TIMESTAMP" if (auto_now_add or auto_now) else f" {default}"
-        return default_str
+        return f" DEFAULT {default}"
 
     def _escape_default_value(self, default: Any):
         if isinstance(default, bool):

--- a/tortoise/backends/mssql/schema_generator.py
+++ b/tortoise/backends/mssql/schema_generator.py
@@ -55,15 +55,8 @@ class MSSQLSchemaGenerator(MSSQLQuotingMixin, BaseSchemaGenerator):
         table: str,
         column: str,
         default: Any,
-        auto_now_add: bool = False,
-        auto_now: bool = False,
     ) -> str:
-        default_str = " DEFAULT"
-        if not (auto_now or auto_now_add):
-            default_str += f" {default}"
-        if auto_now_add or auto_now:
-            default_str += " CURRENT_TIMESTAMP"
-        return default_str
+        return f" DEFAULT {default}"
 
     def _escape_default_value(self, default: Any):
         return encoders.get(type(default))(default)  # type: ignore

--- a/tortoise/backends/mysql/schema_generator.py
+++ b/tortoise/backends/mysql/schema_generator.py
@@ -54,17 +54,8 @@ class MySQLSchemaGenerator(MySQLQuotingMixin, BaseSchemaGenerator):
         table: str,
         column: str,
         default: Any,
-        auto_now_add: bool = False,
-        auto_now: bool = False,
     ) -> str:
-        default_str = " DEFAULT"
-        if not (auto_now or auto_now_add):
-            default_str += f" {default}"
-        if auto_now_add or auto_now:
-            default_str += " CURRENT_TIMESTAMP(6)"
-        if auto_now:
-            default_str += " ON UPDATE CURRENT_TIMESTAMP(6)"
-        return default_str
+        return f" DEFAULT {default}"
 
     def _escape_default_value(self, default: Any):
         return encoders.get(type(default))(default)  # type: ignore

--- a/tortoise/backends/oracle/schema_generator.py
+++ b/tortoise/backends/oracle/schema_generator.py
@@ -72,15 +72,8 @@ class OracleSchemaGenerator(BaseSchemaGenerator):
         table: str,
         column: str,
         default: Any,
-        auto_now_add: bool = False,
-        auto_now: bool = False,
     ) -> str:
-        default_str = " DEFAULT"
-        if not (auto_now or auto_now_add):
-            default_str += f" {default}"
-        if auto_now_add or auto_now:
-            default_str += " CURRENT_TIMESTAMP"
-        return default_str
+        return f" DEFAULT {default}"
 
     def _escape_default_value(self, default: Any):
         return encoders.get(type(default))(default)  # type: ignore

--- a/tortoise/backends/sqlite/schema_generator.py
+++ b/tortoise/backends/sqlite/schema_generator.py
@@ -29,12 +29,8 @@ class SqliteSchemaGenerator(SqliteQuotingMixin, BaseSchemaGenerator):
         table: str,
         column: str,
         default: Any,
-        auto_now_add: bool = False,
-        auto_now: bool = False,
     ) -> str:
-        default_str = " DEFAULT"
-        default_str += " CURRENT_TIMESTAMP" if (auto_now_add or auto_now) else f" {default}"
-        return default_str
+        return f" DEFAULT {default}"
 
     def _escape_default_value(self, default: Any):
         return encoders.get(type(default))(default)  # type: ignore

--- a/tortoise/fields/__init__.py
+++ b/tortoise/fields/__init__.py
@@ -26,6 +26,7 @@ from tortoise.fields.data import (
     TimeField,
     UUIDField,
 )
+from tortoise.fields.db_defaults import Now, SqlDefault
 from tortoise.fields.relational import (
     BackwardFKRelation,
     BackwardOneToOneRelation,
@@ -48,6 +49,8 @@ __all__ = [
     "NO_ACTION",
     "OnDelete",
     "Field",
+    "Now",
+    "SqlDefault",
     "BigIntField",
     "BinaryField",
     "BooleanField",

--- a/tortoise/fields/base.py
+++ b/tortoise/fields/base.py
@@ -241,7 +241,7 @@ class Field(Generic[VALUE], metaclass=_FieldMeta):
         self.db_default = db_default
         if self.has_db_default() and callable(self.db_default):
             raise ConfigurationError(
-                f"{self.__class__.__name__}: db_default must be a static value, not a callable"
+                f"{self.__class__.__name__}: db_default must be a static value or SqlDefault(...), not a callable"
             )
         self.null = null
         self.unique = unique

--- a/tortoise/fields/db_defaults.py
+++ b/tortoise/fields/db_defaults.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+
+class SqlDefault:
+    """Represents a raw SQL expression for use as a database-level default value.
+
+    Use this with the ``db_default`` parameter on fields to emit raw SQL
+    in both ``generate_schemas()`` and migrations.
+
+    .. warning::
+        The SQL string is emitted verbatim into DDL statements.
+        Never construct it from untrusted user input.
+
+    Example::
+
+        class MyModel(Model):
+            created_at = fields.DatetimeField(db_default=SqlDefault("CURRENT_TIMESTAMP"))
+    """
+
+    def __init__(self, sql: str) -> None:
+        self.sql = sql
+
+    def get_sql(self, _context=None, dialect: str | None = None) -> str:
+        return self.sql
+
+    def __repr__(self) -> str:
+        return f"SqlDefault({self.sql!r})"
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, SqlDefault) and self.sql == other.sql
+
+    def __hash__(self) -> int:
+        return hash(self.sql)
+
+
+class Now(SqlDefault):
+    """Convenience subclass of :class:`SqlDefault` that emits ``CURRENT_TIMESTAMP``.
+
+    Example::
+
+        class MyModel(Model):
+            created_at = fields.DatetimeField(db_default=Now())
+    """
+
+    _DIALECT_SQL: dict[str, str] = {
+        "mysql": "CURRENT_TIMESTAMP(6)",
+    }
+
+    def __init__(self) -> None:
+        super().__init__("CURRENT_TIMESTAMP")
+
+    def get_sql(self, _context=None, dialect: str | None = None) -> str:
+        if dialect and dialect in self._DIALECT_SQL:
+            return self._DIALECT_SQL[dialect]
+        return self.sql
+
+    def __repr__(self) -> str:
+        return "Now()"

--- a/tortoise/migrations/expressions.py
+++ b/tortoise/migrations/expressions.py
@@ -5,5 +5,5 @@ class RawSQLTerm:
     def __init__(self, sql: str) -> None:
         self.sql = sql
 
-    def get_sql(self, _context) -> str:
+    def get_sql(self, _context=None, dialect: str | None = None) -> str:
         return self.sql

--- a/tortoise/migrations/schema_editor/base.py
+++ b/tortoise/migrations/schema_editor/base.py
@@ -522,9 +522,12 @@ class BaseSchemaEditor(SchemaQuotingMixin):
             )
 
         if field.has_db_default():
-            db_val = field.to_db_value(field.db_default, model)
-            escaped = self._escape_default_value(db_val)
-            field_definition += f" DEFAULT {escaped}"
+            if hasattr(field.db_default, "get_sql"):
+                field_definition += f" DEFAULT {field.db_default.get_sql(dialect=self.DIALECT)}"
+            else:
+                db_val = field.to_db_value(field.db_default, model)
+                escaped = self._escape_default_value(db_val)
+                field_definition += f" DEFAULT {escaped}"
 
         await self._run_sql(
             self.ADD_FIELD_TEMPLATE.format(
@@ -633,10 +636,13 @@ class BaseSchemaEditor(SchemaQuotingMixin):
             and old_field.db_default != new_field.db_default
         ):
             if new_has_db_default:
-                db_val = new_field.to_db_value(new_field.db_default, model)
-                escaped = self._escape_default_value(db_val)
+                if hasattr(new_field.db_default, "get_sql"):
+                    default_sql = new_field.db_default.get_sql(dialect=self.DIALECT)
+                else:
+                    db_val = new_field.to_db_value(new_field.db_default, model)
+                    default_sql = self._escape_default_value(db_val)
                 changes = self.ALTER_FIELD_SET_DEFAULT_TEMPLATE.format(
-                    column=new_db_field, default=escaped
+                    column=new_db_field, default=default_sql
                 )
             else:
                 changes = self.ALTER_FIELD_DROP_DEFAULT_TEMPLATE.format(column=new_db_field)

--- a/tortoise/migrations/schema_editor/sqlite.py
+++ b/tortoise/migrations/schema_editor/sqlite.py
@@ -127,9 +127,12 @@ class SqliteSchemaEditor(SqliteQuotingMixin, BaseSchemaEditor):
             unique_field = field.unique and not field.pk
 
         if field.has_db_default():
-            db_val = field.to_db_value(field.db_default, model)
-            escaped = self._escape_default_value(db_val)
-            field_definition += f" DEFAULT {escaped}"
+            if hasattr(field.db_default, "get_sql"):
+                field_definition += f" DEFAULT {field.db_default.get_sql(dialect=self.DIALECT)}"
+            else:
+                db_val = field.to_db_value(field.db_default, model)
+                escaped = self._escape_default_value(db_val)
+                field_definition += f" DEFAULT {escaped}"
 
         await self._run_sql(
             self.ADD_FIELD_TEMPLATE.format(table=qualified_table, definition=field_definition)
@@ -319,9 +322,12 @@ class SqliteSchemaEditor(SqliteQuotingMixin, BaseSchemaEditor):
                 )
 
             if actual_field.has_db_default():
-                db_val = actual_field.to_db_value(actual_field.db_default, model)
-                escaped = self._escape_default_value(db_val)
-                field_def += f" DEFAULT {escaped}"
+                if hasattr(actual_field.db_default, "get_sql"):
+                    field_def += f" DEFAULT {actual_field.db_default.get_sql(dialect=self.DIALECT)}"
+                else:
+                    db_val = actual_field.to_db_value(actual_field.db_default, model)
+                    escaped = self._escape_default_value(db_val)
+                    field_def += f" DEFAULT {escaped}"
 
             field_definitions.append(field_def)
 

--- a/tortoise/migrations/writer.py
+++ b/tortoise/migrations/writer.py
@@ -130,6 +130,14 @@ def render_value(value: Any, imports: ImportManager) -> str:
         return repr(value)
     if isinstance(value, bytes):
         return repr(value)
+    from tortoise.fields.db_defaults import Now, SqlDefault
+
+    if isinstance(value, Now):
+        imports.add_from("tortoise.fields.db_defaults", "Now")
+        return "Now()"
+    if isinstance(value, SqlDefault):
+        imports.add_from("tortoise.fields.db_defaults", "SqlDefault")
+        return f"SqlDefault({value.sql!r})"
     if hasattr(value, "get_sql") and callable(value.get_sql):
         sql = value.get_sql(DEFAULT_SQL_CONTEXT)
         imports.add_from("tortoise.migrations.expressions", "RawSQLTerm")


### PR DESCRIPTION
Resolves #2104 

Introduce SqlDefault to pass expressions as db default
Change schema generator behaviour to match migrations (no default in db on `default` in `Field`)

AI Summary:
This pull request introduces support for raw SQL default expressions in database schemas via new `SqlDefault` and `Now` expressions, and clarifies the distinction between Python-only defaults and database-level defaults. It also updates documentation and tests to reflect these changes, and adjusts schema generation so that Python-only defaults (such as `default=...`, `auto_now`, and `auto_now_add`) do not emit `DEFAULT` clauses in generated schemas.

**New features and API additions:**

* Added `SqlDefault` and `Now` expressions for use with the `db_default` parameter, allowing raw SQL expressions (e.g., `CURRENT_TIMESTAMP`) as database defaults. `Now()` is a shorthand for `SqlDefault("CURRENT_TIMESTAMP")`. [[1]](diffhunk://#diff-2c623f3c6a917be56c59d43279244996836262cb1e12d9d0786c9c49eef6b43cR11-R23) [[2]](diffhunk://#diff-1edaa2a137a8ec9a364a4e634bf49da232ddae5a4353f5a91d9a493f8f149b4bR52-R57) [[3]](diffhunk://#diff-c12d82de94e3bcc6048ed11c06b1c043e49caf53317c91299628ff928c28ef03R1-R24) [[4]](diffhunk://#diff-19d4b206ab03922b5f2148895db988a3ceb8421c27915e3a65c5b8be74758843R14) [[5]](diffhunk://#diff-19d4b206ab03922b5f2148895db988a3ceb8421c27915e3a65c5b8be74758843L120-R126) [[6]](diffhunk://#diff-4eb9617ef34dd8e333c9af9b5852c1050ecfc87cf674ed185ad1fb136712609eR537-R799)

**Behavior changes and schema generation:**

* Updated schema generation so that `Field(default=...)`, `auto_now`, and `auto_now_add` no longer emit a `DEFAULT` clause in `generate_schemas()`. Only `db_default` is used for database-level defaults, aligning schema generation with migration behavior. [[1]](diffhunk://#diff-2c623f3c6a917be56c59d43279244996836262cb1e12d9d0786c9c49eef6b43cR11-R23) [[2]](diffhunk://#diff-36de90d48deb78ffde783a1533bc4dd50b3b4d24192b6c70311fa62d0024e956L65-R71) [[3]](diffhunk://#diff-36de90d48deb78ffde783a1533bc4dd50b3b4d24192b6c70311fa62d0024e956L383-R389) [[4]](diffhunk://#diff-36de90d48deb78ffde783a1533bc4dd50b3b4d24192b6c70311fa62d0024e956L465-R471) [[5]](diffhunk://#diff-36de90d48deb78ffde783a1533bc4dd50b3b4d24192b6c70311fa62d0024e956L536-R542) [[6]](diffhunk://#diff-36de90d48deb78ffde783a1533bc4dd50b3b4d24192b6c70311fa62d0024e956L680-R686) [[7]](diffhunk://#diff-36de90d48deb78ffde783a1533bc4dd50b3b4d24192b6c70311fa62d0024e956L766-R772) [[8]](diffhunk://#diff-36de90d48deb78ffde783a1533bc4dd50b3b4d24192b6c70311fa62d0024e956L877-R883) [[9]](diffhunk://#diff-36de90d48deb78ffde783a1533bc4dd50b3b4d24192b6c70311fa62d0024e956L986-R992) [[10]](diffhunk://#diff-36de90d48deb78ffde783a1533bc4dd50b3b4d24192b6c70311fa62d0024e956L1102-R1102) [[11]](diffhunk://#diff-36de90d48deb78ffde783a1533bc4dd50b3b4d24192b6c70311fa62d0024e956L1111-R1111) [[12]](diffhunk://#diff-36de90d48deb78ffde783a1533bc4dd50b3b4d24192b6c70311fa62d0024e956L1198-R1198)

**Documentation improvements:**

* Updated documentation to clarify the difference between Python-only defaults and database-level defaults, and provided usage examples for `db_default`, `SqlDefault`, and `Now`. [[1]](diffhunk://#diff-2c623f3c6a917be56c59d43279244996836262cb1e12d9d0786c9c49eef6b43cR11-R23) [[2]](diffhunk://#diff-1edaa2a137a8ec9a364a4e634bf49da232ddae5a4353f5a91d9a493f8f149b4bR52-R57) [[3]](diffhunk://#diff-d606c1bcd72689c8bb949dcdafe4bcd0420da5cbaa7daf9614f0757734cffaf7L74-R85)

**Testing:**

* Added comprehensive tests for `SqlDefault` and `Now`, including construction, equality, hashing, schema generation, migration rendering, and serialization.

**Examples and migrations:**

* Updated example models and migrations to demonstrate the use of `SqlDefault` and `Now` in real project scenarios. [[1]](diffhunk://#diff-c12d82de94e3bcc6048ed11c06b1c043e49caf53317c91299628ff928c28ef03R1-R24) [[2]](diffhunk://#diff-19d4b206ab03922b5f2148895db988a3ceb8421c27915e3a65c5b8be74758843R14) [[3]](diffhunk://#diff-19d4b206ab03922b5f2148895db988a3ceb8421c27915e3a65c5b8be74758843L120-R126)