### PR TITLE
fix: ensure AddIndex, AddConstraint, RemoveIndex and RemoveConstraint are in correct order

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,13 @@ Changelog
 1.1
 ===
 
+1.1.6
+-----
+
+Fixed
+^^^^^
+- Migration generator now correctly orders ``AddField`` before ``AddIndex`` or ``AddConstraint`` when adding a new indexed field or constraint field to a model.
+
 1.1.5
 -----
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@ Changelog
 
 Fixed
 ^^^^^
-- Migration generator now correctly orders ``AddField`` before ``AddIndex`` or ``AddConstraint`` when adding a new indexed field or constraint field to a model.
+- Migration generator now correctly orders ``AddIndex``, ``RemoveIndex``, ``AddConstraint``, ``RemoveConstraint`` operatins when adding/removing a field to a model and is used in an index or constraint.
 
 1.1.5
 -----

--- a/tests/migrations/test_state_diff_operations.py
+++ b/tests/migrations/test_state_diff_operations.py
@@ -388,3 +388,41 @@ def test_detect_check_constraint_removed() -> None:
     assert len(operations) == 1
     assert isinstance(operations[0], RemoveConstraint)
     assert operations[0].name == "ck_price"
+
+
+def test_generate_alter_field_and_add_index_in_correct_order() -> None:
+    OldWidget = make_model("Widget", "widget", id=fields.IntField(pk=True))
+    NewWidget = make_model(
+        "Widget",
+        "widget",
+        {"indexes": [Index(fields=["value"])]},
+        id=fields.IntField(pk=True),
+        value=fields.IntField(),
+    )
+
+    old_state = build_state("models", OldWidget)
+    new_state = build_state("models", NewWidget)
+
+    operations = OperationGenerator(old_state, new_state).generate()
+    assert len(operations) == 2
+    assert isinstance(operations[0], AddField)
+    assert isinstance(operations[1], AddIndex)
+
+
+def test_generate_alter_field_and_constraint_in_correct_order() -> None:
+    OldWidget = make_model("Widget", "widget", id=fields.IntField(pk=True))
+    NewWidget = make_model(
+        "Widget",
+        "widget",
+        {"constraints": [UniqueConstraint(fields=("value",), name="uq_new")]},
+        id=fields.IntField(pk=True),
+        value=fields.IntField(),
+    )
+
+    old_state = build_state("models", OldWidget)
+    new_state = build_state("models", NewWidget)
+
+    operations = OperationGenerator(old_state, new_state).generate()
+    assert len(operations) == 2
+    assert isinstance(operations[0], AddField)
+    assert isinstance(operations[1], AddConstraint)

--- a/tests/migrations/test_state_diff_operations.py
+++ b/tests/migrations/test_state_diff_operations.py
@@ -409,7 +409,7 @@ def test_generate_alter_field_and_add_index_in_correct_order() -> None:
     assert isinstance(operations[1], AddIndex)
 
 
-def test_generate_alter_field_and_constraint_in_correct_order() -> None:
+def test_generate_alter_field_and_add_constraint_in_correct_order() -> None:
     OldWidget = make_model("Widget", "widget", id=fields.IntField(pk=True))
     NewWidget = make_model(
         "Widget",
@@ -426,3 +426,41 @@ def test_generate_alter_field_and_constraint_in_correct_order() -> None:
     assert len(operations) == 2
     assert isinstance(operations[0], AddField)
     assert isinstance(operations[1], AddConstraint)
+
+
+def test_generate_alter_field_and_remove_index_in_correct_order() -> None:
+    OldWidget = make_model(
+        "Widget",
+        "widget",
+        {"indexes": [Index(fields=["value"])]},
+        id=fields.IntField(pk=True),
+        value=fields.IntField(),
+    )
+    NewWidget = make_model("Widget", "widget", id=fields.IntField(pk=True))
+
+    old_state = build_state("models", OldWidget)
+    new_state = build_state("models", NewWidget)
+
+    operations = OperationGenerator(old_state, new_state).generate()
+    assert len(operations) == 2
+    assert isinstance(operations[0], RemoveIndex)
+    assert isinstance(operations[1], RemoveField)
+
+
+def test_generate_alter_field_and_remove_constraint_in_correct_order() -> None:
+    OldWidget = make_model(
+        "Widget",
+        "widget",
+        {"constraints": [UniqueConstraint(fields=("value",), name="uq_new")]},
+        id=fields.IntField(pk=True),
+        value=fields.IntField(),
+    )
+    NewWidget = make_model("Widget", "widget", id=fields.IntField(pk=True))
+
+    old_state = build_state("models", OldWidget)
+    new_state = build_state("models", NewWidget)
+
+    operations = OperationGenerator(old_state, new_state).generate()
+    assert len(operations) == 2
+    assert isinstance(operations[0], RemoveConstraint)
+    assert isinstance(operations[1], RemoveField)

--- a/tortoise/migrations/schema_generator/state_diff.py
+++ b/tortoise/migrations/schema_generator/state_diff.py
@@ -131,7 +131,6 @@ class StateModelDiff:
 
         # Classes that must always be last
         always_last = (AddIndex, AddConstraint)
-
         operations = sorted(operations, key=lambda op: isinstance(op, always_last))
         return operations
 

--- a/tortoise/migrations/schema_generator/state_diff.py
+++ b/tortoise/migrations/schema_generator/state_diff.py
@@ -115,7 +115,6 @@ class StateModelDiff:
             return []
 
         operations: list[TortoiseOperation] = []
-        operations.extend(StateFieldDiff(self.old_state, self.new_state).generate_operations())
         operations.extend(self._generate_index_operations())
         operations.extend(self._generate_constraint_operations())
         old_options = _model_options_for_compare(self.old_state.options)
@@ -128,6 +127,12 @@ class StateModelDiff:
                 )
             )
 
+        operations.extend(StateFieldDiff(self.old_state, self.new_state).generate_operations())
+
+        # Classes that must always be last
+        always_last = (AddIndex, AddConstraint)
+
+        operations = sorted(operations, key=lambda op: isinstance(op, always_last))
         return operations
 
     @staticmethod

--- a/tortoise/migrations/schema_generator/state_diff.py
+++ b/tortoise/migrations/schema_generator/state_diff.py
@@ -115,6 +115,7 @@ class StateModelDiff:
             return []
 
         operations: list[TortoiseOperation] = []
+        operations.extend(StateFieldDiff(self.old_state, self.new_state).generate_operations())
         operations.extend(self._generate_index_operations())
         operations.extend(self._generate_constraint_operations())
         old_options = _model_options_for_compare(self.old_state.options)
@@ -127,7 +128,6 @@ class StateModelDiff:
                 )
             )
 
-        operations.extend(StateFieldDiff(self.old_state, self.new_state).generate_operations())
         return operations
 
     @staticmethod


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Ensures migration generator now correctly orders `AddIndex` , `AddConstraint`, `RemoveIndex`, `RemoveConstraint` when adding/removing a new indexed field or constraint field to a model.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When adding a new field on an existing model, and using that field in as an index or a constraint, the migration creates operations in the wrong order.
Going from this model:
```python
class OldWidget(models.Model):
    id = fields.IntField(pk=True)
```
to this model:
```python
class OldWidget(models.Model):
    id = fields.IntField(pk=True)
    value = fields.IntField()
    
    class Meta:
        indexes = [Index(fields=["value"])]
```

would generate a migration file with operations in order: `[AddIndex, AddField]` causing migration to fail as it can't add an index to a non existing field.
This PR fixes this order.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

