### PR TITLE
Backend specific migration fixes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,22 @@ Changelog
 1.1
 ===
 
+1.1.3
+-----
+
+Added
+^^^^^
+- ``RandomHex`` dialect-aware ``SqlDefault`` subclass for generating random hex strings across all backends. (#2108)
+- ``Meta.constraints`` support on models — named ``UniqueConstraint`` objects are now captured by the migration autodetector, enabling ``AddConstraint``/``RemoveConstraint`` generation via ``makemigrations``. (#2108)
+- MySQL schema editor: ``_alter_field`` override using ``MODIFY COLUMN`` for NULL/NOT NULL changes; backtick-quoted ``ALTER_FIELD_*`` templates. (#2108)
+- MSSQL schema editor: ``_alter_field`` override with ``ALTER COLUMN`` for nullability, named default constraint management via ``sys.default_constraints``, bracket-quoted templates, and self-referencing FK CASCADE → NO ACTION downgrade. (#2108)
+
+Fixed
+^^^^^
+- MySQL migrations: ``ALTER COLUMN ... SET NOT NULL`` / ``DROP NOT NULL`` now correctly emits ``MODIFY COLUMN col type NOT NULL/NULL``. (#2108)
+- MSSQL migrations: ``DELETE_CONSTRAINT_TEMPLATE`` and ``UNIQUE_CONSTRAINT_CREATE_TEMPLATE`` now use bracket quoting ``[name]`` instead of double quotes. (#2108)
+- MSSQL migrations: self-referencing foreign keys with ``CASCADE`` no longer fail with error 1785; automatically downgraded to ``NO ACTION``. (#2108)
+
 1.1.2
 -----
 

--- a/examples/comprehensive_migrations_project/migrations/0011_populate_computed_fields.py
+++ b/examples/comprehensive_migrations_project/migrations/0011_populate_computed_fields.py
@@ -5,6 +5,13 @@ from decimal import Decimal
 from tortoise import migrations
 from tortoise.migrations import operations as ops
 
+_CONCAT_SQL = {
+    "postgres": "UPDATE employee SET full_name = first_name || ' ' || last_name WHERE full_name IS NULL",
+    "sqlite": "UPDATE employee SET full_name = first_name || ' ' || last_name WHERE full_name IS NULL",
+    "mysql": "UPDATE employee SET full_name = CONCAT(first_name, ' ', last_name) WHERE full_name IS NULL",
+    "mssql": "UPDATE employee SET full_name = first_name + ' ' + last_name WHERE full_name IS NULL",
+}
+
 
 def populate_total_amount(apps, schema_editor):
     """Convert total_cents to total_amount (cents to dollars)."""
@@ -30,6 +37,25 @@ def clear_total_amount(apps, schema_editor):
     return do_clear()
 
 
+def populate_full_name(apps, schema_editor):
+    """Populate full_name from first_name + last_name using dialect-specific SQL."""
+    sql = _CONCAT_SQL[schema_editor.DIALECT]
+
+    async def do_populate():
+        await schema_editor.client.execute_query(sql)
+
+    return do_populate()
+
+
+def clear_full_name(apps, schema_editor):
+    """Reverse: Clear full_name field."""
+
+    async def do_clear():
+        await schema_editor.client.execute_query("UPDATE employee SET full_name = NULL")
+
+    return do_clear()
+
+
 class Migration(migrations.Migration):
     dependencies = [("erp", "0010_add_computed_fields")]
 
@@ -40,8 +66,8 @@ class Migration(migrations.Migration):
             code=populate_total_amount,
             reverse_code=clear_total_amount,
         ),
-        ops.RunSQL(
-            sql="UPDATE employee SET full_name = first_name || ' ' || last_name WHERE full_name IS NULL",
-            reverse_sql="UPDATE employee SET full_name = NULL",
+        ops.RunPython(
+            code=populate_full_name,
+            reverse_code=clear_full_name,
         ),
     ]

--- a/examples/comprehensive_migrations_project/migrations/0017_create_bad_sorted_fk.py
+++ b/examples/comprehensive_migrations_project/migrations/0017_create_bad_sorted_fk.py
@@ -10,6 +10,28 @@ class Migration(migrations.Migration):
 
     operations = [
         ops.CreateModel(
+            name="Warehouse",
+            fields=[
+                (
+                    "id",
+                    fields.IntField(generated=True, primary_key=True, unique=True, db_index=True),
+                ),
+                ("name", fields.CharField(max_length=200)),
+                ("location", fields.CharField(max_length=300)),
+                (
+                    "is_active",
+                    fields.BooleanField(default=True, generated=False, null=False, unique=False),
+                ),
+            ],
+            options={
+                "table": "warehouse",
+                "app": "erp",
+                "pk_attr": "id",
+                "table_description": "Warehouse entity - storage location for inventory.",
+            },
+            bases=["Model"],
+        ),
+        ops.CreateModel(
             name="Alert",
             fields=[
                 (
@@ -39,28 +61,6 @@ class Migration(migrations.Migration):
                 "app": "erp",
                 "pk_attr": "id",
                 "table_description": "Inventory alert - references Warehouse via FK.",
-            },
-            bases=["Model"],
-        ),
-        ops.CreateModel(
-            name="Warehouse",
-            fields=[
-                (
-                    "id",
-                    fields.IntField(generated=True, primary_key=True, unique=True, db_index=True),
-                ),
-                ("name", fields.CharField(max_length=200)),
-                ("location", fields.CharField(max_length=300)),
-                (
-                    "is_active",
-                    fields.BooleanField(default=True, generated=False, null=False, unique=False),
-                ),
-            ],
-            options={
-                "table": "warehouse",
-                "app": "erp",
-                "pk_attr": "id",
-                "table_description": "Warehouse entity - storage location for inventory.",
             },
             bases=["Model"],
         ),

--- a/examples/comprehensive_migrations_project/migrations/0021_add_sql_default_expressions.py
+++ b/examples/comprehensive_migrations_project/migrations/0021_add_sql_default_expressions.py
@@ -1,5 +1,5 @@
 from tortoise import fields, migrations
-from tortoise.fields.db_defaults import Now, SqlDefault
+from tortoise.fields.db_defaults import Now, RandomHex
 from tortoise.migrations import operations as ops
 
 
@@ -17,8 +17,6 @@ class Migration(migrations.Migration):
         ops.AddField(
             model_name="Product",
             name="tracking_id",
-            field=fields.CharField(
-                null=True, db_default=SqlDefault("(lower(hex(randomblob(16))))"), max_length=36
-            ),
+            field=fields.CharField(null=True, db_default=RandomHex(), max_length=36),
         ),
     ]

--- a/examples/comprehensive_migrations_project/migrations/0022_add_employee_constraints.py
+++ b/examples/comprehensive_migrations_project/migrations/0022_add_employee_constraints.py
@@ -1,0 +1,22 @@
+from tortoise import migrations
+from tortoise.migrations import operations as ops
+from tortoise.migrations.constraints import UniqueConstraint
+
+
+class Migration(migrations.Migration):
+    dependencies = [("erp", "0021_add_sql_default_expressions")]
+
+    initial = False
+
+    operations = [
+        ops.AddConstraint(
+            model_name="Employee",
+            constraint=UniqueConstraint(fields=("first_name", "last_name"), name=None),
+        ),
+        ops.AddConstraint(
+            model_name="Employee",
+            constraint=UniqueConstraint(
+                fields=("email", "department_id"), name="uq_employee_email_dept"
+            ),
+        ),
+    ]

--- a/examples/comprehensive_migrations_project/migrations/0023_drop_employee_constraints.py
+++ b/examples/comprehensive_migrations_project/migrations/0023_drop_employee_constraints.py
@@ -1,0 +1,21 @@
+from tortoise import migrations
+from tortoise.migrations import operations as ops
+
+
+class Migration(migrations.Migration):
+    dependencies = [("erp", "0022_add_employee_constraints")]
+
+    initial = False
+
+    operations = [
+        ops.RemoveConstraint(
+            model_name="Employee",
+            name=None,
+            fields=["first_name", "last_name"],
+        ),
+        ops.RemoveConstraint(
+            model_name="Employee",
+            name="uq_employee_email_dept",
+            fields=None,
+        ),
+    ]

--- a/examples/comprehensive_migrations_project/models.py
+++ b/examples/comprehensive_migrations_project/models.py
@@ -11,7 +11,7 @@ from decimal import Decimal
 from enum import Enum, IntEnum
 
 from tortoise import fields, models
-from tortoise.fields import Now, SqlDefault
+from tortoise.fields import Now, RandomHex
 
 
 class OrderStatus(IntEnum):
@@ -121,7 +121,7 @@ class Product(models.Model):
     tracking_id = fields.CharField(
         max_length=36,
         null=True,
-        db_default=SqlDefault("(lower(hex(randomblob(16))))"),
+        db_default=RandomHex(),
     )
     created_at = fields.DatetimeField(db_default=Now())
 

--- a/tests/migrations/test_operations_database.py
+++ b/tests/migrations/test_operations_database.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import re
 from typing import Any
 
 import pytest
 
-from tests.utils.fake_client import FakeClient
+from tests.utils.fake_client import FakeClient, MockIntrospectionClient
 from tortoise import fields
 from tortoise.fields.base import Field
 from tortoise.indexes import Index
@@ -22,6 +23,8 @@ from tortoise.migrations.operations import (
     RunPython,
 )
 from tortoise.migrations.schema_editor.base import BaseSchemaEditor
+from tortoise.migrations.schema_editor.base_postgres import BasePostgresSchemaEditor
+from tortoise.migrations.schema_editor.mysql import MySQLSchemaEditor
 from tortoise.migrations.schema_generator.state import ModelState, State
 from tortoise.migrations.schema_generator.state_apps import StateApps
 from tortoise.models import Model
@@ -256,3 +259,170 @@ async def test_rename_constraint_backward_runs_sql() -> None:
 
     assert client.executed
     assert 'RENAME CONSTRAINT "uniq_new" TO "uniq_old"' in client.executed[0]
+
+
+@pytest.mark.asyncio
+async def test_create_model_uses_inline_unique() -> None:
+    """CREATE TABLE should use inline UNIQUE for unique fields."""
+    OldModel = make_model(
+        "CryptoWallet",
+        meta_options={"table": "crypto_wallets"},
+        id=fields.IntField(pk=True),
+        wallet_address=fields.CharField(max_length=255, unique=True, index=True),
+    )
+
+    create_client = FakeClient("sql")
+    create_editor = TestSchemaEditor(create_client)
+    await create_editor.create_model(OldModel)
+    create_sql = create_client.executed[0]
+    assert " UNIQUE" in create_sql, f"Expected inline UNIQUE in CREATE SQL: {create_sql}"
+
+
+@pytest.mark.asyncio
+async def test_alter_field_unique_to_nonunique_generates_drop_constraint() -> None:
+    """Changing unique=True to unique=False should produce a DROP CONSTRAINT."""
+    OldModel = make_model(
+        "CryptoWallet",
+        meta_options={"table": "crypto_wallets"},
+        id=fields.IntField(pk=True),
+        wallet_address=fields.CharField(max_length=255, unique=True, index=True),
+    )
+    NewModel = make_model(
+        "CryptoWallet",
+        meta_options={"table": "crypto_wallets"},
+        id=fields.IntField(pk=True),
+        wallet_address=fields.CharField(max_length=255, unique=False, index=True),
+    )
+
+    old_state = build_state("models", OldModel)
+    new_state = build_state("models", NewModel)
+
+    alter_client = FakeClient("sql")
+    alter_editor = TestSchemaEditor(alter_client)
+    op = AlterField(
+        model_name="CryptoWallet",
+        name="wallet_address",
+        field=fields.CharField(max_length=255, index=True),
+    )
+    await op.database_forward("models", old_state, new_state, state_editor=alter_editor)
+
+    drop_sqls = [sql for sql in alter_client.executed if "DROP CONSTRAINT" in sql]
+    assert drop_sqls, f"Expected DROP CONSTRAINT SQL, got: {alter_client.executed}"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: AlterField with introspection-based constraint removal
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_postgres_alter_field_uses_introspected_legacy_name() -> None:
+    """PostgreSQL AlterField unique=True->False should use the introspected constraint name."""
+    OldModel = make_model(
+        "CryptoWallet",
+        meta_options={"table": "crypto_wallets"},
+        id=fields.IntField(pk=True),
+        wallet_address=fields.CharField(max_length=255, unique=True, index=True),
+    )
+    NewModel = make_model(
+        "CryptoWallet",
+        meta_options={"table": "crypto_wallets"},
+        id=fields.IntField(pk=True),
+        wallet_address=fields.CharField(max_length=255, unique=False, index=True),
+    )
+
+    old_state = build_state("models", OldModel)
+    new_state = build_state("models", NewModel)
+
+    client = MockIntrospectionClient(
+        "postgres",
+        constraint_names=[{"conname": "crypto_wallets_wallet_address_key"}],
+        inline_comment=False,
+    )
+    editor = BasePostgresSchemaEditor(client)
+    op = AlterField(
+        model_name="CryptoWallet",
+        name="wallet_address",
+        field=fields.CharField(max_length=255, index=True),
+    )
+    await op.database_forward("models", old_state, new_state, state_editor=editor)
+
+    drop_sqls = [sql for sql in client.executed if "DROP CONSTRAINT" in sql]
+    assert drop_sqls, f"Expected DROP CONSTRAINT SQL, got: {client.executed}"
+    assert '"crypto_wallets_wallet_address_key"' in drop_sqls[0]
+    assert "uid_" not in drop_sqls[0]
+
+
+@pytest.mark.asyncio
+async def test_mysql_alter_field_uses_introspected_legacy_name() -> None:
+    """MySQL AlterField unique=True->False should use the introspected index name."""
+    OldModel = make_model(
+        "CryptoWallet",
+        meta_options={"table": "crypto_wallets"},
+        id=fields.IntField(pk=True),
+        wallet_address=fields.CharField(max_length=255, unique=True, index=True),
+    )
+    NewModel = make_model(
+        "CryptoWallet",
+        meta_options={"table": "crypto_wallets"},
+        id=fields.IntField(pk=True),
+        wallet_address=fields.CharField(max_length=255, unique=False, index=True),
+    )
+
+    old_state = build_state("models", OldModel)
+    new_state = build_state("models", NewModel)
+
+    client = MockIntrospectionClient(
+        "mysql",
+        constraint_names=[{"CONSTRAINT_NAME": "wallet_address"}],
+    )
+    editor = MySQLSchemaEditor(client)
+    op = AlterField(
+        model_name="CryptoWallet",
+        name="wallet_address",
+        field=fields.CharField(max_length=255, index=True),
+    )
+    await op.database_forward("models", old_state, new_state, state_editor=editor)
+
+    drop_sqls = [sql for sql in client.executed if "DROP INDEX" in sql]
+    assert drop_sqls, f"Expected DROP INDEX SQL, got: {client.executed}"
+    assert "`wallet_address`" in drop_sqls[0]
+    assert "uid_" not in drop_sqls[0]
+
+
+@pytest.mark.asyncio
+async def test_postgres_alter_field_empty_introspection_uses_deterministic_name() -> None:
+    """PostgreSQL with empty introspection result falls back to deterministic uid_ name."""
+    OldModel = make_model(
+        "CryptoWallet",
+        meta_options={"table": "crypto_wallets"},
+        id=fields.IntField(pk=True),
+        wallet_address=fields.CharField(max_length=255, unique=True, index=True),
+    )
+    NewModel = make_model(
+        "CryptoWallet",
+        meta_options={"table": "crypto_wallets"},
+        id=fields.IntField(pk=True),
+        wallet_address=fields.CharField(max_length=255, unique=False, index=True),
+    )
+
+    old_state = build_state("models", OldModel)
+    new_state = build_state("models", NewModel)
+
+    client = MockIntrospectionClient(
+        "postgres",
+        constraint_names=[],
+        inline_comment=False,
+    )
+    editor = BasePostgresSchemaEditor(client)
+    op = AlterField(
+        model_name="CryptoWallet",
+        name="wallet_address",
+        field=fields.CharField(max_length=255, index=True),
+    )
+    await op.database_forward("models", old_state, new_state, state_editor=editor)
+
+    drop_sqls = [sql for sql in client.executed if "DROP CONSTRAINT" in sql]
+    assert drop_sqls, f"Expected DROP CONSTRAINT SQL, got: {client.executed}"
+    drop_match = re.search(r'"(uid_[^"]+)"', drop_sqls[0])
+    assert drop_match, f"Expected uid_ in DROP CONSTRAINT. SQL: {drop_sqls[0]}"

--- a/tests/migrations/test_schema_editor_backends.py
+++ b/tests/migrations/test_schema_editor_backends.py
@@ -1,0 +1,503 @@
+"""Backend-specific schema editor tests: bool defaults, ALTER COLUMN, FK handling, quoting."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests.utils.fake_client import FakeClient
+from tortoise import fields
+from tortoise.fields.relational import ForeignKeyFieldInstance
+from tortoise.migrations.constraints import UniqueConstraint
+from tortoise.migrations.schema_editor.base import BaseSchemaEditor
+from tortoise.migrations.schema_editor.base_postgres import BasePostgresSchemaEditor
+from tortoise.migrations.schema_editor.mssql import MSSQLSchemaEditor
+from tortoise.migrations.schema_editor.mysql import MySQLSchemaEditor
+from tortoise.migrations.schema_generator.state_apps import StateApps
+from tortoise.models import Model
+
+
+class TestSchemaEditor(BaseSchemaEditor):
+    def _get_table_comment_sql(self, table: str, comment: str) -> str:
+        return ""
+
+    def _get_column_comment_sql(self, table: str, column: str, comment: str) -> str:
+        return ""
+
+
+def init_apps(*models: type[Model]) -> None:
+    apps = StateApps()
+    for model in models:
+        apps.register_model("models", model)
+    apps._init_relations()
+
+
+# ---------------------------------------------------------------------------
+# BooleanField db_default escaping tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_postgres_bool_db_default_true() -> None:
+    """PostgreSQL should emit DEFAULT TRUE for BooleanField(db_default=True)."""
+
+    class Widget(Model):
+        id = fields.IntField(pk=True)
+        is_active = fields.BooleanField(db_default=True)
+
+        class Meta:
+            table = "widget"
+            app = "models"
+
+    client = FakeClient("postgres", inline_comment=False)
+    editor = BasePostgresSchemaEditor(client)
+    await editor.add_field(Widget, "is_active")
+
+    assert client.executed
+    assert "DEFAULT TRUE" in client.executed[0]
+
+
+@pytest.mark.asyncio
+async def test_postgres_bool_db_default_false() -> None:
+    """PostgreSQL should emit DEFAULT FALSE for BooleanField(db_default=False)."""
+
+    class Widget(Model):
+        id = fields.IntField(pk=True)
+        is_active = fields.BooleanField(db_default=False)
+
+        class Meta:
+            table = "widget"
+            app = "models"
+
+    client = FakeClient("postgres", inline_comment=False)
+    editor = BasePostgresSchemaEditor(client)
+    await editor.add_field(Widget, "is_active")
+
+    assert client.executed
+    assert "DEFAULT FALSE" in client.executed[0]
+
+
+@pytest.mark.asyncio
+async def test_base_editor_bool_db_default_still_uses_integer() -> None:
+    """Non-PostgreSQL backends should still emit DEFAULT 1 for BooleanField(db_default=True)."""
+
+    class Widget(Model):
+        id = fields.IntField(pk=True)
+        is_active = fields.BooleanField(db_default=True)
+
+        class Meta:
+            table = "widget"
+            app = "models"
+
+    client = FakeClient("sql")
+    editor = TestSchemaEditor(client)
+    await editor.add_field(Widget, "is_active")
+
+    assert client.executed
+    assert "DEFAULT 1" in client.executed[0]
+
+
+@pytest.mark.asyncio
+async def test_postgres_int_db_default_unaffected() -> None:
+    """PostgreSQL non-bool db_default should still work (regression guard)."""
+
+    class Widget(Model):
+        id = fields.IntField(pk=True)
+        stock = fields.IntField(db_default=0)
+
+        class Meta:
+            table = "widget"
+            app = "models"
+
+    client = FakeClient("postgres", inline_comment=False)
+    editor = BasePostgresSchemaEditor(client)
+    await editor.add_field(Widget, "stock")
+
+    assert client.executed
+    assert "DEFAULT 0" in client.executed[0]
+
+
+@pytest.mark.asyncio
+async def test_mssql_bool_db_default_still_uses_integer() -> None:
+    """MSSQL (BIT column) should still emit DEFAULT 1 for BooleanField(db_default=True)."""
+
+    class Widget(Model):
+        id = fields.IntField(pk=True)
+        is_active = fields.BooleanField(db_default=True)
+
+        class Meta:
+            table = "widget"
+            app = "models"
+
+    client = FakeClient("mssql", inline_comment=False)
+    editor = MSSQLSchemaEditor(client)
+    await editor.add_field(Widget, "is_active")
+
+    assert client.executed
+    assert "DEFAULT 1" in client.executed[0]
+
+
+@pytest.mark.asyncio
+async def test_postgres_alter_field_bool_db_default() -> None:
+    """PostgreSQL alter_field adding db_default=True should emit SET DEFAULT TRUE."""
+
+    class OldWidget(Model):
+        id = fields.IntField(pk=True)
+        is_active = fields.BooleanField(default=True)
+
+        class Meta:
+            table = "widget"
+            app = "models"
+
+    class NewWidget(Model):
+        id = fields.IntField(pk=True)
+        is_active = fields.BooleanField(default=True, db_default=True)
+
+        class Meta:
+            table = "widget"
+            app = "models"
+
+    client = FakeClient("postgres", inline_comment=False)
+    editor = BasePostgresSchemaEditor(client)
+    await editor.alter_field(OldWidget, NewWidget, "is_active")
+
+    assert client.executed
+    set_default_sqls = [sql for sql in client.executed if "DEFAULT" in sql]
+    assert set_default_sqls, f"Expected SET DEFAULT SQL, got: {client.executed}"
+    assert "TRUE" in set_default_sqls[0]
+
+
+# ---------------------------------------------------------------------------
+# MySQL ALTER COLUMN tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mysql_alter_field_null_to_not_null() -> None:
+    """MySQL should use MODIFY COLUMN with type for null->not-null change."""
+
+    class OldWidget(Model):
+        id = fields.IntField(pk=True)
+        budget = fields.DecimalField(null=True, max_digits=12, decimal_places=2)
+
+        class Meta:
+            table = "department"
+            app = "models"
+
+    class NewWidget(Model):
+        id = fields.IntField(pk=True)
+        budget = fields.DecimalField(max_digits=12, decimal_places=2)
+
+        class Meta:
+            table = "department"
+            app = "models"
+
+    client = FakeClient("mysql")
+    editor = MySQLSchemaEditor(client)
+    await editor.alter_field(OldWidget, NewWidget, "budget")
+
+    assert client.executed
+    sql = client.executed[0]
+    assert "MODIFY COLUMN" in sql
+    assert "`budget`" in sql
+    assert "NOT NULL" in sql
+
+
+@pytest.mark.asyncio
+async def test_mysql_alter_field_not_null_to_null() -> None:
+    """MySQL should use MODIFY COLUMN with type for not-null->null change."""
+
+    class OldWidget(Model):
+        id = fields.IntField(pk=True)
+        budget = fields.DecimalField(max_digits=12, decimal_places=2)
+
+        class Meta:
+            table = "department"
+            app = "models"
+
+    class NewWidget(Model):
+        id = fields.IntField(pk=True)
+        budget = fields.DecimalField(null=True, max_digits=12, decimal_places=2)
+
+        class Meta:
+            table = "department"
+            app = "models"
+
+    client = FakeClient("mysql")
+    editor = MySQLSchemaEditor(client)
+    await editor.alter_field(OldWidget, NewWidget, "budget")
+
+    assert client.executed
+    sql = client.executed[0]
+    assert "MODIFY COLUMN" in sql
+    assert "`budget`" in sql
+    assert "NULL" in sql
+    assert "NOT NULL" not in sql
+
+
+@pytest.mark.asyncio
+async def test_mysql_alter_field_set_default() -> None:
+    """MySQL SET DEFAULT should use backtick quoting."""
+
+    class OldWidget(Model):
+        id = fields.IntField(pk=True)
+        stock = fields.IntField()
+
+        class Meta:
+            table = "product"
+            app = "models"
+
+    class NewWidget(Model):
+        id = fields.IntField(pk=True)
+        stock = fields.IntField(db_default=10)
+
+        class Meta:
+            table = "product"
+            app = "models"
+
+    client = FakeClient("mysql")
+    editor = MySQLSchemaEditor(client)
+    await editor.alter_field(OldWidget, NewWidget, "stock")
+
+    assert client.executed
+    sql = client.executed[0]
+    assert "ALTER COLUMN `stock` SET DEFAULT" in sql
+    assert '"stock"' not in sql  # No double-quote quoting
+
+
+# ---------------------------------------------------------------------------
+# MSSQL ALTER COLUMN tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mssql_alter_field_null_to_not_null() -> None:
+    """MSSQL should use ALTER COLUMN [col] type NOT NULL for nullability change."""
+
+    class OldWidget(Model):
+        id = fields.IntField(pk=True)
+        budget = fields.DecimalField(null=True, max_digits=12, decimal_places=2)
+
+        class Meta:
+            table = "department"
+            app = "models"
+
+    class NewWidget(Model):
+        id = fields.IntField(pk=True)
+        budget = fields.DecimalField(max_digits=12, decimal_places=2)
+
+        class Meta:
+            table = "department"
+            app = "models"
+
+    client = FakeClient("mssql", inline_comment=False)
+    editor = MSSQLSchemaEditor(client)
+    await editor.alter_field(OldWidget, NewWidget, "budget")
+
+    assert client.executed
+    sql = client.executed[0]
+    assert "ALTER COLUMN [budget]" in sql
+    assert "NOT NULL" in sql
+    assert "SET NOT NULL" not in sql  # MSSQL doesn't use SET NOT NULL
+
+
+@pytest.mark.asyncio
+async def test_mssql_alter_field_set_default() -> None:
+    """MSSQL should use ADD DEFAULT ... FOR [col] instead of ALTER COLUMN SET DEFAULT."""
+
+    class OldWidget(Model):
+        id = fields.IntField(pk=True)
+        stock = fields.IntField()
+
+        class Meta:
+            table = "product"
+            app = "models"
+
+    class NewWidget(Model):
+        id = fields.IntField(pk=True)
+        stock = fields.IntField(db_default=10)
+
+        class Meta:
+            table = "product"
+            app = "models"
+
+    client = FakeClient("mssql", inline_comment=False)
+    editor = MSSQLSchemaEditor(client)
+    await editor.alter_field(OldWidget, NewWidget, "stock")
+
+    assert client.executed
+    sql = client.executed[0]
+    assert "ADD DEFAULT" in sql
+    assert "FOR [stock]" in sql
+
+
+@pytest.mark.asyncio
+async def test_mssql_alter_field_drop_default() -> None:
+    """MSSQL should use dynamic SQL to find and drop default constraint."""
+
+    class OldWidget(Model):
+        id = fields.IntField(pk=True)
+        stock = fields.IntField(db_default=10)
+
+        class Meta:
+            table = "product"
+            app = "models"
+
+    class NewWidget(Model):
+        id = fields.IntField(pk=True)
+        stock = fields.IntField()
+
+        class Meta:
+            table = "product"
+            app = "models"
+
+    client = FakeClient("mssql", inline_comment=False)
+    editor = MSSQLSchemaEditor(client)
+    await editor.alter_field(OldWidget, NewWidget, "stock")
+
+    assert client.executed
+    sql = client.executed[0]
+    assert "sys.default_constraints" in sql
+    assert "DROP CONSTRAINT" in sql
+
+
+# ---------------------------------------------------------------------------
+# MSSQL self-referencing FK tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mssql_self_referencing_fk_downgrades_cascade() -> None:
+    """MSSQL should use NO ACTION for self-referencing FK instead of CASCADE."""
+
+    class Department(Model):
+        id = fields.IntField(pk=True)
+        name = fields.CharField(max_length=150)
+        parent: ForeignKeyFieldInstance[Any] | None = fields.ForeignKeyField(
+            "models.Department",
+            source_field="parent_id",
+            null=True,
+            related_name="children",
+        )
+
+        class Meta:
+            table = "department"
+            app = "models"
+
+    init_apps(Department)
+
+    client = FakeClient("mssql", inline_comment=False)
+    editor = MSSQLSchemaEditor(client)
+    await editor.create_model(Department)
+
+    assert client.executed
+    sql = client.executed[0]
+    assert "NO ACTION" in sql
+    assert "ON DELETE CASCADE" not in sql
+
+
+@pytest.mark.asyncio
+async def test_mssql_non_self_referencing_fk_keeps_cascade() -> None:
+    """MSSQL should keep CASCADE for non-self-referencing FKs."""
+
+    class Company(Model):
+        id = fields.IntField(pk=True)
+        name = fields.CharField(max_length=300)
+
+        class Meta:
+            table = "company"
+            app = "models"
+
+    class Department(Model):
+        id = fields.IntField(pk=True)
+        name = fields.CharField(max_length=150)
+        company: ForeignKeyFieldInstance[Any] = fields.ForeignKeyField(
+            "models.Company",
+            source_field="company_id",
+            related_name="departments",
+        )
+
+        class Meta:
+            table = "department"
+            app = "models"
+
+    init_apps(Company, Department)
+
+    client = FakeClient("mssql", inline_comment=False)
+    editor = MSSQLSchemaEditor(client)
+    await editor.create_model(Department)
+
+    assert client.executed
+    sql = client.executed[0]
+    assert "ON DELETE CASCADE" in sql
+
+
+# ---------------------------------------------------------------------------
+# MSSQL template quoting tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mssql_delete_constraint_uses_brackets() -> None:
+    """MSSQL DELETE_CONSTRAINT_TEMPLATE should use bracket quoting."""
+
+    class Widget(Model):
+        id = fields.IntField(pk=True)
+        email = fields.CharField(max_length=255, unique=True)
+
+        class Meta:
+            table = "widget"
+            app = "models"
+
+    client = FakeClient("mssql", inline_comment=False)
+    editor = MSSQLSchemaEditor(client)
+    constraint = UniqueConstraint(fields=("email",))
+    await editor.remove_constraint(Widget, constraint)
+
+    assert client.executed
+    sql = client.executed[0]
+    # Should use brackets, not double quotes
+    assert "DROP CONSTRAINT [" in sql
+    assert 'DROP CONSTRAINT "' not in sql
+
+
+@pytest.mark.asyncio
+async def test_mssql_unique_constraint_create_uses_brackets() -> None:
+    """MSSQL UNIQUE_CONSTRAINT_CREATE_TEMPLATE should use bracket quoting."""
+
+    class Widget(Model):
+        id = fields.IntField(pk=True)
+        email = fields.CharField(max_length=255)
+
+        class Meta:
+            table = "widget"
+            app = "models"
+
+    client = FakeClient("mssql", inline_comment=False)
+    editor = MSSQLSchemaEditor(client)
+    constraint = UniqueConstraint(fields=("email",))
+    await editor.add_constraint(Widget, constraint)
+
+    assert client.executed
+    sql = client.executed[0]
+    assert "CONSTRAINT [" in sql
+    assert 'CONSTRAINT "' not in sql
+
+
+# ---------------------------------------------------------------------------
+# RandomHex dialect-aware default tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_random_hex_produces_dialect_specific_sql() -> None:
+    """RandomHex should produce different SQL for each dialect."""
+    from tortoise.fields.db_defaults import RandomHex
+
+    rh = RandomHex()
+    assert "randomblob" in rh.get_sql(dialect="sqlite")
+    assert "md5(random" in rh.get_sql(dialect="postgres")
+    assert "RANDOM_BYTES" in rh.get_sql(dialect="mysql")
+    assert "HASHBYTES" in rh.get_sql(dialect="mssql")
+    assert "SYS_GUID" in rh.get_sql(dialect="oracle")

--- a/tests/migrations/test_schema_editor_constraints.py
+++ b/tests/migrations/test_schema_editor_constraints.py
@@ -1,0 +1,265 @@
+"""Tests for introspection-based unique constraint removal across all backends."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.utils.fake_client import FakeClient, MockIntrospectionClient
+from tortoise import fields
+from tortoise.migrations.constraints import UniqueConstraint
+from tortoise.migrations.schema_editor.base import BaseSchemaEditor
+from tortoise.migrations.schema_editor.base_postgres import BasePostgresSchemaEditor
+from tortoise.migrations.schema_editor.mssql import MSSQLSchemaEditor
+from tortoise.migrations.schema_editor.mysql import MySQLSchemaEditor
+from tortoise.migrations.schema_editor.oracle import OracleSchemaEditor
+from tortoise.migrations.schema_editor.sqlite import SqliteSchemaEditor
+from tortoise.models import Model
+
+
+class TestSchemaEditor(BaseSchemaEditor):
+    def _get_table_comment_sql(self, table: str, comment: str) -> str:
+        return ""
+
+    def _get_column_comment_sql(self, table: str, column: str, comment: str) -> str:
+        return ""
+
+
+# Each backend's introspection returns a different dict key for the constraint name.
+# SQLite uses PRAGMA-based introspection (tested separately below).
+INTROSPECTION_BACKENDS = [
+    pytest.param(
+        BasePostgresSchemaEditor,
+        {"dialect": "postgres", "inline_comment": False},
+        {"conname": "legacy_auto_name"},
+        "legacy_auto_name",
+        id="postgres",
+    ),
+    pytest.param(
+        MySQLSchemaEditor,
+        {"dialect": "mysql"},
+        {"CONSTRAINT_NAME": "old_auto_name"},
+        "old_auto_name",
+        id="mysql",
+    ),
+    pytest.param(
+        MSSQLSchemaEditor,
+        {"dialect": "mssql", "inline_comment": False},
+        {"name": "UQ__widget__email_legacy"},
+        "UQ__widget__email_legacy",
+        id="mssql",
+    ),
+    pytest.param(
+        OracleSchemaEditor,
+        {"dialect": "oracle", "inline_comment": False},
+        {"CONSTRAINT_NAME": "SYS_C0012345"},
+        "SYS_C0012345",
+        id="oracle",
+    ),
+]
+
+
+@pytest.mark.asyncio
+async def test_base_get_unique_constraint_names_from_db_returns_empty() -> None:
+    """Base _get_unique_constraint_names_from_db returns [] (no introspection)."""
+    client = FakeClient("sql")
+    editor = TestSchemaEditor(client)
+    result = await editor._get_unique_constraint_names_from_db("widget", "name", None)
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_base_remove_constraint_fallback_to_deterministic_name() -> None:
+    """When introspection returns empty, remove_constraint uses deterministic uid_ name."""
+
+    class WidgetEmail(Model):
+        id = fields.IntField(pk=True)
+        email = fields.CharField(max_length=255, unique=True)
+
+        class Meta:
+            table = "widget"
+            app = "models"
+
+    client = FakeClient("sql")
+    editor = TestSchemaEditor(client)
+
+    constraint = UniqueConstraint(fields=("email",))
+    await editor.remove_constraint(WidgetEmail, constraint)
+
+    assert client.executed
+    drop_sql = client.executed[0]
+    assert 'DROP CONSTRAINT "uid_' in drop_sql
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("editor_cls", "client_kwargs", "mock_row", "expected_name"),
+    INTROSPECTION_BACKENDS,
+)
+async def test_introspection_returns_constraint_names(
+    editor_cls: type[BaseSchemaEditor],
+    client_kwargs: dict,
+    mock_row: dict,
+    expected_name: str,
+) -> None:
+    """Backend introspection returns the constraint name from mock results."""
+    client = MockIntrospectionClient(constraint_names=[mock_row], **client_kwargs)
+    editor = editor_cls(client)
+    result = await editor._get_unique_constraint_names_from_db("widget", "email", None)
+    assert result == [expected_name]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("editor_cls", "client_kwargs", "mock_row", "expected_name"),
+    INTROSPECTION_BACKENDS,
+)
+async def test_remove_constraint_uses_introspected_name(
+    editor_cls: type[BaseSchemaEditor],
+    client_kwargs: dict,
+    mock_row: dict,
+    expected_name: str,
+) -> None:
+    """remove_constraint should use the introspected name instead of uid_."""
+
+    class Widget(Model):
+        id = fields.IntField(pk=True)
+        email = fields.CharField(max_length=255, unique=True)
+
+        class Meta:
+            table = "widget"
+            app = "models"
+
+    client = MockIntrospectionClient(constraint_names=[mock_row], **client_kwargs)
+    editor = editor_cls(client)
+
+    constraint = UniqueConstraint(fields=("email",))
+    await editor.remove_constraint(Widget, constraint)
+
+    assert client.executed
+    drop_sql = client.executed[0]
+    assert expected_name in drop_sql
+    assert "uid_" not in drop_sql
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("editor_cls", "client_kwargs", "mock_row", "expected_name"),
+    INTROSPECTION_BACKENDS,
+)
+async def test_remove_constraint_fallback_with_fakeclient(
+    editor_cls: type[BaseSchemaEditor],
+    client_kwargs: dict,
+    mock_row: dict,
+    expected_name: str,
+) -> None:
+    """With FakeClient (no introspection) falls back to deterministic uid_ name."""
+
+    class Widget(Model):
+        id = fields.IntField(pk=True)
+        email = fields.CharField(max_length=255, unique=True)
+
+        class Meta:
+            table = "widget"
+            app = "models"
+
+    client = FakeClient(**client_kwargs)
+    editor = editor_cls(client)
+
+    constraint = UniqueConstraint(fields=("email",))
+    await editor.remove_constraint(Widget, constraint)
+
+    assert client.executed
+    drop_sql = client.executed[0]
+    assert "uid_" in drop_sql
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("editor_cls", "client_kwargs", "mock_row", "expected_name"),
+    INTROSPECTION_BACKENDS,
+)
+async def test_empty_introspection_falls_back_to_deterministic_name(
+    editor_cls: type[BaseSchemaEditor],
+    client_kwargs: dict,
+    mock_row: dict,
+    expected_name: str,
+) -> None:
+    """When introspection returns empty list, use deterministic uid_ name."""
+
+    class Widget(Model):
+        id = fields.IntField(pk=True)
+        email = fields.CharField(max_length=255, unique=True)
+
+        class Meta:
+            table = "widget"
+            app = "models"
+
+    client = MockIntrospectionClient(constraint_names=[], **client_kwargs)
+    editor = editor_cls(client)
+
+    constraint = UniqueConstraint(fields=("email",))
+    await editor.remove_constraint(Widget, constraint)
+
+    assert client.executed
+    drop_sql = client.executed[0]
+    assert "uid_" in drop_sql
+
+
+# ---------------------------------------------------------------------------
+# SQLite-specific introspection tests (PRAGMA-based, different mock shape)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sqlite_introspection_raises_with_fakeclient() -> None:
+    """SQLite _get_unique_constraint_names_from_db raises when FakeClient has no execute_query."""
+    client = FakeClient("sqlite")
+    editor = SqliteSchemaEditor(client)
+    with pytest.raises(NotImplementedError):
+        await editor._get_unique_constraint_names_from_db("widget", "name", None)
+
+
+@pytest.mark.asyncio
+async def test_sqlite_introspection_finds_unique_index() -> None:
+    """SQLite introspection should find unique index by column using PRAGMA."""
+    client = MockIntrospectionClient(
+        "sqlite",
+        pragma_index_list=[
+            {
+                "seq": 0,
+                "name": "sqlite_autoindex_widget_1",
+                "unique": 1,
+                "origin": "c",
+                "partial": 0,
+            },
+        ],
+        pragma_index_info={
+            "sqlite_autoindex_widget_1": [{"seqno": 0, "cid": 1, "name": "email"}],
+        },
+    )
+    editor = SqliteSchemaEditor(client)
+    result = await editor._get_unique_constraint_names_from_db("widget", "email", None)
+    assert result == ["sqlite_autoindex_widget_1"]
+
+
+@pytest.mark.asyncio
+async def test_sqlite_remove_constraint_fallback_with_fakeclient() -> None:
+    """SQLite with FakeClient falls back to deterministic uid_ name."""
+
+    class Widget(Model):
+        id = fields.IntField(pk=True)
+        email = fields.CharField(max_length=255, unique=True)
+
+        class Meta:
+            table = "widget"
+            app = "models"
+
+    client = FakeClient("sqlite")
+    editor = SqliteSchemaEditor(client)
+
+    constraint = UniqueConstraint(fields=("email",))
+    await editor.remove_constraint(Widget, constraint)
+
+    assert client.executed
+    drop_sql = client.executed[0]
+    assert '"uid_' in drop_sql

--- a/tests/utils/fake_client.py
+++ b/tests/utils/fake_client.py
@@ -49,3 +49,46 @@ class FakeClient(BaseDBAsyncClient):
 
     async def execute_query_dict(self, query: str, values: list | None = None) -> list[dict]:
         raise NotImplementedError()
+
+
+class MockIntrospectionClient(FakeClient):
+    """A FakeClient subclass that returns configurable results for introspection queries.
+
+    When ``execute_query`` is called with a query containing known introspection
+    keywords (``pg_constraint``, ``information_schema``, ``PRAGMA index_list``,
+    ``PRAGMA index_info``), the client returns configured results instead of
+    raising ``NotImplementedError``.
+    """
+
+    def __init__(
+        self,
+        dialect: str,
+        *,
+        constraint_names: list[dict] | None = None,
+        pragma_index_list: list[dict] | None = None,
+        pragma_index_info: dict[str, list[dict]] | None = None,
+        inline_comment: bool = True,
+        charset: str | None = None,
+    ) -> None:
+        super().__init__(dialect, inline_comment=inline_comment, charset=charset)
+        self.constraint_names = constraint_names or []
+        self.pragma_index_list = pragma_index_list or []
+        self.pragma_index_info = pragma_index_info or {}
+
+    async def execute_query(self, query: str, values: list | None = None) -> tuple[int, list[dict]]:
+        if (
+            "pg_constraint" in query
+            or "information_schema" in query
+            or "sys.key_constraints" in query
+            or "USER_CONSTRAINTS" in query
+            or "ALL_CONSTRAINTS" in query
+        ):
+            return len(self.constraint_names), self.constraint_names
+        if "PRAGMA index_list" in query:
+            return len(self.pragma_index_list), self.pragma_index_list
+        if "PRAGMA index_info" in query:
+            # Extract the index name from the query: PRAGMA index_info("idx_name")
+            idx_name = query.split('"')[1] if '"' in query else ""
+            info = self.pragma_index_info.get(idx_name, [])
+            return len(info), info
+        raise NotImplementedError()

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -583,7 +583,7 @@ def run_async(coro: Coroutine) -> None:
         portal.call(main)
 
 
-__version__ = "1.1.2"
+__version__ = "1.1.3"
 
 __all__ = [
     "BackwardFKRelation",

--- a/tortoise/backends/mssql/schema_generator.py
+++ b/tortoise/backends/mssql/schema_generator.py
@@ -17,6 +17,7 @@ class MSSQLSchemaGenerator(MSSQLQuotingMixin, BaseSchemaGenerator):
     TABLE_CREATE_TEMPLATE = "CREATE TABLE {table_name} ({fields}){extra};"
     FIELD_TEMPLATE = "[{name}] {type}{nullable}{unique}{primary}{default}"
     INDEX_CREATE_TEMPLATE = "CREATE INDEX [{index_name}] ON {table_name} ({fields});"
+    UNIQUE_CONSTRAINT_CREATE_TEMPLATE = "CONSTRAINT [{index_name}] UNIQUE ({fields})"
     GENERATED_PK_TEMPLATE = "[{field_name}] {generated_sql}"
     FK_TEMPLATE = (
         "{constraint}FOREIGN KEY ([{db_column}])"

--- a/tortoise/fields/__init__.py
+++ b/tortoise/fields/__init__.py
@@ -26,7 +26,7 @@ from tortoise.fields.data import (
     TimeField,
     UUIDField,
 )
-from tortoise.fields.db_defaults import Now, SqlDefault
+from tortoise.fields.db_defaults import Now, RandomHex, SqlDefault
 from tortoise.fields.relational import (
     BackwardFKRelation,
     BackwardOneToOneRelation,
@@ -50,6 +50,7 @@ __all__ = [
     "OnDelete",
     "Field",
     "Now",
+    "RandomHex",
     "SqlDefault",
     "BigIntField",
     "BinaryField",

--- a/tortoise/fields/db_defaults.py
+++ b/tortoise/fields/db_defaults.py
@@ -56,3 +56,39 @@ class Now(SqlDefault):
 
     def __repr__(self) -> str:
         return "Now()"
+
+
+class RandomHex(SqlDefault):
+    """Convenience subclass of :class:`SqlDefault` that emits a dialect-specific
+    expression for generating a random 32-character hex string.
+
+    Example::
+
+        class MyModel(Model):
+            tracking_id = fields.CharField(max_length=36, db_default=RandomHex())
+    """
+
+    _DIALECT_SQL: dict[str, str] = {
+        "sqlite": "(lower(hex(randomblob(16))))",
+        "postgres": "md5(random()::text)",
+        "mysql": "(LOWER(HEX(RANDOM_BYTES(16))))",
+        "mssql": "(LOWER(CONVERT(VARCHAR(32), HASHBYTES('MD5', NEWID()), 2)))",
+        "oracle": "LOWER(RAWTOHEX(SYS_GUID()))",
+    }
+
+    def __init__(self) -> None:
+        super().__init__(self._DIALECT_SQL["sqlite"])
+
+    def get_sql(self, _context=None, dialect: str | None = None) -> str:
+        if dialect and dialect in self._DIALECT_SQL:
+            return self._DIALECT_SQL[dialect]
+        return self.sql
+
+    def __repr__(self) -> str:
+        return "RandomHex()"
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, RandomHex)
+
+    def __hash__(self) -> int:
+        return hash("RandomHex")

--- a/tortoise/migrations/schema_editor/base.py
+++ b/tortoise/migrations/schema_editor/base.py
@@ -721,6 +721,42 @@ class BaseSchemaEditor(SchemaQuotingMixin):
             return constraint.name
         return self._get_unique_constraint_name(model, list(constraint.fields))
 
+    async def _get_unique_constraint_names_from_db(
+        self, table_name: str, column_name: str, schema: str | None = None
+    ) -> list[str]:
+        """Query the database for actual unique constraint/index names on a column.
+
+        Returns a list of constraint names enforcing uniqueness on the given column.
+        The base implementation returns an empty list. Backend-specific subclasses
+        override this method with introspection queries.
+        """
+        return []
+
+    async def _resolve_constraint_name(
+        self, model: type[Model], constraint: UniqueConstraint
+    ) -> str:
+        """Resolve the actual constraint name via introspection, falling back to deterministic name.
+
+        Tries database introspection first to discover the real constraint name
+        (handles legacy databases with auto-generated names). Falls back to the
+        deterministic uid_ name when introspection is unavailable (FakeClient,
+        collect_sql mode, or empty results).
+        """
+        deterministic_name = self._constraint_name_for_model(model, constraint)
+        if not self.collect_sql:
+            try:
+                column_name = constraint.fields[0]
+                introspected = await self._get_unique_constraint_names_from_db(
+                    model._meta.db_table, column_name, model._meta.schema
+                )
+                if introspected:
+                    return introspected[0]
+            except Exception:  # nosec B110
+                # Introspection unavailable (FakeClient, no connection, etc.)
+                # Fall back to deterministic name
+                pass
+        return deterministic_name
+
     async def add_index(self, model: type[Model], index: Index) -> None:
         index.resolve_expressions(model)
         index_sql = self._get_index_sql(
@@ -773,7 +809,7 @@ class BaseSchemaEditor(SchemaQuotingMixin):
         )
 
     async def remove_constraint(self, model: type[Model], constraint: UniqueConstraint) -> None:
-        constraint_name = self._constraint_name_for_model(model, constraint)
+        constraint_name = await self._resolve_constraint_name(model, constraint)
         await self._run_sql(
             self.DELETE_CONSTRAINT_TEMPLATE.format(
                 table=self._qualify_table_name(model._meta.db_table, model._meta.schema),

--- a/tortoise/migrations/schema_editor/base_postgres.py
+++ b/tortoise/migrations/schema_editor/base_postgres.py
@@ -72,6 +72,11 @@ class BasePostgresSchemaEditor(BaseSchemaEditor):
             extra=extra,
         )
 
+    def _escape_default_value(self, default: object) -> str:
+        if isinstance(default, bool):
+            return "TRUE" if default else "FALSE"
+        return super()._escape_default_value(default)
+
     def _get_unique_index_sql(
         self, table_name: str, field_names: list[str], schema: str | None = None
     ) -> str:
@@ -82,3 +87,24 @@ class BasePostgresSchemaEditor(BaseSchemaEditor):
             fields=", ".join([self.quote(f) for f in field_names]),
             extra="",
         )
+
+    async def _get_unique_constraint_names_from_db(
+        self, table_name: str, column_name: str, schema: str | None = None
+    ) -> list[str]:
+        """Query pg_constraint for unique constraint names on a specific column."""
+        nsp = schema or "public"
+        query = (
+            "SELECT con.conname "
+            "FROM pg_constraint con "
+            "JOIN pg_class rel ON rel.oid = con.conrelid "
+            "JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace "
+            "JOIN pg_attribute att ON att.attrelid = con.conrelid "
+            "AND att.attnum = ANY(con.conkey) "
+            f"WHERE rel.relname = '{table_name}' "  # nosec B608
+            f"AND att.attname = '{column_name}' "
+            "AND con.contype = 'u' "
+            "AND array_length(con.conkey, 1) = 1 "
+            f"AND nsp.nspname = '{nsp}'"
+        )
+        _, rows = await self.client.execute_query(query)
+        return [row["conname"] for row in rows]

--- a/tortoise/migrations/schema_editor/mssql.py
+++ b/tortoise/migrations/schema_editor/mssql.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from tortoise.fields.base import CASCADE
+from copy import copy
+
+from tortoise.fields.base import CASCADE, Field
 from tortoise.fields.relational import ManyToManyFieldInstance
 from tortoise.migrations.schema_editor.base import BaseSchemaEditor
 from tortoise.models import Model
@@ -37,12 +39,16 @@ class MSSQLSchemaEditor(MSSQLQuotingMixin, BaseSchemaEditor):
     RENAME_FIELD_TEMPLATE = "EXEC sp_rename '{table}.{old_column}', '{new_column}', 'COLUMN'"
     DELETE_FIELD_TEMPLATE = "ALTER TABLE {table} DROP COLUMN [{column}]"
     DROP_INDEX_TEMPLATE = "DROP INDEX [{name}] ON {table}"
+    DELETE_CONSTRAINT_TEMPLATE = "ALTER TABLE {table} DROP CONSTRAINT [{name}]"
+    DELETE_FK_TEMPLATE = DELETE_CONSTRAINT_TEMPLATE
+    UNIQUE_CONSTRAINT_CREATE_TEMPLATE = "CONSTRAINT [{index_name}] UNIQUE ({fields})"
     RENAME_INDEX_TEMPLATE = "EXEC sp_rename '{table}.{old_name}', '{new_name}', 'INDEX'"
     RENAME_CONSTRAINT_TEMPLATE = "EXEC sp_rename '{table}.{old_name}', '{new_name}', 'OBJECT'"
 
     def __init__(self, connection, atomic: bool = True, collect_sql: bool = False) -> None:
         super().__init__(connection, atomic, collect_sql=collect_sql)
         self._foreign_keys: list[str] = []
+        self._current_model_table: tuple[str, str | None] | None = None
 
     async def create_schema(self, schema_name: str) -> None:
         await self._run_sql(
@@ -70,6 +76,15 @@ class MSSQLSchemaEditor(MSSQLQuotingMixin, BaseSchemaEditor):
     def _get_column_comment_sql(self, table: str, column: str, comment: str) -> str:
         return ""
 
+    def _get_fk_field_definition(self, model: type[Model], key_field_name: str) -> str:
+        # Track the current model table so _get_fk_reference_string can detect
+        # self-referencing FKs and downgrade CASCADE to NO ACTION (MSSQL error 1785).
+        self._current_model_table = (model._meta.db_table, model._meta.schema)
+        try:
+            return super()._get_fk_field_definition(model, key_field_name)
+        finally:
+            self._current_model_table = None
+
     def _get_fk_reference_string(
         self,
         constraint_name: str,
@@ -79,6 +94,15 @@ class MSSQLSchemaEditor(MSSQLQuotingMixin, BaseSchemaEditor):
         on_delete: str,
         comment: str,
     ) -> str:
+        # MSSQL error 1785: self-referencing FK with CASCADE is not allowed.
+        # Silently downgrade to NO ACTION for self-referencing FKs.
+        current = getattr(self, "_current_model_table", None)
+        if current and on_delete == CASCADE:
+            source_table, source_schema = current
+            source_qualified = self._qualify_table_name(source_table, source_schema)
+            if table == source_qualified:
+                on_delete = "NO ACTION"
+
         constraint = f"CONSTRAINT [{constraint_name}] " if constraint_name else ""
         fk = self.FK_TEMPLATE.format(
             constraint=constraint,
@@ -96,6 +120,65 @@ class MSSQLSchemaEditor(MSSQLQuotingMixin, BaseSchemaEditor):
         extra = list(dict.fromkeys(self._foreign_keys))
         self._foreign_keys.clear()
         return extra
+
+    async def _alter_field(self, model: type[Model], old_field: Field, new_field: Field) -> None:
+        db_field = new_field.source_field or new_field.model_field_name
+        qualified_table = self._qualify_table_name(model._meta.db_table, model._meta.schema)
+
+        # MSSQL requires ALTER COLUMN with full type for nullability changes
+        if old_field.null != new_field.null:
+            col_type = new_field.get_for_dialect(self.DIALECT, "SQL_TYPE")
+            nullable = "NULL" if new_field.null else "NOT NULL"
+            await self._run_sql(
+                f"ALTER TABLE {qualified_table} ALTER COLUMN [{db_field}] {col_type} {nullable}"
+            )
+            old_field = copy(old_field)
+            old_field.null = new_field.null
+
+        # MSSQL uses named default constraints instead of ALTER COLUMN SET/DROP DEFAULT
+        old_has_default = old_field.has_db_default()
+        new_has_default = new_field.has_db_default()
+        default_changed = old_has_default != new_has_default or (
+            old_has_default and new_has_default and old_field.db_default != new_field.db_default
+        )
+        if default_changed:
+            if old_has_default:
+                await self._drop_default_constraint(
+                    model._meta.db_table, db_field, model._meta.schema
+                )
+            if new_has_default:
+                if hasattr(new_field.db_default, "get_sql"):
+                    default_sql = new_field.db_default.get_sql(dialect=self.DIALECT)
+                else:
+                    db_val = new_field.to_db_value(new_field.db_default, model)
+                    default_sql = self._escape_default_value(db_val)
+                await self._run_sql(
+                    f"ALTER TABLE {qualified_table} ADD DEFAULT {default_sql} FOR [{db_field}]"
+                )
+            # Patch so super() skips the default change
+            old_field = copy(old_field)
+            old_field.db_default = new_field.db_default
+
+        # Let base handle index, unique, description, and rename
+        await super()._alter_field(model, old_field, new_field)
+
+    async def _drop_default_constraint(
+        self, table_name: str, column_name: str, schema: str | None = None
+    ) -> None:
+        schema_filter = f" AND s.name = '{schema}'" if schema else ""
+        drop_sql = (  # nosec B608
+            "DECLARE @sql NVARCHAR(MAX) = N'';\n"
+            "SELECT @sql = N'ALTER TABLE [' + s.name + '].[' + t.name + ']"
+            " DROP CONSTRAINT [' + dc.name + ']'\n"
+            "FROM sys.default_constraints dc\n"
+            "JOIN sys.columns c ON dc.parent_object_id = c.object_id"
+            " AND dc.parent_column_id = c.column_id\n"
+            "JOIN sys.tables t ON dc.parent_object_id = t.object_id\n"
+            "JOIN sys.schemas s ON t.schema_id = s.schema_id\n"
+            f"WHERE t.name = '{table_name}' AND c.name = '{column_name}'{schema_filter};\n"
+            "IF @sql <> N'' EXEC sp_executesql @sql;"
+        )
+        await self._run_sql(drop_sql)
 
     def _format_m2m_fk(self, table: str, column: str, target_table: str, target_field: str) -> str:
         return self.FK_TEMPLATE.format(
@@ -160,11 +243,31 @@ class MSSQLSchemaEditor(MSSQLQuotingMixin, BaseSchemaEditor):
                     m2m_create_string = "\n".join(lines)
         return m2m_create_string
 
+    async def _get_unique_constraint_names_from_db(
+        self, table_name: str, column_name: str, schema: str | None = None
+    ) -> list[str]:
+        """Query sys.key_constraints for unique constraint names on a specific column."""
+        schema_filter = f" AND s.name = '{schema}'" if schema else ""
+        query = (  # nosec B608
+            "SELECT kc.name "
+            "FROM sys.key_constraints kc "
+            "JOIN sys.tables t ON kc.parent_object_id = t.object_id "
+            "JOIN sys.schemas s ON t.schema_id = s.schema_id "
+            "JOIN sys.index_columns ic ON kc.parent_object_id = ic.object_id "
+            "AND kc.unique_index_id = ic.index_id "
+            "JOIN sys.columns c ON ic.object_id = c.object_id AND ic.column_id = c.column_id "
+            f"WHERE t.name = '{table_name}' AND c.name = '{column_name}' "
+            f"AND kc.type = 'UQ'{schema_filter}"
+        )
+        _, rows = await self.client.execute_query(query)
+        return [row["name"] for row in rows]
+
     async def remove_constraint(self, model, constraint) -> None:
+        constraint_name = await self._resolve_constraint_name(model, constraint)
         await self._run_sql(
             self.DELETE_CONSTRAINT_TEMPLATE.format(
                 table=self._qualify_table_name(model._meta.db_table, model._meta.schema),
-                name=self._constraint_name_for_model(model, constraint),
+                name=constraint_name,
             )
         )
 

--- a/tortoise/migrations/schema_editor/mysql.py
+++ b/tortoise/migrations/schema_editor/mysql.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from tortoise.fields.base import CASCADE
+from copy import copy
+
+from tortoise.fields.base import CASCADE, Field
 from tortoise.fields.relational import ManyToManyFieldInstance
 from tortoise.migrations.schema_editor.base import BaseSchemaEditor
 from tortoise.models import Model
@@ -30,6 +32,10 @@ class MySQLSchemaEditor(MySQLQuotingMixin, BaseSchemaEditor):
     DELETE_TABLE_TEMPLATE = "DROP TABLE {table}"
     ADD_FIELD_TEMPLATE = "ALTER TABLE {table} ADD COLUMN {definition}"
     ALTER_FIELD_TEMPLATE = "ALTER TABLE {table} {changes}"
+    ALTER_FIELD_NULL_TEMPLATE = "ALTER COLUMN `{column}` DROP NOT NULL"
+    ALTER_FIELD_NOT_NULL_TEMPLATE = "ALTER COLUMN `{column}` SET NOT NULL"
+    ALTER_FIELD_SET_DEFAULT_TEMPLATE = "ALTER COLUMN `{column}` SET DEFAULT {default}"
+    ALTER_FIELD_DROP_DEFAULT_TEMPLATE = "ALTER COLUMN `{column}` DROP DEFAULT"
     RENAME_FIELD_TEMPLATE = "ALTER TABLE {table} RENAME COLUMN `{old_column}` TO `{new_column}`"
     DELETE_FIELD_TEMPLATE = "ALTER TABLE {table} DROP COLUMN `{column}`"
     DROP_INDEX_TEMPLATE = "DROP INDEX `{name}` ON {table}"
@@ -171,16 +177,58 @@ class MySQLSchemaEditor(MySQLQuotingMixin, BaseSchemaEditor):
                     m2m_create_string = "\n".join(lines)
         return m2m_create_string
 
+    async def _alter_field(self, model: type[Model], old_field: Field, new_field: Field) -> None:
+        # MySQL does not support ALTER COLUMN ... SET/DROP NOT NULL.
+        # It requires MODIFY COLUMN with the full column type specification.
+        if old_field.null != new_field.null:
+            db_field = new_field.source_field or new_field.model_field_name
+            qualified_table = self._qualify_table_name(model._meta.db_table, model._meta.schema)
+            col_type = new_field.get_for_dialect(self.DIALECT, "SQL_TYPE")
+            nullable = "NULL" if new_field.null else "NOT NULL"
+            await self._run_sql(
+                f"ALTER TABLE {qualified_table} MODIFY COLUMN"
+                f" {self.quote(db_field)} {col_type} {nullable}"
+            )
+            # Patch old_field copy so base skips the null change
+            old_field = copy(old_field)
+            old_field.null = new_field.null
+
+        await super()._alter_field(model, old_field, new_field)
+
     async def add_constraint(self, model, constraint) -> None:
-        unique_index_sql = self._get_unique_index_sql(
-            model._meta.db_table, list(constraint.fields), schema=model._meta.schema
+        table = self._qualify_table_name(model._meta.db_table, model._meta.schema)
+        index_name = self._generate_index_name_for_table(
+            "uidx", model._meta.db_table, list(constraint.fields)
         )
-        await self._run_sql(unique_index_sql)
+        columns = ", ".join([self.quote(f) for f in constraint.fields])
+        await self._run_sql(f"ALTER TABLE {table} ADD UNIQUE KEY `{index_name}` ({columns})")
+
+    async def _get_unique_constraint_names_from_db(
+        self, table_name: str, column_name: str, schema: str | None = None
+    ) -> list[str]:
+        """Query information_schema for unique constraint names on a specific column."""
+        query = (
+            "SELECT tc.CONSTRAINT_NAME "
+            "FROM information_schema.table_constraints tc "
+            "JOIN information_schema.key_column_usage kcu "
+            "ON tc.CONSTRAINT_NAME = kcu.CONSTRAINT_NAME "
+            "AND tc.TABLE_SCHEMA = kcu.TABLE_SCHEMA "
+            "AND tc.TABLE_NAME = kcu.TABLE_NAME "
+            f"WHERE tc.TABLE_NAME = '{table_name}' "  # nosec B608
+            "AND tc.TABLE_SCHEMA = DATABASE() "
+            "AND tc.CONSTRAINT_TYPE = 'UNIQUE' "
+            f"AND kcu.COLUMN_NAME = '{column_name}' "
+            "GROUP BY tc.CONSTRAINT_NAME "
+            "HAVING COUNT(kcu.COLUMN_NAME) = 1"
+        )
+        _, rows = await self.client.execute_query(query)
+        return [row["CONSTRAINT_NAME"] for row in rows]
 
     async def remove_constraint(self, model, constraint) -> None:
+        constraint_name = await self._resolve_constraint_name(model, constraint)
         await self._run_sql(
             self.DROP_INDEX_TEMPLATE.format(
                 table=self._qualify_table_name(model._meta.db_table, model._meta.schema),
-                name=self._constraint_name_for_model(model, constraint),
+                name=constraint_name,
             )
         )

--- a/tortoise/migrations/schema_editor/oracle.py
+++ b/tortoise/migrations/schema_editor/oracle.py
@@ -135,3 +135,34 @@ class OracleSchemaEditor(BaseSchemaEditor):
                     lines.insert(-1, indent + unique_index_sql)
                     m2m_create_string = "\n".join(lines)
         return m2m_create_string
+
+    async def _get_unique_constraint_names_from_db(
+        self, table_name: str, column_name: str, schema: str | None = None
+    ) -> list[str]:
+        """Query USER_CONSTRAINTS/ALL_CONSTRAINTS for unique constraint names on a column."""
+        upper_table = table_name.upper()
+        upper_column = column_name.upper()
+        if schema:
+            query = (
+                "SELECT ac.CONSTRAINT_NAME "
+                "FROM ALL_CONSTRAINTS ac "
+                "JOIN ALL_CONS_COLUMNS acc "
+                "ON ac.CONSTRAINT_NAME = acc.CONSTRAINT_NAME "
+                "AND ac.OWNER = acc.OWNER "
+                f"WHERE ac.TABLE_NAME = '{upper_table}' "  # nosec B608
+                f"AND acc.COLUMN_NAME = '{upper_column}' "
+                "AND ac.CONSTRAINT_TYPE = 'U' "
+                f"AND ac.OWNER = '{schema.upper()}'"
+            )
+        else:
+            query = (
+                "SELECT uc.CONSTRAINT_NAME "
+                "FROM USER_CONSTRAINTS uc "
+                "JOIN USER_CONS_COLUMNS ucc "
+                "ON uc.CONSTRAINT_NAME = ucc.CONSTRAINT_NAME "
+                f"WHERE uc.TABLE_NAME = '{upper_table}' "  # nosec B608
+                f"AND ucc.COLUMN_NAME = '{upper_column}' "
+                "AND uc.CONSTRAINT_TYPE = 'U'"
+            )
+        _, rows = await self.client.execute_query(query)
+        return [row["CONSTRAINT_NAME"] for row in rows]

--- a/tortoise/migrations/schema_editor/sqlite.py
+++ b/tortoise/migrations/schema_editor/sqlite.py
@@ -151,8 +151,24 @@ class SqliteSchemaEditor(SqliteQuotingMixin, BaseSchemaEditor):
         )
         await self._run_sql(index_sql)
 
+    async def _get_unique_constraint_names_from_db(
+        self, table_name: str, column_name: str, schema: str | None = None
+    ) -> list[str]:
+        """Use PRAGMA index_list + PRAGMA index_info to find unique index names."""
+        _, indexes = await self.client.execute_query(f'PRAGMA index_list("{table_name}")')
+        result: list[str] = []
+        for idx in indexes:
+            if not idx.get("unique"):
+                continue
+            idx_name = idx.get("name", "")
+            _, columns = await self.client.execute_query(f'PRAGMA index_info("{idx_name}")')
+            col_names = [col.get("name") for col in columns]
+            if col_names == [column_name]:
+                result.append(idx_name)
+        return result
+
     async def remove_constraint(self, model, constraint) -> None:
-        constraint_name = self._constraint_name_for_model(model, constraint)
+        constraint_name = await self._resolve_constraint_name(model, constraint)
         await self.remove_index(
             model,
             Index(fields=constraint.fields, name=constraint_name),

--- a/tortoise/migrations/schema_generator/state.py
+++ b/tortoise/migrations/schema_generator/state.py
@@ -83,6 +83,8 @@ class ModelState(BaseEntityState):
             options["app"] = model._meta.app
         if model._meta.unique_together:
             options["unique_together"] = model._meta.unique_together
+        if model._meta.constraints:
+            options["constraints"] = model._meta.constraints
         if model._meta.indexes:
             options["indexes"] = model._meta.indexes
         if model._meta.pk_attr:

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -201,6 +201,7 @@ class MetaInfo:
         "basetable",
         "_filters",
         "unique_together",
+        "constraints",
         "manager",
         "indexes",
         "pk_attr",
@@ -223,6 +224,7 @@ class MetaInfo:
         self.schema: str | None = getattr(meta, "schema", None)
         self.app: str | None = getattr(meta, "app", None)
         self.unique_together: tuple[tuple[str, ...], ...] = get_together(meta, "unique_together")
+        self.constraints: tuple = tuple(getattr(meta, "constraints", ()))
         self.indexes: tuple[tuple[str, ...] | Index, ...] = get_together(meta, "indexes")
         self._default_ordering: tuple[tuple[str, Order], ...] = prepare_default_ordering(meta)
         self._ordering_validated: bool = False


### PR DESCRIPTION
Resolved #2108 and some other backend specific issues

AI summary:
This pull request introduces several improvements and new features to the migrations and schema editing system, with a focus on enhanced cross-database compatibility, new constraint management, and improved test coverage. The most significant changes include the addition of a dialect-aware random hex default generator, support for named unique constraints in migrations, enhancements to schema editors for MySQL and MSSQL, and comprehensive tests for unique constraint handling.

**Major Features and Enhancements**

* Added a new `RandomHex` dialect-aware `SqlDefault` subclass to generate random hex strings as default values across all supported backends, replacing backend-specific SQL expressions. (`RandomHex`) is now used in both models and migrations for fields like `tracking_id`. [[1]](diffhunk://#diff-c12d82de94e3bcc6048ed11c06b1c043e49caf53317c91299628ff928c28ef03L2-R2) [[2]](diffhunk://#diff-c12d82de94e3bcc6048ed11c06b1c043e49caf53317c91299628ff928c28ef03L20-R20) [[3]](diffhunk://#diff-19d4b206ab03922b5f2148895db988a3ceb8421c27915e3a65c5b8be74758843L14-R14) [[4]](diffhunk://#diff-19d4b206ab03922b5f2148895db988a3ceb8421c27915e3a65c5b8be74758843L124-R124) [[5]](diffhunk://#diff-2c623f3c6a917be56c59d43279244996836262cb1e12d9d0786c9c49eef6b43cR11-R26)
* Introduced support for `Meta.constraints` on models, enabling named `UniqueConstraint` objects to be captured by the migration autodetector. This allows for automatic generation of `AddConstraint` and `RemoveConstraint` operations in migrations. [[1]](diffhunk://#diff-1bf21c692e8b7f958306da6a8034d1b790754dd4693c8daccb035d66debb0f31R1-R22) [[2]](diffhunk://#diff-588b57bdeb0b1b8b33523f6e65f77063fa570949f351dbb802dff83265752df6R1-R21) [[3]](diffhunk://#diff-2c623f3c6a917be56c59d43279244996836262cb1e12d9d0786c9c49eef6b43cR11-R26)

**Schema Editor and Backend Improvements**

* Enhanced MySQL and MSSQL schema editors:
  - MySQL: `_alter_field` now uses `MODIFY COLUMN` for NULL/NOT NULL changes and backtick-quoted templates.
  - MSSQL: `_alter_field` uses `ALTER COLUMN` for nullability, manages named default constraints, uses bracket-quoted templates, and downgrades self-referencing FK CASCADE to NO ACTION.

**Migration and Model Changes**

* Updated migrations to use dialect-specific SQL for computed fields and switched from `RunSQL` to `RunPython` for better backend compatibility. [[1]](diffhunk://#diff-86dc66973bb19ca98929ccaf57da905bbda02618963ae8cb619ac1c6f447fd30R8-R14) [[2]](diffhunk://#diff-86dc66973bb19ca98929ccaf57da905bbda02618963ae8cb619ac1c6f447fd30R40-R58) [[3]](diffhunk://#diff-86dc66973bb19ca98929ccaf57da905bbda02618963ae8cb619ac1c6f447fd30L43-R71)
* Adjusted the order of model creation in migrations for consistency and correctness. [[1]](diffhunk://#diff-bd731650b164cdf05b05c1085c2e9e8a57f8b6e9ac9d14cbba0338c703122104R12-R33) [[2]](diffhunk://#diff-bd731650b164cdf05b05c1085c2e9e8a57f8b6e9ac9d14cbba0338c703122104L45-L66)

**Testing Improvements**

* Added comprehensive tests for unique constraint handling, including:
  - Inline unique constraints in `CREATE TABLE` statements.
  - Proper dropping of unique constraints when altering fields from unique to non-unique.
  - Backend-specific introspection and fallback behavior for constraint names in PostgreSQL and MySQL. [[1]](diffhunk://#diff-d8bb20df6aabc14326eadef9c9b2bd27a8c2b1e3ac98170c313ec28cdff15e52R3-R8) [[2]](diffhunk://#diff-d8bb20df6aabc14326eadef9c9b2bd27a8c2b1e3ac98170c313ec28cdff15e52R26-R27) [[3]](diffhunk://#diff-d8bb20df6aabc14326eadef9c9b2bd27a8c2b1e3ac98170c313ec28cdff15e52R262-R428)

**Documentation**

* Updated the `CHANGELOG.rst` to document all new features, backend improvements, and bug fixes included in this release.