### PR TITLE
Fix AlterField ignoring max_length changes in migrations

### DIFF
--- a/tests/migrations/test_schema_editor_backends.py
+++ b/tests/migrations/test_schema_editor_backends.py
@@ -722,3 +722,92 @@ async def test_oracle_alter_field_drop_default() -> None:
 
     assert len(client.executed) == 1
     assert client.executed[0] == 'ALTER TABLE "product" MODIFY ("stock" DEFAULT NULL)'
+
+
+# ---------------------------------------------------------------------------
+# ALTER COLUMN TYPE tests (max_length changes)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_postgres_alter_field_max_length() -> None:
+    """PostgreSQL alter_field changing max_length should emit ALTER COLUMN TYPE."""
+
+    class OldWidget(Model):
+        id = fields.IntField(pk=True)
+        name = fields.CharField(max_length=32, null=True)
+
+        class Meta:
+            table = "widget"
+            app = "models"
+
+    class NewWidget(Model):
+        id = fields.IntField(pk=True)
+        name = fields.CharField(max_length=64, null=True)
+
+        class Meta:
+            table = "widget"
+            app = "models"
+
+    client = FakeClient("postgres", inline_comment=False)
+    editor = BasePostgresSchemaEditor(client)
+    await editor.alter_field(OldWidget, NewWidget, "name")
+
+    assert len(client.executed) == 1
+    assert client.executed[0] == 'ALTER TABLE "widget" ALTER COLUMN "name" TYPE VARCHAR(64)'
+
+
+@pytest.mark.asyncio
+async def test_mysql_alter_field_max_length() -> None:
+    """MySQL alter_field changing max_length should use MODIFY COLUMN."""
+
+    class OldWidget(Model):
+        id = fields.IntField(pk=True)
+        name = fields.CharField(max_length=32, null=True)
+
+        class Meta:
+            table = "widget"
+            app = "models"
+
+    class NewWidget(Model):
+        id = fields.IntField(pk=True)
+        name = fields.CharField(max_length=64, null=True)
+
+        class Meta:
+            table = "widget"
+            app = "models"
+
+    client = FakeClient("mysql")
+    editor = MySQLSchemaEditor(client)
+    await editor.alter_field(OldWidget, NewWidget, "name")
+
+    assert len(client.executed) == 1
+    assert client.executed[0] == "ALTER TABLE `widget` MODIFY COLUMN `name` VARCHAR(64) NULL"
+
+
+@pytest.mark.asyncio
+async def test_mssql_alter_field_max_length() -> None:
+    """MSSQL alter_field changing max_length should use ALTER COLUMN with full type."""
+
+    class OldWidget(Model):
+        id = fields.IntField(pk=True)
+        name = fields.CharField(max_length=32, null=True)
+
+        class Meta:
+            table = "widget"
+            app = "models"
+
+    class NewWidget(Model):
+        id = fields.IntField(pk=True)
+        name = fields.CharField(max_length=64, null=True)
+
+        class Meta:
+            table = "widget"
+            app = "models"
+
+    client = FakeClient("mssql")
+    editor = MSSQLSchemaEditor(client)
+    await editor.alter_field(OldWidget, NewWidget, "name")
+
+    assert len(client.executed) == 1
+    assert client.executed[0] == "ALTER TABLE [widget] ALTER COLUMN [name] VARCHAR(64) NULL"

--- a/tortoise/migrations/schema_editor/base.py
+++ b/tortoise/migrations/schema_editor/base.py
@@ -39,6 +39,7 @@ class BaseSchemaEditor(SchemaQuotingMixin):
     RENAME_FIELD_TEMPLATE = 'ALTER TABLE {table} RENAME COLUMN "{old_column}" TO "{new_column}"'
     ALTER_FIELD_NULL_TEMPLATE = 'ALTER COLUMN "{column}" DROP NOT NULL'
     ALTER_FIELD_NOT_NULL_TEMPLATE = 'ALTER COLUMN "{column}" SET NOT NULL'
+    ALTER_FIELD_TYPE_TEMPLATE = 'ALTER COLUMN "{column}" TYPE {sql_type}'
     ALTER_FIELD_SET_DEFAULT_TEMPLATE = 'ALTER COLUMN "{column}" SET DEFAULT {default}'
     ALTER_FIELD_DROP_DEFAULT_TEMPLATE = 'ALTER COLUMN "{column}" DROP DEFAULT'
 
