### PR TITLE
fix: use configured timezone for MySQL session time_zone

### DIFF
--- a/tests/backends/test_connection_params.py
+++ b/tests/backends/test_connection_params.py
@@ -190,9 +190,7 @@ async def test_mysql_session_timezone_uses_configured_tz():
 
                 # Verify SET time_zone was called with Asia/Shanghai offset (+8:00)
                 tz_calls = [
-                    call
-                    for call in mock_cursor.execute.await_args_list
-                    if "time_zone" in str(call)
+                    call for call in mock_cursor.execute.await_args_list if "time_zone" in str(call)
                 ]
                 assert len(tz_calls) == 1, f"Expected 1 SET time_zone call, got {tz_calls}"
                 assert "+8:00" in str(tz_calls[0]), (

--- a/tests/backends/test_connection_params.py
+++ b/tests/backends/test_connection_params.py
@@ -1,8 +1,15 @@
-from unittest.mock import AsyncMock, patch
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import asyncpg
 import pytest
 
+try:
+    import asyncmy as mysql
+except ImportError:
+    import aiomysql as mysql
+
+from tortoise import timezone
 from tortoise.context import TortoiseContext
 
 
@@ -129,3 +136,75 @@ async def test_psycopg_connection_params():
                 )
     except ImportError:
         pytest.skip("psycopg not installed")
+
+
+@pytest.mark.asyncio
+async def test_mysql_session_timezone_uses_configured_tz():
+    """Test that MySQL session timezone reflects the configured timezone, not UTC.
+
+    Regression test for https://github.com/tortoise/tortoise-orm/issues/2114
+    """
+    mock_cursor = AsyncMock()
+
+    # connection.cursor() must return a sync object that supports async-with
+    cursor_cm = MagicMock()
+    cursor_cm.__aenter__ = AsyncMock(return_value=mock_cursor)
+    cursor_cm.__aexit__ = AsyncMock(return_value=False)
+
+    mock_connection = MagicMock()
+    mock_connection.cursor.return_value = cursor_cm
+
+    mock_pool = MagicMock(spec=mysql.Pool)
+    mock_pool.acquire = AsyncMock(return_value=mock_connection)
+    mock_pool.release = AsyncMock()
+
+    old_use_tz = os.environ.get("USE_TZ")
+    old_tz = os.environ.get("TIMEZONE")
+    try:
+        os.environ["USE_TZ"] = "True"
+        os.environ["TIMEZONE"] = "Asia/Shanghai"
+        timezone._reset_timezone_cache()
+
+        with patch(
+            "tortoise.backends.mysql.client.mysql.create_pool",
+            new=AsyncMock(return_value=mock_pool),
+        ):
+            ctx = TortoiseContext()
+            async with ctx:
+                await ctx.connections._init(
+                    {
+                        "models": {
+                            "engine": "tortoise.backends.mysql",
+                            "credentials": {
+                                "database": "test",
+                                "host": "127.0.0.1",
+                                "password": "foomip",
+                                "port": 3306,
+                                "user": "root",
+                            },
+                        }
+                    },
+                    False,
+                )
+                await ctx.connections.get("models").create_connection(with_db=True)
+
+                # Verify SET time_zone was called with Asia/Shanghai offset (+8:00)
+                tz_calls = [
+                    call
+                    for call in mock_cursor.execute.await_args_list
+                    if "time_zone" in str(call)
+                ]
+                assert len(tz_calls) == 1, f"Expected 1 SET time_zone call, got {tz_calls}"
+                assert "+8:00" in str(tz_calls[0]), (
+                    f"Expected +8:00 for Asia/Shanghai, got {tz_calls[0]}"
+                )
+    finally:
+        if old_use_tz is not None:
+            os.environ["USE_TZ"] = old_use_tz
+        else:
+            os.environ.pop("USE_TZ", None)
+        if old_tz is not None:
+            os.environ["TIMEZONE"] = old_tz
+        else:
+            os.environ.pop("TIMEZONE", None)
+        timezone._reset_timezone_cache()

--- a/tortoise/backends/mysql/client.py
+++ b/tortoise/backends/mysql/client.py
@@ -19,7 +19,6 @@ except ImportError:
 
 from pypika_tortoise import MySQLQuery
 
-from tortoise import timezone
 from tortoise.backends.base.client import (
     BaseDBAsyncClient,
     Capabilities,
@@ -38,7 +37,7 @@ from tortoise.exceptions import (
     OperationalError,
     TransactionManagementError,
 )
-from tortoise.timezone import get_use_tz
+from tortoise.timezone import get_default_timezone, get_use_tz
 
 T = TypeVar("T")
 FuncType = Callable[..., Coroutine[None, None, T]]
@@ -137,8 +136,13 @@ class MySQLClient(BaseDBAsyncClient):
                                 self.capabilities.__dict__["supports_transactions"] = False
                         # Only set session timezone when use_tz=True
                         if get_use_tz():
-                            hours = timezone.now().utcoffset().seconds / 3600  # type: ignore
-                            tz = f"{int(hours):+d}:{int((hours % 1) * 60):02d}"
+                            from datetime import datetime as _datetime
+
+                            offset = _datetime.now(tz=get_default_timezone()).utcoffset()
+                            total_seconds = int(offset.total_seconds())  # type: ignore
+                            hours = total_seconds // 3600
+                            minutes = abs(total_seconds) % 3600 // 60
+                            tz = f"{hours:+d}:{minutes:02d}"
                             await cursor.execute(f"SET time_zone='{tz}';")
             self.log.debug("Created connection %s pool with params: %s", self._pool, self._template)
         except errors.OperationalError:


### PR DESCRIPTION
## Description

When `use_tz=True`, the MySQL client sets the session `time_zone` using `timezone.now().utcoffset()`. Since `timezone.now()` returns a UTC-aware datetime, its `utcoffset()` is always `timedelta(0)`, causing the session to always be set to `+0:00` regardless of the configured timezone (e.g. `Asia/Shanghai`).

This PR replaces `timezone.now()` with `get_default_timezone()` to compute the correct UTC offset from the user-configured timezone.

## Motivation and Context

Fixes #2114

## How Has This Been Tested?

- Added `test_mysql_session_timezone_uses_configured_tz` in `tests/backends/test_connection_params.py`
- The test configures `USE_TZ=True` and `TIMEZONE=Asia/Shanghai`, then verifies the `SET time_zone` call uses `+8:00`
- Existing tests continue to pass

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.