### PR TITLE
Migrations fixes for comments and db_default in MySQL

### DIFF
--- a/tests/migrations/test_operations_real_db.py
+++ b/tests/migrations/test_operations_real_db.py
@@ -587,3 +587,206 @@ async def test_alter_field_null_change(db_isolated):
             await conn.execute_script(f"DROP TABLE IF EXISTS {q('test_config', dialect)}")
         except Exception:
             pass
+
+
+# ---------------------------------------------------------------------------
+# Issue #2141 reproduction tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_alter_field_max_length_preserves_db_default(db_isolated):
+    """Changing max_length on a field with db_default must not lose the default.
+
+    Reproduces https://github.com/tortoise/tortoise-orm/issues/2141 (bug 1).
+
+    On MySQL, MODIFY COLUMN resets the full column definition.  If the
+    migration editor only emits ``MODIFY COLUMN col VARCHAR(20) NOT NULL``
+    without re-applying the DEFAULT, the database default silently disappears.
+    """
+    conn = db_isolated.db()
+    dialect = conn.capabilities.dialect
+
+    if dialect == "sqlite":
+        pytest.skip("SQLite uses table-recreation, not ALTER COLUMN")
+
+    editor = _get_schema_editor(conn)
+
+    # Create table with a VARCHAR(10) column that has db_default=''
+    create_op = CreateModel(
+        name="Profile",
+        fields=[
+            ("id", IntField(primary_key=True)),
+            ("tag", CharField(max_length=50)),
+            ("name", CharField(max_length=10, db_default="")),
+        ],
+        options={"table": "test_profile_2141"},
+    )
+    state = State(models={}, apps=StateApps())
+
+    try:
+        await create_op.run("models", state, dry_run=False, state_editor=editor)
+
+        tbl = q("test_profile_2141", dialect)
+
+        # Verify the default works before any ALTER
+        await conn.execute_script(
+            f"INSERT INTO {tbl} ({q('tag', dialect)}) VALUES ('before_alter')"
+        )
+        rows = await conn.execute_query_dict(
+            f"SELECT * FROM {tbl} WHERE {q('tag', dialect)} = 'before_alter'"
+        )
+        assert rows[0]["name"] == "", "db_default='' should produce empty string"
+
+        # AlterField: change max_length from 10 -> 20, keeping db_default=''
+        alter_op = AlterField(
+            model_name="Profile",
+            name="name",
+            field=CharField(max_length=20, db_default=""),
+        )
+        await alter_op.run("models", state, dry_run=False, state_editor=editor)
+
+        # Insert again omitting 'name' — the default should still work
+        await conn.execute_script(f"INSERT INTO {tbl} ({q('tag', dialect)}) VALUES ('after_alter')")
+        rows = await conn.execute_query_dict(
+            f"SELECT * FROM {tbl} WHERE {q('tag', dialect)} = 'after_alter'"
+        )
+        assert rows[0]["name"] == "", "db_default='' was lost after AlterField changed max_length"
+    finally:
+        try:
+            await conn.execute_script(f"DROP TABLE IF EXISTS {q('test_profile_2141', dialect)}")
+        except Exception:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_alter_field_null_change_preserves_db_default(db_isolated):
+    """Changing nullability on a field with db_default must not lose the default.
+
+    Reproduces a variant of https://github.com/tortoise/tortoise-orm/issues/2141
+    (bug 1) where the trigger is a nullability change instead of max_length.
+    """
+    conn = db_isolated.db()
+    dialect = conn.capabilities.dialect
+
+    if dialect == "sqlite":
+        pytest.skip("SQLite uses table-recreation, not ALTER COLUMN")
+
+    editor = _get_schema_editor(conn)
+
+    # Create table with db_default=99 on an integer column
+    create_op = CreateModel(
+        name="Score",
+        fields=[
+            ("id", IntField(primary_key=True)),
+            ("tag", CharField(max_length=50)),
+            ("value", IntField(null=False, db_default=99)),
+        ],
+        options={"table": "test_score_2141"},
+    )
+    state = State(models={}, apps=StateApps())
+
+    try:
+        await create_op.run("models", state, dry_run=False, state_editor=editor)
+
+        tbl = q("test_score_2141", dialect)
+
+        # Verify the default works before any ALTER
+        await conn.execute_script(f"INSERT INTO {tbl} ({q('tag', dialect)}) VALUES ('before')")
+        rows = await conn.execute_query_dict(
+            f"SELECT * FROM {tbl} WHERE {q('tag', dialect)} = 'before'"
+        )
+        assert rows[0]["value"] == 99
+
+        # AlterField: make nullable, keep same db_default
+        alter_op = AlterField(
+            model_name="Score",
+            name="value",
+            field=IntField(null=True, db_default=99),
+        )
+        await alter_op.run("models", state, dry_run=False, state_editor=editor)
+
+        # The default should still work after the null change
+        await conn.execute_script(f"INSERT INTO {tbl} ({q('tag', dialect)}) VALUES ('after_null')")
+        rows = await conn.execute_query_dict(
+            f"SELECT * FROM {tbl} WHERE {q('tag', dialect)} = 'after_null'"
+        )
+        assert rows[0]["value"] == 99, "db_default=99 was lost after AlterField changed nullability"
+    finally:
+        try:
+            await conn.execute_script(f"DROP TABLE IF EXISTS {q('test_score_2141', dialect)}")
+        except Exception:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_alter_field_description_change_applied(db_isolated):
+    """Changing only a field's description should execute actual DDL.
+
+    Reproduces https://github.com/tortoise/tortoise-orm/issues/2141 (bug 2).
+
+    The migration diff detects description changes (migration file IS created),
+    but ``_alter_field`` has ``pass`` for description changes, so no SQL runs.
+    On PostgreSQL this should emit ``COMMENT ON COLUMN``; on MySQL the COMMENT
+    should appear in a ``MODIFY COLUMN`` clause.
+    """
+    conn = db_isolated.db()
+    dialect = conn.capabilities.dialect
+
+    if dialect == "sqlite":
+        pytest.skip("SQLite does not support column comments")
+
+    editor = _get_schema_editor(conn)
+
+    create_op = CreateModel(
+        name="Item",
+        fields=[
+            ("id", IntField(primary_key=True)),
+            ("name", CharField(max_length=100, description="item name")),
+        ],
+        options={"table": "test_item_2141"},
+    )
+    state = State(models={}, apps=StateApps())
+
+    try:
+        await create_op.run("models", state, dry_run=False, state_editor=editor)
+
+        # AlterField: change only the description
+        alter_op = AlterField(
+            model_name="Item",
+            name="name",
+            field=CharField(max_length=100, description="short item name"),
+        )
+        await alter_op.run("models", state, dry_run=False, state_editor=editor)
+
+        # Verify the comment was actually updated in the database
+        tbl = "test_item_2141"
+        if dialect in ("postgres",):
+            query = (
+                "SELECT col_description(c.oid, a.attnum) AS comment "
+                "FROM pg_class c "
+                "JOIN pg_attribute a ON a.attrelid = c.oid "
+                f"WHERE c.relname = '{tbl}' AND a.attname = 'name'"
+            )
+            rows = await conn.execute_query_dict(query)
+            comment = rows[0]["comment"] if rows else None
+            assert comment == "short item name", (
+                f"PostgreSQL column comment not updated: got {comment!r}"
+            )
+        elif dialect == "mysql":
+            query = (
+                "SELECT COLUMN_COMMENT FROM INFORMATION_SCHEMA.COLUMNS "
+                f"WHERE TABLE_NAME = '{tbl}' AND COLUMN_NAME = 'name'"
+            )
+            rows = await conn.execute_query_dict(query)
+            comment = rows[0]["COLUMN_COMMENT"] if rows else None
+            assert comment == "short item name", (
+                f"MySQL column comment not updated: got {comment!r}"
+            )
+        else:
+            pytest.skip(f"Comment introspection not implemented for {dialect}")
+    finally:
+        try:
+            await conn.execute_script(f"DROP TABLE IF EXISTS {q('test_item_2141', dialect)}")
+        except Exception:
+            pass

