### PR TITLE
Fix CreateModel not including DEFAULT clause for db_default fields

### DIFF
--- a/tests/migrations/test_schema_editor_sql.py
+++ b/tests/migrations/test_schema_editor_sql.py
@@ -226,3 +226,26 @@ async def test_alter_generated_field_raises() -> None:
     with pytest.raises(ValueError):
         await editor.alter_field(OldSearchDocument, NewSearchDocument, "search_vector")
     assert not client.executed
+
+
+@pytest.mark.asyncio
+async def test_create_model_includes_db_default() -> None:
+    """CreateModel should include DEFAULT clause for fields with db_default."""
+
+    class WidgetWithDefault(Model):
+        id = fields.IntField(pk=True)
+        status = fields.CharField(max_length=20, db_default="active")
+
+        class Meta:
+            table = "widget"
+            app = "models"
+
+    client = FakeClient("sql")
+    editor = TestSchemaEditor(client)
+
+    await editor.create_model(WidgetWithDefault)
+
+    assert len(client.executed) == 1
+    sql = client.executed[0]
+    assert 'CREATE TABLE "widget"' in sql
+    assert "DEFAULT 'active'" in sql

--- a/tortoise/migrations/schema_editor/base.py
+++ b/tortoise/migrations/schema_editor/base.py
@@ -359,6 +359,16 @@ class BaseSchemaEditor(SchemaQuotingMixin):
                     comment=comment,
                 )
 
+            if field_object.has_db_default():
+                if hasattr(field_object.db_default, "get_sql"):
+                    field_creation_string += (
+                        f" DEFAULT {field_object.db_default.get_sql(dialect=self.DIALECT)}"
+                    )
+                else:
+                    db_val = field_object.to_db_value(field_object.db_default, model)
+                    escaped = self._escape_default_value(db_val)
+                    field_creation_string += f" DEFAULT {escaped}"
+
             in_table_definitions.append(field_creation_string)
 
             if field_object.index and not field_object.pk:


### PR DESCRIPTION
## Description

`_get_model_sql_data` builds column definitions for `CREATE TABLE` but never appends a `DEFAULT` clause for fields that have `db_default` set. This means that when a migration contains a `CreateModel` operation, the generated SQL omits `DEFAULT` values even when the model fields specify `db_default`.

The `add_field` path already handles this correctly by appending `DEFAULT ...` to the column definition.

## Motivation and Context

Fixes #2117

When a user defines a model with `db_default` on one or more fields and runs the initial migration, the `CREATE TABLE` statement lacks the `DEFAULT` clause. This forces the database to require explicit values on every insert, defeating the purpose of `db_default`.

## How Has This Been Tested?

Added `test_create_model_includes_db_default` in `tests/migrations/test_schema_editor_sql.py` that:

1. Defines a model with `CharField(max_length=20, db_default="active")`
2. Calls `create_model` via the schema editor
3. Asserts the generated SQL contains `DEFAULT 'active'`

All existing schema editor tests continue to pass (67 total).

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.