### PR TITLE
Increase validators test coverage

### DIFF
--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -21,6 +21,13 @@ async def test_validator_max_length(db):
 
 
 @pytest.mark.asyncio
+async def test_validator_min_length(db):
+    with pytest.raises(ValidationError, match="Length of 'aa' 2 < 3"):
+        await ValidatorModel.create(min_length="aa")
+    await ValidatorModel.create(min_length="aaaa")
+
+
+@pytest.mark.asyncio
 async def test_validator_min_value(db):
     # min value is 10
     with pytest.raises(ValidationError):
@@ -58,6 +65,14 @@ async def test_validator_ipv6(db):
     with pytest.raises(ValidationError):
         await ValidatorModel.create(ipv6="aaaaaa")
     await ValidatorModel.create(ipv6="::")
+
+
+@pytest.mark.asyncio
+async def test_validator_ipv46(db):
+    with pytest.raises(ValidationError, match="'aaaaaa' is not a valid IPv4 or IPv6 address."):
+        await ValidatorModel.create(ipv46="aaaaaa")
+    await ValidatorModel.create(ipv46="::")
+    await ValidatorModel.create(ipv46="8.8.8.8")
 
 
 @pytest.mark.asyncio

--- a/tests/testmodels.py
+++ b/tests/testmodels.py
@@ -25,10 +25,12 @@ from tortoise.timezone import UTC
 from tortoise.validators import (
     CommaSeparatedIntegerListValidator,
     MaxValueValidator,
+    MinLengthValidator,
     MinValueValidator,
     RegexValidator,
     validate_ipv4_address,
     validate_ipv6_address,
+    validate_ipv46_address,
 )
 
 
@@ -900,8 +902,10 @@ class RequiredPKModel(Model):
 class ValidatorModel(Model):
     regex = fields.CharField(max_length=100, null=True, validators=[RegexValidator("abc.+", re.I)])
     max_length = fields.CharField(max_length=5, null=True)
+    min_length = fields.CharField(max_length=5, null=True, validators=[MinLengthValidator(3)])
     ipv4 = fields.CharField(max_length=100, null=True, validators=[validate_ipv4_address])
     ipv6 = fields.CharField(max_length=100, null=True, validators=[validate_ipv6_address])
+    ipv46 = fields.CharField(max_length=100, null=True, validators=[validate_ipv46_address])
     max_value = fields.IntField(null=True, validators=[MaxValueValidator(20.0)])
     min_value = fields.IntField(null=True, validators=[MinValueValidator(10.0)])
     max_value_decimal = fields.DecimalField(


### PR DESCRIPTION
Add tests for `MinLengthValidator` and `validate_ipv46_address` validators

## Description

Adds test coverage for `MinLengthValidator` and `validate_ipv46_address` validator.

## Motivation and Context

Improves test coverage for existing validators that were previously untested. 

## How Has This Been Tested?

- Added unit tests in `tests/test_validators.py`
- Tests verify both validation success and failure cases

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