--- a/tests/migrations/test_schema_editor_backends.py
+++ b/tests/migrations/test_schema_editor_backends.py
@@ -811,3 +811,254 @@ async def test_mssql_alter_field_max_length() -> None:
 
     assert len(client.executed) == 1
     assert client.executed[0] == "ALTER TABLE [widget] ALTER COLUMN [name] VARCHAR(64) NULL"
+
+
+# ---------------------------------------------------------------------------
+# Bug 1: MySQL MODIFY COLUMN preserves db_default (Issue #2141)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mysql_alter_field_max_length_preserves_db_default() -> None:
+    """MySQL MODIFY COLUMN for max_length change must re-emit SET DEFAULT."""
+
+    class OldWidget(Model):
+        id = fields.IntField(pk=True)
+        name = fields.CharField(max_length=10, db_default="")
+
+        class Meta:
+            table = "profile"
+            app = "models"
+
+    class NewWidget(Model):
+        id = fields.IntField(pk=True)
+        name = fields.CharField(max_length=20, db_default="")
+
+        class Meta:
+            table = "profile"
+            app = "models"
+
+    client = FakeClient("mysql")
+    editor = MySQLSchemaEditor(client)
+    await editor.alter_field(OldWidget, NewWidget, "name")
+
+    assert len(client.executed) == 1
+    sql = client.executed[0]
+    assert "MODIFY COLUMN" in sql
+    assert "DEFAULT ''" in sql
+
+
+@pytest.mark.asyncio
+async def test_mysql_alter_field_null_change_preserves_db_default() -> None:
+    """MySQL MODIFY COLUMN for null change must preserve DEFAULT in the same statement."""
+
+    class OldWidget(Model):
+        id = fields.IntField(pk=True)
+        value = fields.IntField(null=False, db_default=99)
+
+        class Meta:
+            table = "score"
+            app = "models"
+
+    class NewWidget(Model):
+        id = fields.IntField(pk=True)
+        value = fields.IntField(null=True, db_default=99)
+
+        class Meta:
+            table = "score"
+            app = "models"
+
+    client = FakeClient("mysql")
+    editor = MySQLSchemaEditor(client)
+    await editor.alter_field(OldWidget, NewWidget, "value")
+
+    assert len(client.executed) == 1
+    sql = client.executed[0]
+    assert "MODIFY COLUMN" in sql
+    assert "DEFAULT 99" in sql
+
+
+# ---------------------------------------------------------------------------
+# Bug 2: Description changes emit real SQL (Issue #2141)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_postgres_alter_field_description_change() -> None:
+    """PostgreSQL should emit COMMENT ON COLUMN when description changes."""
+
+    class OldWidget(Model):
+        id = fields.IntField(pk=True)
+        name = fields.CharField(max_length=100, description="item name")
+
+        class Meta:
+            table = "item"
+            app = "models"
+
+    class NewWidget(Model):
+        id = fields.IntField(pk=True)
+        name = fields.CharField(max_length=100, description="short item name")
+
+        class Meta:
+            table = "item"
+            app = "models"
+
+    client = FakeClient("postgres", inline_comment=False)
+    editor = BasePostgresSchemaEditor(client)
+    await editor.alter_field(OldWidget, NewWidget, "name")
+
+    assert len(client.executed) == 1
+    assert "COMMENT ON COLUMN" in client.executed[0]
+    assert "short item name" in client.executed[0]
+
+
+@pytest.mark.asyncio
+async def test_postgres_alter_field_description_removal() -> None:
+    """PostgreSQL should emit COMMENT ON COLUMN ... IS NULL when description removed."""
+
+    class OldWidget(Model):
+        id = fields.IntField(pk=True)
+        name = fields.CharField(max_length=100, description="item name")
+
+        class Meta:
+            table = "item"
+            app = "models"
+
+    class NewWidget(Model):
+        id = fields.IntField(pk=True)
+        name = fields.CharField(max_length=100)
+
+        class Meta:
+            table = "item"
+            app = "models"
+
+    client = FakeClient("postgres", inline_comment=False)
+    editor = BasePostgresSchemaEditor(client)
+    await editor.alter_field(OldWidget, NewWidget, "name")
+
+    assert len(client.executed) == 1
+    assert "IS NULL" in client.executed[0]
+
+
+@pytest.mark.asyncio
+async def test_mysql_alter_field_description_change() -> None:
+    """MySQL should emit MODIFY COLUMN with COMMENT when description changes."""
+
+    class OldWidget(Model):
+        id = fields.IntField(pk=True)
+        name = fields.CharField(max_length=100, description="item name")
+
+        class Meta:
+            table = "item"
+            app = "models"
+
+    class NewWidget(Model):
+        id = fields.IntField(pk=True)
+        name = fields.CharField(max_length=100, description="short item name")
+
+        class Meta:
+            table = "item"
+            app = "models"
+
+    client = FakeClient("mysql")
+    editor = MySQLSchemaEditor(client)
+    await editor.alter_field(OldWidget, NewWidget, "name")
+
+    assert len(client.executed) == 1
+    assert "MODIFY COLUMN" in client.executed[0]
+    assert "COMMENT" in client.executed[0]
+    assert "short item name" in client.executed[0]
+
+
+@pytest.mark.asyncio
+async def test_base_alter_field_description_change_noop() -> None:
+    """Base editor should emit no SQL for description-only changes (unsupported)."""
+
+    class OldWidget(Model):
+        id = fields.IntField(pk=True)
+        name = fields.CharField(max_length=100, description="old desc")
+
+        class Meta:
+            table = "item"
+            app = "models"
+
+    class NewWidget(Model):
+        id = fields.IntField(pk=True)
+        name = fields.CharField(max_length=100, description="new desc")
+
+        class Meta:
+            table = "item"
+            app = "models"
+
+    client = FakeClient("sql")
+    editor = TestSchemaEditor(client)
+    await editor.alter_field(OldWidget, NewWidget, "name")
+
+    assert len(client.executed) == 0
+
+
+# ---------------------------------------------------------------------------
+# Step 3: Combined description + other changes on MySQL (Issue #2141)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mysql_alter_field_null_and_description_combined() -> None:
+    """MySQL should emit a single MODIFY COLUMN with both NULL and COMMENT."""
+
+    class OldWidget(Model):
+        id = fields.IntField(pk=True)
+        name = fields.CharField(max_length=100, description="old desc")
+
+        class Meta:
+            table = "item"
+            app = "models"
+
+    class NewWidget(Model):
+        id = fields.IntField(pk=True)
+        name = fields.CharField(max_length=100, null=True, description="new desc")
+
+        class Meta:
+            table = "item"
+            app = "models"
+
+    client = FakeClient("mysql")
+    editor = MySQLSchemaEditor(client)
+    await editor.alter_field(OldWidget, NewWidget, "name")
+
+    # Should be a single MODIFY COLUMN with both NULL and COMMENT
+    modify_stmts = [s for s in client.executed if "MODIFY COLUMN" in s]
+    assert len(modify_stmts) == 1
+    assert "NULL" in modify_stmts[0]
+    assert "COMMENT" in modify_stmts[0]
+    assert "new desc" in modify_stmts[0]
+
+
+@pytest.mark.asyncio
+async def test_mysql_alter_field_null_change_preserves_description() -> None:
+    """MySQL MODIFY COLUMN for null change must preserve existing COMMENT."""
+
+    class OldWidget(Model):
+        id = fields.IntField(pk=True)
+        name = fields.CharField(max_length=100, description="keep this")
+
+        class Meta:
+            table = "item"
+            app = "models"
+
+    class NewWidget(Model):
+        id = fields.IntField(pk=True)
+        name = fields.CharField(max_length=100, null=True, description="keep this")
+
+        class Meta:
+            table = "item"
+            app = "models"
+
+    client = FakeClient("mysql")
+    editor = MySQLSchemaEditor(client)
+    await editor.alter_field(OldWidget, NewWidget, "name")
+
+    modify_stmts = [s for s in client.executed if "MODIFY COLUMN" in s]
+    assert len(modify_stmts) == 1
+    assert "COMMENT" in modify_stmts[0]
+    assert "keep this" in modify_stmts[0]

