### PR TITLE
Fix various docstring issues across multiple classes

### DIFF
--- a/tortoise/connection.py
+++ b/tortoise/connection.py
@@ -40,7 +40,6 @@ class ConnectionHandler:
     """
 
     def __init__(self) -> None:
-        """Initialize connection handler with empty storage."""
         self._db_config: DBConfigType | None = None
         self._create_db: bool = False
         # Use ContextVar for task isolation within this handler instance.

--- a/tortoise/context.py
+++ b/tortoise/context.py
@@ -146,7 +146,6 @@ class TortoiseContext:
     """
 
     def __init__(self) -> None:
-        """Initialize a new TortoiseContext with empty state."""
         self._connections: ConnectionHandler | None = None
         self._apps: Apps | None = None
         self._inited: bool = False

--- a/tortoise/expressions.py
+++ b/tortoise/expressions.py
@@ -605,7 +605,7 @@ class Aggregate(Function):
 
     :param field: Field name
     :param default_values: Extra parameters to the function.
-    :param is_distinct: Flag for aggregate with distinction
+    :param distinct: Flag for aggregate with distinction
     """
 
     database_func: type[AggregateFunction] = DistinctOptionFunction

--- a/tortoise/fields/base.py
+++ b/tortoise/fields/base.py
@@ -82,6 +82,8 @@ class Field(Generic[VALUE], metaclass=_FieldMeta):
     :param default: A default value for the field if not specified on Model creation.
         This can also be a callable for dynamic defaults in which case we will call it.
         The default value will not be part of the schema.
+    :param db_default: A database-level default value. This can be a static value or an
+        instance of :class:`~tortoise.fields.db_defaults.SqlDefault`
     :param unique: Is this field unique?
     :param db_index: Should this field be indexed by itself?
     :param description: Field description. Will also appear in ``Tortoise.describe_model()``

--- a/tortoise/filters.py
+++ b/tortoise/filters.py
@@ -35,10 +35,16 @@ if TYPE_CHECKING:  # pragma: nocoverage
 
 
 class Like(BasicCriterion):
+    """
+    A Like that supports an ESCAPE clause
+
+    :param left: The left side of the LIKE expression (field/term).
+    :param right: The right side of the LIKE expression (pattern/value).
+    :param alias: Optional alias for the column.
+    :param escape: The escape clause to use. Defaults to " ESCAPE '\\'".
+    """
+
     def __init__(self, left, right, alias=None, escape=" ESCAPE '\\'") -> None:
-        """
-        A Like that supports an ESCAPE clause
-        """
         super().__init__(Matching.like, left, right, alias=alias)
         self.escape = escape
 

--- a/tortoise/indexes.py
+++ b/tortoise/indexes.py
@@ -14,6 +14,15 @@ if TYPE_CHECKING:
 
 
 class Index:
+    """
+    All kinds of index parent class, default is BTreeIndex.
+
+    :param expressions: The expressions of on which the index is desired.
+    :param fields: A tuple of names of the fields on which the index is desired.
+    :param name: The name of the index.
+    :raises ValueError: If params conflict.
+    """
+
     INDEX_TYPE = ""
 
     def __init__(
@@ -22,14 +31,6 @@ class Index:
         fields: tuple[str, ...] | list[str] | None = None,
         name: str | None = None,
     ) -> None:
-        """
-        All kinds of index parent class, default is BTreeIndex.
-
-        :param expressions: The expressions of on which the index is desired.
-        :param fields: A tuple of names of the fields on which the index is desired.
-        :param name: The name of the index.
-        :raises ValueError: If params conflict.
-        """
         self.fields = list(fields or [])
         if not expressions and not fields:
             raise ConfigurationError(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR corrects and improves docstrings in several classes:
- Removes redundant docstrings from `__init__` methods in `ConnectionHandler` and `TortoiseContext` 
- Fixes parameter name typo in `Aggregate` class docstring (`is_distinct` → `distinct`)
- Adds missing `db_default` parameter documentation to `Field` class
- Improves docstrings in `Like` and `Index` classes with proper parameter documentation

## Motivation and Context

These fixes improve the accuracy and consistency of the API documentation.

## How Has This Been Tested?

This is a documentation-only change with no functional code changes. The changes were verified by:
- Running linting/type checking to ensure no regressions
- Checking that docstrings are properly formatted

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

