### PR TITLE
Fix plus sign in DB URL password being decoded to space

### DIFF
--- a/tests/backends/test_db_url.py
+++ b/tests/backends/test_db_url.py
@@ -245,6 +245,12 @@ def test_mysql_pre_encoded_percent_in_password():
     assert res["credentials"]["password"] == "foo%bar"
 
 
+def test_postgres_plus_sign_in_password():
+    for scheme, engine in _postgres_scheme_engines.items():
+        res = expand_db_url(f"{scheme}://postgres:p%2Bss+word@127.0.0.1:54321/test")
+        assert res["credentials"]["password"] == "p+ss+word"
+
+
 def test_mysql_basic():
     res = expand_db_url("mysql://root:@127.0.0.1:33060/test")
     assert res == {

--- a/tortoise/backends/base/config_generator.py
+++ b/tortoise/backends/base/config_generator.py
@@ -212,7 +212,7 @@ def expand_db_url(db_url: str, testing: bool = False) -> dict:
         params[vmap["password"]] = (
             None
             if (not url.password and db_backend in {"postgres", "asyncpg", "psycopg"})
-            else urlparse.unquote_plus(url.password or "")
+            else urlparse.unquote(url.password or "")
         )
 
     return {"engine": db["engine"], "credentials": params}


### PR DESCRIPTION
## Description

Changed `unquote_plus()` to `unquote()` when decoding the password from the database URL. This preserves literal `+` characters in passwords.

## Motivation and Context

Fixes #1505

The `+`-as-space encoding is only valid in query strings, not in the userinfo component of a URI (RFC 3986). Popular libraries like SQLAlchemy and libpq use `unquote()` for the same reason. Some PaaS platforms (e.g., Railway.app) pass DB URLs with plain `+` in passwords via environment variables, and these were being silently corrupted to spaces.

## How Has This Been Tested?

Added `test_postgres_plus_sign_in_password` that verifies a URL with both a literal `+` and a percent-encoded `%2B` in the password produces the correct decoded password. All 30 existing `test_db_url` tests continue to pass.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.