--- a/tortoise/migrations/schema_editor/base.py
+++ b/tortoise/migrations/schema_editor/base.py
@@ -82,6 +82,12 @@ class BaseSchemaEditor(SchemaQuotingMixin):
         # Databases have their own way of supporting comments for column level
         raise NotImplementedError()  # pragma: nocoverage
 
+    async def _alter_column_comment(
+        self, model: type[Model], old_field: Field, new_field: Field
+    ) -> None:
+        """Alter column comment. Override in backends that support column comments."""
+        pass
+
     def _table_generate_extra(self, table: str) -> str:
         return ""
 
@@ -644,8 +650,7 @@ class BaseSchemaEditor(SchemaQuotingMixin):
                 await self.remove_constraint(model, constraint)
 
         if old_field.description != new_field.description:
-            # TODO description management
-            pass
+            await self._alter_column_comment(model, old_field, new_field)
 
         old_has_db_default = old_field.has_db_default()
         new_has_db_default = new_field.has_db_default()

--- a/tortoise/migrations/schema_editor/base_postgres.py
+++ b/tortoise/migrations/schema_editor/base_postgres.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
+from tortoise.fields.base import Field
 from tortoise.migrations.schema_editor.base import BaseSchemaEditor
 from tortoise.models import Model
 
@@ -51,6 +52,23 @@ class BasePostgresSchemaEditor(BaseSchemaEditor):
         if sql:
             return "\n" + sql
         return ""
