### PR TITLE
Remove query parameters from logs

### DIFF
--- a/tests/test_logging_security.py
+++ b/tests/test_logging_security.py
@@ -1,0 +1,100 @@
+"""Test that sensitive data is not exposed in debug logging."""
+
+import logging
+from io import StringIO
+
+from tests.testmodels import User
+from tortoise.contrib.test import TestCase
+
+
+class TestLoggingSecurity(TestCase):
+    """Test cases for ensuring sensitive data is not logged by Tortoise ORM."""
+
+    async def test_query_parameters_not_logged_in_tortoise_db_client(self):
+        """Test that query parameters are not logged by tortoise.db_client logger."""
+        # Create a string IO to capture log output
+        log_capture = StringIO()
+
+        # Get the tortoise db_client logger and add our handler
+        logger = logging.getLogger("tortoise.db_client")
+        original_level = logger.level
+        handler = logging.StreamHandler(log_capture)
+        handler.setLevel(logging.DEBUG)
+        formatter = logging.Formatter("%(name)s:%(levelname)s:%(message)s")
+        handler.setFormatter(formatter)
+
+        # Set up logging
+        logger.setLevel(logging.DEBUG)
+        logger.addHandler(handler)
+
+        try:
+            # Create a user with potentially sensitive data
+            sensitive_email = "admin@secret-company.com"
+            sensitive_username = "admin_with_secret_key_123"
+            sensitive_bio = "bio with password: my_secret_password_123"
+
+            user = await User.create(
+                username=sensitive_username, mail=sensitive_email, bio=sensitive_bio
+            )
+
+            # Get the captured log output
+            log_output = log_capture.getvalue()
+
+            # Verify that the SQL query structure is still logged
+            self.assertIn("INSERT INTO", log_output)
+            self.assertIn("user", log_output.lower())
+
+            # Verify that sensitive data is NOT in the log output
+            self.assertNotIn(
+                sensitive_email, log_output, f"Sensitive email found in log output: {log_output}"
+            )
+            self.assertNotIn(
+                sensitive_username,
+                log_output,
+                f"Sensitive username found in log output: {log_output}",
+            )
+            self.assertNotIn(
+                sensitive_bio, log_output, f"Sensitive bio found in log output: {log_output}"
+            )
+            self.assertNotIn(
+                "my_secret_password_123",
+                log_output,
+                f"Sensitive password found in log output: {log_output}",
+            )
+
+            # Test UPDATE operation
+            log_capture.seek(0)  # Reset the capture
+            log_capture.truncate(0)
+
+            new_sensitive_email = "super_secret_admin@classified.gov"
+            user.mail = new_sensitive_email
+            await user.save()
+
+            log_output = log_capture.getvalue()
+            self.assertNotIn(
+                new_sensitive_email,
+                log_output,
+                f"Sensitive email found in UPDATE log: {log_output}",
+            )
+
+            # Test SELECT operation
+            log_capture.seek(0)  # Reset the capture
+            log_capture.truncate(0)
+
+            await User.filter(username=sensitive_username).first()
+
+            log_output = log_capture.getvalue()
+            self.assertNotIn(
+                sensitive_username,
+                log_output,
+                f"Sensitive username found in SELECT log: {log_output}",
+            )
+
+            # Clean up
+            await user.delete()
+
+        finally:
+            # Restore original logging setup
+            logger.removeHandler(handler)
+            logger.setLevel(original_level)
+            handler.close()

--- a/tortoise/backends/asyncpg/client.py
+++ b/tortoise/backends/asyncpg/client.py
@@ -108,14 +108,14 @@ class AsyncpgDBClient(BasePostgresClient):
     @translate_exceptions
     async def execute_insert(self, query: str, values: list) -> asyncpg.Record | None:
         async with self.acquire_connection() as connection:
-            self.log.debug("%s: %s", query, values)
+            self.log.debug("%s", query)
             # TODO: Cache prepared statement
             return await connection.fetchrow(query, *values)
 
     @translate_exceptions
     async def execute_many(self, query: str, values: list) -> None:
         async with self.acquire_connection() as connection:
-            self.log.debug("%s: %s", query, values)
+            self.log.debug("%s", query)
             # TODO: Consider using copy_records_to_table instead
             transaction = connection.transaction()
             await transaction.start()
@@ -130,7 +130,7 @@ class AsyncpgDBClient(BasePostgresClient):
     @translate_exceptions
     async def execute_query(self, query: str, values: list | None = None) -> tuple[int, list[dict]]:
         async with self.acquire_connection() as connection:
-            self.log.debug("%s: %s", query, values)
+            self.log.debug("%s", query)
             if values:
                 params = [query, *values]
             else:
@@ -154,7 +154,7 @@ class AsyncpgDBClient(BasePostgresClient):
     @translate_exceptions
     async def execute_query_dict(self, query: str, values: list | None = None) -> list[dict]:
         async with self.acquire_connection() as connection:
-            self.log.debug("%s: %s", query, values)
+            self.log.debug("%s", query)
             if values:
                 return list(map(dict, await connection.fetch(query, *values)))
             return list(map(dict, await connection.fetch(query)))
