### PR TITLE
Fix sql(params_inline=True) not inlining subquery filter values

### DIFF
--- a/tests/test_query_api.py
+++ b/tests/test_query_api.py
@@ -17,6 +17,7 @@ from tortoise.connection import connections
 from tortoise.context import TortoiseContext, tortoise_test_context
 from tortoise.contrib import test
 from tortoise.exceptions import ParamsError
+from tortoise.expressions import Subquery
 from tortoise.models import Model
 from tortoise.query_api import QueryResult, execute_pypika
 
@@ -343,3 +344,20 @@ async def test_execute_pypika_requires_connection_with_multiple_configured(multi
         await execute_pypika(query)
 
     assert "multiple databases" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_subquery_params_inline(query_api_db) -> None:
+    """Subquery filter values should be inlined when using sql(params_inline=True).
+
+    Regression test for https://github.com/tortoise/tortoise-orm/issues/1800
+    """
+    query = QueryModel.filter(
+        id__in=Subquery(QueryModel.filter(name="alpha").values_list("id"))
+    )
+    sql = query.sql(params_inline=True)
+    assert "'alpha'" in sql, f"Expected 'alpha' in inline SQL, got: {sql}"
+
+    # Also verify parameterized mode still works
+    sql_param = query.sql(params_inline=False)
+    assert "alpha" not in sql_param, f"Expected no 'alpha' in parameterized SQL, got: {sql_param}"

--- a/tortoise/expressions.py
+++ b/tortoise/expressions.py
@@ -233,7 +233,9 @@ class Subquery(Term):
     def get_sql(self, ctx: SqlContext) -> str:
         self.query._choose_db_if_not_chosen()
         self.query._make_query()
-        return self.query.query.get_parameterized_sql(ctx)[0]
+        if ctx.parameterizer:
+            return self.query.query.get_parameterized_sql(ctx)[0]
+        return self.query.query.get_sql(ctx)
 
     def as_(self, alias: str) -> Selectable:  # type: ignore
         self.query._choose_db_if_not_chosen()


### PR DESCRIPTION
## Summary

Fixes #1800

`Subquery.get_sql()` unconditionally called `get_parameterized_sql()`, which creates a new `Parameterizer` even when the outer context expects inline values. This caused subquery filter values to be rendered as `?` placeholders instead of being inlined.

The fix checks whether the `SqlContext` has an active parameterizer:
- If yes (parameterized mode): use `get_parameterized_sql()` so values are collected into the outer query's parameterizer
- If no (inline mode): use `get_sql()` so values are rendered directly

### Before
```python
query = MyModel.filter(id__in=Subquery(OtherModel.filter(field="test_value").values_list("id")))
query.sql(params_inline=True)
# SELECT ... WHERE "id" IN (SELECT "id" FROM "other_model" WHERE "field"=?)
#                                                                        ^ value missing
```

### After
```python
query.sql(params_inline=True)
# SELECT ... WHERE "id" IN (SELECT "id" FROM "other_model" WHERE "field"='test_value')
#                                                                        ^ value inlined
```

## Changes

- `tortoise/expressions.py`: Check `ctx.parameterizer` before choosing between `get_sql()` and `get_parameterized_sql()`
- `tests/test_query_api.py`: Added regression test verifying subquery values are inlined

## Test plan
- [x] New regression test passes (`test_subquery_params_inline`)
- [x] Existing subquery tests pass (`test_queryset.py -k subquery`)
- [x] Existing `params_inline` tests pass (`test_case_when.py`)
- [x] All query API tests pass (16 passed, 2 skipped)