+
+    async def _alter_column_comment(
+        self, model: type[Model], old_field: Field, new_field: Field
+    ) -> None:
+        """Emit COMMENT ON COLUMN for PostgreSQL."""
+        db_field = new_field.source_field or new_field.model_field_name
+        qualified_table = self._qualify_table_name(model._meta.db_table, model._meta.schema)
+        if new_field.description:
+            comment = self._escape_comment(new_field.description)
+            await self._run_sql(
+                self.COLUMN_COMMENT_TEMPLATE.format(
+                    table=qualified_table, column=db_field, comment=comment
+                )
+            )
+        else:
+            # Remove comment: SET NULL
+            await self._run_sql(f'COMMENT ON COLUMN {qualified_table}."{db_field}" IS NULL;')
 
     def _get_index_sql(
         self,

--- a/tortoise/migrations/schema_editor/mysql.py
+++ b/tortoise/migrations/schema_editor/mysql.py
@@ -287,30 +287,63 @@ class MySQLSchemaEditor(MySQLQuotingMixin, BaseSchemaEditor):
             )
         )
 
+    def _build_modify_column_sql(
+        self, model: type[Model], field: Field, qualified_table: str
+    ) -> str:
+        """Build a complete MODIFY COLUMN clause including DEFAULT and COMMENT."""
+        db_field = field.source_field or field.model_field_name
+        sql_type = field.get_for_dialect(self.DIALECT, "SQL_TYPE")
+        nullable = "NULL" if field.null else "NOT NULL"
+        default = ""
+        if field.has_db_default():
+            if hasattr(field.db_default, "get_sql"):
+                default_sql = field.db_default.get_sql(dialect=self.DIALECT)
+            else:
+                db_val = field.to_db_value(field.db_default, model)
+                default_sql = self._escape_default_value(db_val)
+            default = f" DEFAULT {default_sql}"
+        comment = ""
+        if field.description:
+            comment = f" COMMENT '{self._escape_comment(field.description)}'"
+        return (
+            f"ALTER TABLE {qualified_table} MODIFY COLUMN"
+            f" {self.quote(db_field)} {sql_type} {nullable}{default}{comment}"
+        )
+
     async def _alter_field(self, model: type[Model], old_field: Field, new_field: Field) -> None:
         # MySQL does not support ALTER COLUMN ... SET/DROP NOT NULL or ALTER COLUMN ... TYPE.
         # It requires MODIFY COLUMN with the full column type specification.