@@ -186,7 +186,7 @@ class TransactionWrapper(AsyncpgDBClient, TransactionalDBClient):
     @translate_exceptions
     async def execute_many(self, query: str, values: list) -> None:
         async with self.acquire_connection() as connection:
-            self.log.debug("%s: %s", query, values)
+            self.log.debug("%s", query)
             # TODO: Consider using copy_records_to_table instead
             await connection.executemany(query, values)
 

--- a/tortoise/backends/mssql/client.py
+++ b/tortoise/backends/mssql/client.py
@@ -63,7 +63,7 @@ class MSSQLClient(ODBCClient):
     @translate_exceptions
     async def execute_insert(self, query: str, values: list) -> int:
         async with self.acquire_connection() as connection:
-            self.log.debug("%s: %s", query, values)
+            self.log.debug("%s", query)
             async with connection.cursor() as cursor:
                 await cursor.execute(f"SET NOCOUNT ON; {query}; SELECT @@IDENTITY", values)
                 return (await cursor.fetchone())[0]

--- a/tortoise/backends/mysql/client.py
+++ b/tortoise/backends/mysql/client.py
@@ -187,7 +187,7 @@ class MySQLClient(BaseDBAsyncClient):
     @translate_exceptions
     async def execute_insert(self, query: str, values: list) -> int:
         async with self.acquire_connection() as connection:
-            self.log.debug("%s: %s", query, values)
+            self.log.debug("%s", query)
             async with connection.cursor() as cursor:
                 await cursor.execute(query, values)
                 return cursor.lastrowid  # return auto-generated id
@@ -195,7 +195,7 @@ class MySQLClient(BaseDBAsyncClient):
     @translate_exceptions
     async def execute_many(self, query: str, values: list) -> None:
         async with self.acquire_connection() as connection:
-            self.log.debug("%s: %s", query, values)
+            self.log.debug("%s", query)
             async with connection.cursor() as cursor:
                 if self.capabilities.supports_transactions:
                     await connection.begin()
@@ -212,7 +212,7 @@ class MySQLClient(BaseDBAsyncClient):
     @translate_exceptions
     async def execute_query(self, query: str, values: list | None = None) -> tuple[int, list[dict]]:
         async with self.acquire_connection() as connection:
-            self.log.debug("%s: %s", query, values)
+            self.log.debug("%s", query)
             async with connection.cursor() as cursor:
                 await cursor.execute(query, values)
                 rows = await cursor.fetchall()
@@ -252,7 +252,7 @@ class TransactionWrapper(MySQLClient, TransactionalDBClient):
     @translate_exceptions
     async def execute_many(self, query: str, values: list) -> None:
         async with self.acquire_connection() as connection:
-            self.log.debug("%s: %s", query, values)
+            self.log.debug("%s", query)
             async with connection.cursor() as cursor:
                 await cursor.executemany(query, values)
 

--- a/tortoise/backends/odbc/client.py
+++ b/tortoise/backends/odbc/client.py
@@ -124,7 +124,7 @@ class ODBCClient(BaseDBAsyncClient, ABC):
     @translate_exceptions
     async def execute_many(self, query: str, values: list) -> None:
         async with self.acquire_connection() as connection:
-            self.log.debug("%s: %s", query, values)
+            self.log.debug("%s", query)
             async with connection.cursor() as cursor:
                 try:
                     await cursor.executemany(query, values)
@@ -137,7 +137,7 @@ class ODBCClient(BaseDBAsyncClient, ABC):
     @translate_exceptions
     async def execute_query(self, query: str, values: list | None = None) -> tuple[int, list[dict]]:
         async with self.acquire_connection() as connection:
-            self.log.debug("%s: %s", query, values)
+            self.log.debug("%s", query)
             async with connection.cursor() as cursor:
                 if values:
                     await cursor.execute(query, values)
@@ -185,7 +185,7 @@ class ODBCTransactionWrapper(TransactionalDBClient):
     @translate_exceptions
     async def execute_many(self, query: str, values: list) -> None:
         async with self.acquire_connection() as connection:
-            self.log.debug("%s: %s", query, values)
+            self.log.debug("%s", query)
             cursor = await connection.cursor()
             await cursor.executemany(query, values)
 

--- a/tortoise/backends/oracle/client.py
+++ b/tortoise/backends/oracle/client.py
@@ -92,7 +92,7 @@ class OracleClient(ODBCClient):
     @translate_exceptions
     async def execute_insert(self, query: str, values: list) -> int:
         async with self.acquire_connection() as connection:
-            self.log.debug("%s: %s", query, values)
+            self.log.debug("%s", query)
             await connection.execute(query, values)
             return 0
 

--- a/tortoise/backends/psycopg/client.py
+++ b/tortoise/backends/psycopg/client.py
@@ -134,7 +134,7 @@ class PsycopgClient(postgres_client.BasePostgresClient):
         connection: psycopg.AsyncConnection
         async with self.acquire_connection() as connection:
             async with connection.cursor() as cursor:
-                self.log.debug("%s: %s", query, values)
+                self.log.debug("%s", query)
                 await cursor.executemany(query, values)
 
     @postgres_client.translate_exceptions