@@ -603,6 +604,13 @@ class BaseSchemaEditor(SchemaQuotingMixin):
         qualified_table = self._qualify_table_name(model._meta.db_table, model._meta.schema)
         if await self._alter_generated_field(model, old_field, new_field):
             return
+        old_sql_type = old_field.get_for_dialect(self.DIALECT, "SQL_TYPE")
+        new_sql_type = new_field.get_for_dialect(self.DIALECT, "SQL_TYPE")
+        if old_sql_type != new_sql_type:
+            changes = self.ALTER_FIELD_TYPE_TEMPLATE.format(
+                column=new_db_field, sql_type=new_sql_type
+            )
+            actions.append(self.ALTER_FIELD_TEMPLATE.format(table=qualified_table, changes=changes))
         if old_field.null != new_field.null:
             if new_field.null:
                 changes = self.ALTER_FIELD_NULL_TEMPLATE.format(column=old_db_field)

--- a/tortoise/migrations/schema_editor/mssql.py
+++ b/tortoise/migrations/schema_editor/mssql.py
@@ -126,15 +126,22 @@ class MSSQLSchemaEditor(MSSQLQuotingMixin, BaseSchemaEditor):
         db_field = new_field.source_field or new_field.model_field_name
         qualified_table = self._qualify_table_name(model._meta.db_table, model._meta.schema)
 
-        # MSSQL requires ALTER COLUMN with full type for nullability changes
-        if old_field.null != new_field.null:
-            col_type = new_field.get_for_dialect(self.DIALECT, "SQL_TYPE")
+        # MSSQL requires ALTER COLUMN with full type for nullability and type changes
+        old_sql_type = old_field.get_for_dialect(self.DIALECT, "SQL_TYPE")
+        new_sql_type = new_field.get_for_dialect(self.DIALECT, "SQL_TYPE")
+        null_changed = old_field.null != new_field.null
+        type_changed = old_sql_type != new_sql_type
+
+        if null_changed or type_changed:
             nullable = "NULL" if new_field.null else "NOT NULL"
             await self._run_sql(
-                f"ALTER TABLE {qualified_table} ALTER COLUMN [{db_field}] {col_type} {nullable}"
+                f"ALTER TABLE {qualified_table} ALTER COLUMN [{db_field}] {new_sql_type} {nullable}"
             )
             old_field = copy(old_field)
             old_field.null = new_field.null
+            for attr in ("max_length", "max_digits", "decimal_places"):
+                if hasattr(new_field, attr):
+                    setattr(old_field, attr, getattr(new_field, attr))
 
         # MSSQL uses named default constraints instead of ALTER COLUMN SET/DROP DEFAULT
         old_has_default = old_field.has_db_default()

--- a/tortoise/migrations/schema_editor/mysql.py
+++ b/tortoise/migrations/schema_editor/mysql.py
@@ -288,20 +288,27 @@ class MySQLSchemaEditor(MySQLQuotingMixin, BaseSchemaEditor):
         )
 
     async def _alter_field(self, model: type[Model], old_field: Field, new_field: Field) -> None:
-        # MySQL does not support ALTER COLUMN ... SET/DROP NOT NULL.
+        # MySQL does not support ALTER COLUMN ... SET/DROP NOT NULL or ALTER COLUMN ... TYPE.
         # It requires MODIFY COLUMN with the full column type specification.
-        if old_field.null != new_field.null:
+        old_sql_type = old_field.get_for_dialect(self.DIALECT, "SQL_TYPE")
+        new_sql_type = new_field.get_for_dialect(self.DIALECT, "SQL_TYPE")
+        null_changed = old_field.null != new_field.null
+        type_changed = old_sql_type != new_sql_type
+
+        if null_changed or type_changed:
             db_field = new_field.source_field or new_field.model_field_name
             qualified_table = self._qualify_table_name(model._meta.db_table, model._meta.schema)
-            col_type = new_field.get_for_dialect(self.DIALECT, "SQL_TYPE")
             nullable = "NULL" if new_field.null else "NOT NULL"
             await self._run_sql(
                 f"ALTER TABLE {qualified_table} MODIFY COLUMN"
-                f" {self.quote(db_field)} {col_type} {nullable}"
+                f" {self.quote(db_field)} {new_sql_type} {nullable}"
             )