+        # MODIFY COLUMN resets the entire column definition, so we must include
+        # all attributes (type, nullability, DEFAULT, COMMENT) in a single statement.
         old_sql_type = old_field.get_for_dialect(self.DIALECT, "SQL_TYPE")
         new_sql_type = new_field.get_for_dialect(self.DIALECT, "SQL_TYPE")
         null_changed = old_field.null != new_field.null
         type_changed = old_sql_type != new_sql_type
 
         if null_changed or type_changed:
-            db_field = new_field.source_field or new_field.model_field_name
             qualified_table = self._qualify_table_name(model._meta.db_table, model._meta.schema)
-            nullable = "NULL" if new_field.null else "NOT NULL"
-            await self._run_sql(
-                f"ALTER TABLE {qualified_table} MODIFY COLUMN"
-                f" {self.quote(db_field)} {new_sql_type} {nullable}"
-            )
-            # Patch old_field copy so base skips the null and type changes
+            await self._run_sql(self._build_modify_column_sql(model, new_field, qualified_table))
+            # Patch old_field copy so base skips changes already handled by MODIFY
             old_field = copy(old_field)
             old_field.null = new_field.null
+            old_field.db_default = new_field.db_default
+            old_field.description = new_field.description
             for attr in ("max_length", "max_digits", "decimal_places"):
                 if hasattr(new_field, attr):
                     setattr(old_field, attr, getattr(new_field, attr))
 
         await super()._alter_field(model, old_field, new_field)
+
+    async def _alter_column_comment(
+        self, model: type[Model], old_field: Field, new_field: Field
+    ) -> None:
+        """Emit MODIFY COLUMN with full column definition for MySQL.
+
+        MySQL has no standalone COMMENT ON COLUMN statement, so changing the
+        comment requires re-issuing MODIFY COLUMN with all attributes.
+        """
+        qualified_table = self._qualify_table_name(model._meta.db_table, model._meta.schema)
+        await self._run_sql(self._build_modify_column_sql(model, new_field, qualified_table))
 
     async def add_constraint(self, model, constraint) -> None:
         from tortoise.migrations.constraints import CheckConstraint


### PR DESCRIPTION
Fixes #2141

Added comment changing handling for mysql and postgre
Fixed issue for mysql where db_default was lost on alter field