@@ -148,7 +148,7 @@ class PsycopgClient(postgres_client.BasePostgresClient):
         async with self.acquire_connection() as connection:
             cursor: psycopg.AsyncCursor | psycopg.AsyncServerCursor
             async with connection.cursor(row_factory=row_factory) as cursor:
-                self.log.debug("%s: %s", query, values)
+                self.log.debug("%s", query)
                 await cursor.execute(query, values)
 
                 rowcount = int(cursor.rowcount or cursor.rownumber or 0)

--- a/tortoise/backends/sqlite/client.py
+++ b/tortoise/backends/sqlite/client.py
@@ -127,13 +127,13 @@ class SqliteClient(BaseDBAsyncClient):
     @translate_exceptions
     async def execute_insert(self, query: str, values: list) -> int:
         async with self.acquire_connection() as connection:
-            self.log.debug("%s: %s", query, values)
+            self.log.debug("%s", query)
             return (await connection.execute_insert(query, values))[0]
 
     @translate_exceptions
     async def execute_many(self, query: str, values: list[list]) -> None:
         async with self.acquire_connection() as connection:
-            self.log.debug("%s: %s", query, values)
+            self.log.debug("%s", query)
             # This code is only ever called in AUTOCOMMIT mode
             await connection.execute("BEGIN")
             try:
@@ -150,7 +150,7 @@ class SqliteClient(BaseDBAsyncClient):
     ) -> tuple[int, Sequence[dict]]:
         query = query.replace("\x00", "'||CHAR(0)||'")
         async with self.acquire_connection() as connection:
-            self.log.debug("%s: %s", query, values)
+            self.log.debug("%s", query)
             start = connection.total_changes
             rows = await connection.execute_fetchall(query, values)
             return (connection.total_changes - start) or len(rows), rows
@@ -159,7 +159,7 @@ class SqliteClient(BaseDBAsyncClient):
     async def execute_query_dict(self, query: str, values: list | None = None) -> list[dict]:
         query = query.replace("\x00", "'||CHAR(0)||'")
         async with self.acquire_connection() as connection:
-            self.log.debug("%s: %s", query, values)
+            self.log.debug("%s", query)
             return list(map(dict, await connection.execute_fetchall(query, values)))
 
     @translate_exceptions
@@ -229,7 +229,7 @@ class SqliteTransactionWrapper(SqliteClient, TransactionalDBClient):
     @translate_exceptions
     async def execute_many(self, query: str, values: list[list]) -> None:
         async with self.acquire_connection() as connection:
-            self.log.debug("%s: %s", query, values)
+            self.log.debug("%s", query)
             # Already within transaction, so ideal for performance
             await connection.executemany(query, values)
 


### PR DESCRIPTION
This PR ports the changes from the approved but stale PR #1997 (by @bddap)

fixes https://github.com/tortoise/tortoise-orm/issues/1996

FYI @henadzit

## Description
This PR fixes a security vulnerability where sensitive data (passwords, tokens, API keys, personal information) was being exposed in debug logs through SQL query parameters. The fix removes parameter values from debug logging while preserving the SQL query structure for debugging purposes.

**Changes made:**
- Updated logging statements in 7 backend database client files (21 total logging calls)
- Changed from `self.log.debug("%s: %s", query, values)` to `self.log.debug("%s", query)`
- Affects: MySQL, SQLite, PostgreSQL/psycopg, ODBC, Oracle, MSSQL, and AsyncPG backends

**Before:**

```python
DEBUG:tortoise.db_client:INSERT INTO "users" ("username","password_hash","email") VALUES (?,?,?): ['admin', 'super_secret_hash_123', 'admin@example.com']
```

**After:**

```python
DEBUG:tortoise.db_client:INSERT INTO "users" ("username","password_hash","email") VALUES (?,?,?)
```

## Motivation and Context

Fixes https://github.com/tortoise/tortoise-orm/issues/1996

SQL query parameters often contain sensitive information that should never be logged:
- User passwords and password hashes-
- Authentication tokens and API keys
- Personal identifiable information (emails, names, addresses)
- Business-critical data that could be exposed in log files

This creates a significant security risk, especially in:
- Development environments where debug logging is commonly enabled
- Production systems where logs might be accidentally enabled or collected
- Shared development environments where logs could be accessed by unauthorized users

The current implementation logs both the SQL structure AND the parameter values, which unnecessarily exposes this sensitive data.

## How Has This Been Tested?

**1. Added comprehensive test suite** (`tests/test_logging_security.py`):
   - Validates that sensitive data (usernames, emails, bio information) is NOT exposed in debug logs
   - Confirms SQL query structure is still logged for debugging purposes
   - Tests INSERT, UPDATE, and SELECT operations
   - Uses proper log capture mechanism to verify actual log output

**2. Manual verification:**
   - Tested with debug logging enabled across different database backends
   - Confirmed that SQL queries are still logged (maintaining debugging capability)
   - Verified that parameter values are completely absent from log output

**3. Existing test compatibility:**
   - All existing tests continue to pass (no breaking changes)
   - The fix is purely additive to security without affecting functionality

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