-            # Patch old_field copy so base skips the null change
+            # Patch old_field copy so base skips the null and type changes
             old_field = copy(old_field)
             old_field.null = new_field.null
+            for attr in ("max_length", "max_digits", "decimal_places"):
+                if hasattr(new_field, attr):
+                    setattr(old_field, attr, getattr(new_field, attr))
 
         await super()._alter_field(model, old_field, new_field)
 

--- a/tortoise/migrations/schema_editor/oracle.py
+++ b/tortoise/migrations/schema_editor/oracle.py
@@ -158,21 +158,28 @@ class OracleSchemaEditor(BaseSchemaEditor):
     async def _alter_field(self, model: type[Model], old_field: Field, new_field: Field) -> None:
         """Override to use Oracle MODIFY syntax instead of ALTER COLUMN.
 
-        Oracle does not support ``ALTER COLUMN``.  Nullability and default
+        Oracle does not support ``ALTER COLUMN``.  Nullability, type, and default
         changes must use ``ALTER TABLE ... MODIFY ("col" type ...)``.
         """
         db_field = new_field.source_field or new_field.model_field_name
         qualified_table = self._qualify_table_name(model._meta.db_table, model._meta.schema)
 
-        # Handle nullability changes with MODIFY
-        if old_field.null != new_field.null:
-            col_type = new_field.get_for_dialect(self.DIALECT, "SQL_TYPE")
+        # Handle nullability and type changes with MODIFY
+        old_sql_type = old_field.get_for_dialect(self.DIALECT, "SQL_TYPE")
+        new_sql_type = new_field.get_for_dialect(self.DIALECT, "SQL_TYPE")
+        null_changed = old_field.null != new_field.null
+        type_changed = old_sql_type != new_sql_type
+
+        if null_changed or type_changed:
             nullable = "NULL" if new_field.null else "NOT NULL"
             await self._run_sql(
-                f'ALTER TABLE {qualified_table} MODIFY ("{db_field}" {col_type} {nullable})'
+                f'ALTER TABLE {qualified_table} MODIFY ("{db_field}" {new_sql_type} {nullable})'
             )
             old_field = copy(old_field)
             old_field.null = new_field.null
+            for attr in ("max_length", "max_digits", "decimal_places"):
+                if hasattr(new_field, attr):
+                    setattr(old_field, attr, getattr(new_field, attr))
 
         # Handle db_default changes with MODIFY
         old_has_default = old_field.has_db_default()
@@ -180,7 +187,6 @@ class OracleSchemaEditor(BaseSchemaEditor):
         if old_has_default != new_has_default or (
             old_has_default and new_has_default and old_field.db_default != new_field.db_default
         ):
-            col_type = new_field.get_for_dialect(self.DIALECT, "SQL_TYPE")
             if new_has_default:
                 if hasattr(new_field.db_default, "get_sql"):
                     default_sql = new_field.db_default.get_sql(dialect=self.DIALECT)


### PR DESCRIPTION
## Description

The `_alter_field` method in the migration schema editor only checked for changes to nullability, index, unique, description, default, and rename. It did not compare the SQL column type, so changing `max_length` (e.g. `VARCHAR(32)` → `VARCHAR(64)`) produced no migration SQL and the database schema was left out of sync.

This PR adds SQL type comparison to the base schema editor and updates the MySQL, MSSQL, and Oracle overrides to emit the correct `ALTER` statements when the column type changes.

## Motivation and Context

Fixes #2120

When a user changes `max_length` on a `CharField` and generates a migration, Tortoise correctly creates an `AlterField` operation. However, applying that migration does nothing because `_alter_field()` sees no difference in the properties it checks and returns early.

## How Has This Been Tested?

Added three new tests in `tests/migrations/test_schema_editor_backends.py`:

- `test_postgres_alter_field_max_length` — verifies `ALTER TABLE ... ALTER COLUMN ... TYPE VARCHAR(64)` is generated
- `test_mysql_alter_field_max_length` — verifies `ALTER TABLE ... MODIFY COLUMN ... VARCHAR(64) NULL` is generated
- `test_mssql_alter_field_max_length` — verifies `ALTER TABLE ... ALTER COLUMN ... VARCHAR(64) NULL` is generated

All existing schema editor tests continue to pass (69 total).

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.