### PR TITLE
Return value generated by db_default on create

### DIFF
--- a/docs/models.rst
+++ b/docs/models.rst
@@ -286,6 +286,26 @@ The ``Meta`` class
 
             ordering = ["name", "-score"]
 
+    .. attribute:: fetch_db_defaults
+        :annotation: = True
+
+        When ``True`` (the default), after an INSERT on a non-RETURNING backend
+        (e.g. MySQL), Tortoise will issue a follow-up ``SELECT`` to fetch
+        database-applied default values for fields declared with ``db_default``.
+
+        Set to ``False`` to skip the extra query when you don't need the
+        database-generated values back on the Python instance immediately.
+        On RETURNING backends (PostgreSQL, SQLite) the values are always
+        returned in the INSERT response regardless of this setting.
+
+        .. code-block:: python3
+
+            class MyModel(Model):
+                score = fields.IntField(db_default=0)
+
+                class Meta:
+                    fetch_db_defaults = False
+
     .. attribute:: manager
         :annotation: = tortoise.manager.Manager
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ keywords = ["sql", "mysql", "postgres", "psql", "sqlite", "aiosqlite", "asyncpg"
 dynamic = ["version"]
 requires-python = ">=3.10"
 dependencies = [
-    "pypika-tortoise (>=0.6.3,<1.0.0)",
+    "pypika-tortoise (>=0.6.5,<1.0.0)",
     "iso8601 (>=2.1.0,<3.0.0); python_version < '4.0'",
     "aiosqlite (>=0.16.0,<1.0.0)",
     "anyio",

--- a/tests/test_db_default_insert.py
+++ b/tests/test_db_default_insert.py
@@ -14,6 +14,7 @@ These tests verify that fields with db_default:
 import datetime
 from decimal import Decimal
 
+import pydantic
 import pytest
 
 from tests.testmodels import DefaultModel, NoFetchDefaultModel, SqlDefaultModel
@@ -254,8 +255,20 @@ class TestMetaInfo:
 
 class TestPydanticDbDefault:
     @pytest.mark.asyncio
-    async def test_pydantic_model_db_default_field_optional(self, db):
-        PydanticDefault = pydantic_model_creator(DefaultModel)
-        # Should not raise -- db_default fields are optional
-        instance = PydanticDefault(id=1)
-        assert instance.int_default is None
+    async def test_pydantic_no_fetch_requires_refresh(self, db):
+        PydanticNoFetch = pydantic_model_creator(NoFetchDefaultModel)
+
+        instance = await NoFetchDefaultModel.create()
+        conn = instance._meta.db
+
+        if not conn.capabilities.support_returning:
+            # Without RETURNING, unfetched db_default fields are DatabaseDefault sentinels
+            # and pydantic validation will fail
+            with pytest.raises(pydantic.ValidationError):
+                await PydanticNoFetch.from_tortoise_orm(instance)
+
+        # After refreshing from db, pydantic model succeeds
+        refreshed = await NoFetchDefaultModel.get(pk=instance.pk)
+        pydantic_instance = await PydanticNoFetch.from_tortoise_orm(refreshed)
+        assert pydantic_instance.int_val == 1
+        assert pydantic_instance.char_val == "test"

--- a/tests/test_db_default_insert.py
+++ b/tests/test_db_default_insert.py
@@ -1,0 +1,266 @@
+"""
+Integration tests for db_default field behavior during INSERT.
+
+These tests verify that fields with db_default:
+1. Get DatabaseDefault sentinel set when no value provided
+2. Emit DEFAULT keyword in INSERT SQL
+3. Have DB-applied defaults fetched back via RETURNING or SELECT
+4. Work correctly when user provides explicit values
+5. Work with bulk_create (resolving to literal values)
+6. Work with save()/update (skipping DatabaseDefault fields)
+7. Work with Meta.fetch_db_defaults = False
+"""
+
+import pytest
+
+from tortoise import fields
+from tortoise.fields.base import DatabaseDefault
+
+
+class TestDatabaseDefaultSentinel:
+    def test_repr(self):
+        f = fields.IntField(db_default=1)
+        f.model_field_name = "test_field"
+        dd = DatabaseDefault(f)
+        assert "DatabaseDefault" in repr(dd)
+
+    def test_bool_is_false(self):
+        f = fields.IntField(db_default=1)
+        dd = DatabaseDefault(f)
+        assert bool(dd) is False
+
+    def test_str(self):
+        f = fields.IntField(db_default=1)
+        dd = DatabaseDefault(f)
+        assert str(dd) == "<DB_DEFAULT>"
+
+
+class TestFieldRequired:
+    def test_required_false_with_db_default(self):
+        f = fields.CharField(max_length=50, db_default="")
+        assert f.required is False
+
+
+class TestGetDbDefaultValue:
+    def test_returns_database_default_when_has_db_default(self):
+        f = fields.IntField(db_default=42)
+        result = f.get_db_default_value()
+        assert isinstance(result, DatabaseDefault)
+        assert result.field is f
+
+    def test_returns_none_when_no_db_default(self):
+        f = fields.IntField()
+        result = f.get_db_default_value()
+        assert result is None
+
+
+class TestModelInitDbDefault:
+    @pytest.mark.asyncio
+    async def test_init_sets_database_default(self, db):
+        from tests.testmodels import DefaultModel
+
+        instance = DefaultModel()
+        assert isinstance(instance.int_default, DatabaseDefault)
+        assert isinstance(instance.char_default, DatabaseDefault)
+        assert isinstance(instance.bool_default, DatabaseDefault)
+        assert isinstance(instance.float_default, DatabaseDefault)
+
+    @pytest.mark.asyncio
+    async def test_init_with_explicit_value(self, db):
+        from tests.testmodels import DefaultModel
+
+        instance = DefaultModel(int_default=42)
+        assert instance.int_default == 42
+        assert isinstance(instance.char_default, DatabaseDefault)
+
+
+class TestConstructWithDbDefault:
+    @pytest.mark.asyncio
+    async def test_construct_sets_database_default(self, db):
+        from tests.testmodels import DefaultModel
+
+        instance = DefaultModel.construct()
+        assert isinstance(instance.int_default, DatabaseDefault)
+        assert isinstance(instance.char_default, DatabaseDefault)
+
+
+class TestCreateWithDbDefault:
+    @pytest.mark.asyncio
+    async def test_create_no_args_applies_db_defaults_and_persists(self, db):
+        from tests.testmodels import DefaultModel
+
+        instance = await DefaultModel.create()
+        assert instance.pk is not None
+        assert instance.int_default == 1
+        assert instance.float_default == 1.5
+        assert instance.bool_default is True
+        assert instance.char_default == "tortoise"
+
+        refreshed = await DefaultModel.get(pk=instance.pk)
+        assert refreshed.int_default == 1
+        assert refreshed.char_default == "tortoise"
+        assert refreshed.bool_default is True
+        assert refreshed.float_default == 1.5
+
+    @pytest.mark.asyncio
+    async def test_create_with_partial_override(self, db):
+        from tests.testmodels import DefaultModel
+
+        instance = await DefaultModel.create(int_default=99, char_default="custom")
+        assert instance.int_default == 99
+        assert instance.char_default == "custom"
+        assert instance.bool_default is True
+
+        instance2 = await DefaultModel.create(int_default=42)
+        assert instance2.int_default == 42
+        assert instance2.char_default == "tortoise"
+
+    @pytest.mark.asyncio
+    async def test_create_all_explicit_values(self, db):
+        """When all values are provided, cached query path is used (no DEFAULT keyword)."""
+        import datetime
+        from decimal import Decimal
+
+        from tests.testmodels import DefaultModel
+        from tortoise.timezone import UTC
+
+        instance = await DefaultModel.create(
+            int_default=10,
+            float_default=2.5,
+            decimal_default=Decimal("3.14"),
+            bool_default=False,
+            char_default="all_set",
+            date_default=datetime.date(2024, 1, 1),
+            datetime_default=datetime.datetime(2024, 1, 1, tzinfo=UTC),
+        )
+        assert instance.int_default == 10
+        assert instance.float_default == 2.5
+        assert instance.char_default == "all_set"
+        assert instance.bool_default is False
+
+
+class TestBulkCreateWithDbDefault:
+    @pytest.mark.asyncio
+    async def test_bulk_create_all_defaults(self, db):
+        from tests.testmodels import DefaultModel
+
+        instances = [DefaultModel() for _ in range(3)]
+        await DefaultModel.bulk_create(instances)
+        all_inst = await DefaultModel.all()
+        assert len(all_inst) == 3
+        for inst in all_inst:
+            assert inst.int_default == 1
+            assert inst.char_default == "tortoise"
+
+    @pytest.mark.asyncio
+    async def test_bulk_create_all_explicit_values(self, db):
+        """When all instances provide explicit values for a db_default field, column is included."""
+        from tests.testmodels import DefaultModel
+
+        inst1 = DefaultModel(int_default=99)
+        inst2 = DefaultModel(int_default=77)
+        await DefaultModel.bulk_create([inst1, inst2])
+        all_inst = await DefaultModel.all().order_by("id")
+        assert all_inst[0].int_default == 99
+        assert all_inst[1].int_default == 77
+
+    @pytest.mark.asyncio
+    async def test_bulk_create_mixed_raises(self, db):
+        """Mixed usage (some default, some explicit) for same field raises OperationalError."""
+        from tests.testmodels import DefaultModel
+        from tortoise.exceptions import OperationalError
+
+        inst1 = DefaultModel(int_default=99)
+        inst2 = DefaultModel()  # int_default is DatabaseDefault
+        with pytest.raises(OperationalError, match="Cannot use bulk_create"):
+            await DefaultModel.bulk_create([inst1, inst2])
+
+    @pytest.mark.asyncio
+    async def test_bulk_create_sql_default_all_defaults_omits_column(self, db):
+        """bulk_create with SqlDefault fields where all use default should omit the column."""
+        from tests.testmodels import SqlDefaultModel
+
+        instances = [SqlDefaultModel(name="test1"), SqlDefaultModel(name="test2")]
+        await SqlDefaultModel.bulk_create(instances)
+        all_inst = await SqlDefaultModel.all()
+        assert len(all_inst) == 2
+        for inst in all_inst:
+            assert inst.created_at is not None
+
+    @pytest.mark.asyncio
+    async def test_bulk_create_allowed_with_fetch_false(self, db):
+        """bulk_create with db_default fields on fetch_db_defaults=False model should work."""
+        from tests.testmodels import NoFetchDefaultModel
+
+        instances = [NoFetchDefaultModel() for _ in range(3)]
+        await NoFetchDefaultModel.bulk_create(instances)
+        all_inst = await NoFetchDefaultModel.all()
+        assert len(all_inst) == 3
+        for inst in all_inst:
+            assert inst.int_val == 1
+            assert inst.char_val == "test"
+
+
+class TestSaveUpdateWithDbDefault:
+    @pytest.mark.asyncio
+    async def test_update_skips_database_default_fields(self, db):
+        from tests.testmodels import DefaultModel
+
+        instance = await DefaultModel.create()
+
+        # Targeted update with update_fields
+        instance.int_default = 42
+        await instance.save(update_fields=["int_default"])
+        refreshed = await DefaultModel.get(pk=instance.pk)
+        assert refreshed.int_default == 42
+        assert refreshed.char_default == "tortoise"
+
+        # Full save() should also skip DatabaseDefault fields
+        refreshed.int_default = 99
+        await refreshed.save()
+        final = await DefaultModel.get(pk=instance.pk)
+        assert final.int_default == 99
+        assert final.char_default == "tortoise"
+
+
+class TestNoFetchDbDefaults:
+    @pytest.mark.asyncio
+    async def test_create_with_no_fetch(self, db):
+        """Models with fetch_db_defaults=False still emit DEFAULT keyword."""
+        from tests.testmodels import NoFetchDefaultModel
+
+        instance = await NoFetchDefaultModel.create()
+        assert instance.pk is not None
+        # On RETURNING backends (sqlite, pg), values should be fetched despite fetch_db_defaults=False
+        # because RETURNING is always used.
+        # On non-RETURNING backends, values remain DatabaseDefault.
+        # For SQLite (used in tests), values should be populated.
+        refreshed = await NoFetchDefaultModel.get(pk=instance.pk)
+        assert refreshed.int_val == 1
+        assert refreshed.char_val == "test"
+
+
+class TestMetaInfo:
+    @pytest.mark.asyncio
+    async def test_db_default_meta_attributes(self, db):
+        from tests.testmodels import DefaultModel, NoFetchDefaultModel
+
+        meta = DefaultModel._meta
+        assert len(meta.db_default_db_columns) > 0
+        assert "int_default" in meta.db_default_db_columns
+        assert "char_default" in meta.db_default_db_columns
+        assert meta.fetch_db_defaults is True
+
+        assert NoFetchDefaultModel._meta.fetch_db_defaults is False
+
+
+class TestPydanticDbDefault:
+    @pytest.mark.asyncio
+    async def test_pydantic_model_db_default_field_optional(self, db):
+        from tests.testmodels import DefaultModel
+        from tortoise.contrib.pydantic import pydantic_model_creator
+
+        PydanticDefault = pydantic_model_creator(DefaultModel)
+        # Should not raise -- db_default fields are optional
+        instance = PydanticDefault(id=1)
+        assert instance.int_default is None

--- a/tests/test_db_default_insert.py
+++ b/tests/test_db_default_insert.py
@@ -11,10 +11,17 @@ These tests verify that fields with db_default:
 7. Work with Meta.fetch_db_defaults = False
 """
 
+import datetime
+from decimal import Decimal
+
 import pytest
 
+from tests.testmodels import DefaultModel, NoFetchDefaultModel, SqlDefaultModel
 from tortoise import fields
+from tortoise.contrib.pydantic import pydantic_model_creator
+from tortoise.exceptions import OperationalError
 from tortoise.fields.base import DatabaseDefault
+from tortoise.timezone import UTC
 
 
 class TestDatabaseDefaultSentinel:
@@ -57,7 +64,6 @@ class TestGetDbDefaultValue:
 class TestModelInitDbDefault:
     @pytest.mark.asyncio
     async def test_init_sets_database_default(self, db):
-        from tests.testmodels import DefaultModel
 
         instance = DefaultModel()
         assert isinstance(instance.int_default, DatabaseDefault)
@@ -67,7 +73,6 @@ class TestModelInitDbDefault:
 
     @pytest.mark.asyncio
     async def test_init_with_explicit_value(self, db):
-        from tests.testmodels import DefaultModel
 
         instance = DefaultModel(int_default=42)
         assert instance.int_default == 42
@@ -77,7 +82,6 @@ class TestModelInitDbDefault:
 class TestConstructWithDbDefault:
     @pytest.mark.asyncio
     async def test_construct_sets_database_default(self, db):
-        from tests.testmodels import DefaultModel
 
         instance = DefaultModel.construct()
         assert isinstance(instance.int_default, DatabaseDefault)
@@ -87,7 +91,6 @@ class TestConstructWithDbDefault:
 class TestCreateWithDbDefault:
     @pytest.mark.asyncio
     async def test_create_no_args_applies_db_defaults_and_persists(self, db):
-        from tests.testmodels import DefaultModel
 
         instance = await DefaultModel.create()
         assert instance.pk is not None
@@ -104,7 +107,6 @@ class TestCreateWithDbDefault:
 
     @pytest.mark.asyncio
     async def test_create_with_partial_override(self, db):
-        from tests.testmodels import DefaultModel
 
         instance = await DefaultModel.create(int_default=99, char_default="custom")
         assert instance.int_default == 99
@@ -118,12 +120,6 @@ class TestCreateWithDbDefault:
     @pytest.mark.asyncio
     async def test_create_all_explicit_values(self, db):
         """When all values are provided, cached query path is used (no DEFAULT keyword)."""
-        import datetime
-        from decimal import Decimal
-
-        from tests.testmodels import DefaultModel
-        from tortoise.timezone import UTC
-
         instance = await DefaultModel.create(
             int_default=10,
             float_default=2.5,
@@ -142,7 +138,6 @@ class TestCreateWithDbDefault:
 class TestBulkCreateWithDbDefault:
     @pytest.mark.asyncio
     async def test_bulk_create_all_defaults(self, db):
-        from tests.testmodels import DefaultModel
 
         instances = [DefaultModel() for _ in range(3)]
         await DefaultModel.bulk_create(instances)
@@ -155,7 +150,6 @@ class TestBulkCreateWithDbDefault:
     @pytest.mark.asyncio
     async def test_bulk_create_all_explicit_values(self, db):
         """When all instances provide explicit values for a db_default field, column is included."""
-        from tests.testmodels import DefaultModel
 
         inst1 = DefaultModel(int_default=99)
         inst2 = DefaultModel(int_default=77)
@@ -167,9 +161,6 @@ class TestBulkCreateWithDbDefault:
     @pytest.mark.asyncio
     async def test_bulk_create_mixed_raises(self, db):
         """Mixed usage (some default, some explicit) for same field raises OperationalError."""
-        from tests.testmodels import DefaultModel
-        from tortoise.exceptions import OperationalError
-
         inst1 = DefaultModel(int_default=99)
         inst2 = DefaultModel()  # int_default is DatabaseDefault
         with pytest.raises(OperationalError, match="Cannot use bulk_create"):
@@ -178,8 +169,6 @@ class TestBulkCreateWithDbDefault:
     @pytest.mark.asyncio
     async def test_bulk_create_sql_default_all_defaults_omits_column(self, db):
         """bulk_create with SqlDefault fields where all use default should omit the column."""
-        from tests.testmodels import SqlDefaultModel
-
         instances = [SqlDefaultModel(name="test1"), SqlDefaultModel(name="test2")]
         await SqlDefaultModel.bulk_create(instances)
         all_inst = await SqlDefaultModel.all()
@@ -191,8 +180,6 @@ class TestBulkCreateWithDbDefault:
     @pytest.mark.asyncio
     async def test_bulk_create_allowed_with_fetch_false(self, db):
         """bulk_create with db_default fields on fetch_db_defaults=False model should work."""
-        from tests.testmodels import NoFetchDefaultModel
-
         instances = [NoFetchDefaultModel() for _ in range(3)]
         await NoFetchDefaultModel.bulk_create(instances)
         all_inst = await NoFetchDefaultModel.all()
@@ -205,7 +192,6 @@ class TestBulkCreateWithDbDefault:
 class TestSaveUpdateWithDbDefault:
     @pytest.mark.asyncio
     async def test_update_skips_database_default_fields(self, db):
-        from tests.testmodels import DefaultModel
 
         instance = await DefaultModel.create()
 
@@ -227,15 +213,28 @@ class TestSaveUpdateWithDbDefault:
 class TestNoFetchDbDefaults:
     @pytest.mark.asyncio
     async def test_create_with_no_fetch(self, db):
-        """Models with fetch_db_defaults=False still emit DEFAULT keyword."""
-        from tests.testmodels import NoFetchDefaultModel
+        """Models with fetch_db_defaults=False still emit DEFAULT keyword.
+
+        On RETURNING backends (sqlite, pg), values are populated via RETURNING
+        regardless of fetch_db_defaults.
+        On non-RETURNING backends (mysql), values remain DatabaseDefault on the
+        in-memory instance since the post-INSERT SELECT is skipped.
+        """
+        conn = db.db()
 
         instance = await NoFetchDefaultModel.create()
         assert instance.pk is not None
-        # On RETURNING backends (sqlite, pg), values should be fetched despite fetch_db_defaults=False
-        # because RETURNING is always used.
-        # On non-RETURNING backends, values remain DatabaseDefault.
-        # For SQLite (used in tests), values should be populated.
+
+        if conn.capabilities.support_returning:
+            # RETURNING populates values regardless of fetch_db_defaults
+            assert instance.int_val == 1
+            assert instance.char_val == "test"
+        else:
+            # Non-RETURNING backends skip the post-INSERT SELECT
+            assert isinstance(instance.int_val, DatabaseDefault)
+            assert isinstance(instance.char_val, DatabaseDefault)
+
+        # A fresh SELECT always returns the real values
         refreshed = await NoFetchDefaultModel.get(pk=instance.pk)
         assert refreshed.int_val == 1
         assert refreshed.char_val == "test"
@@ -244,8 +243,6 @@ class TestNoFetchDbDefaults:
 class TestMetaInfo:
     @pytest.mark.asyncio
     async def test_db_default_meta_attributes(self, db):
-        from tests.testmodels import DefaultModel, NoFetchDefaultModel
-
         meta = DefaultModel._meta
         assert len(meta.db_default_db_columns) > 0
         assert "int_default" in meta.db_default_db_columns
@@ -258,9 +255,6 @@ class TestMetaInfo:
 class TestPydanticDbDefault:
     @pytest.mark.asyncio
     async def test_pydantic_model_db_default_field_optional(self, db):
-        from tests.testmodels import DefaultModel
-        from tortoise.contrib.pydantic import pydantic_model_creator
-
         PydanticDefault = pydantic_model_creator(DefaultModel)
         # Should not raise -- db_default fields are optional
         instance = PydanticDefault(id=1)

--- a/tests/test_db_default_insert.py
+++ b/tests/test_db_default_insert.py
@@ -186,6 +186,7 @@ class TestBulkCreateWithDbDefault:
         assert len(all_inst) == 2
         for inst in all_inst:
             assert inst.created_at is not None
+            assert inst.counter == 0
 
     @pytest.mark.asyncio
     async def test_bulk_create_allowed_with_fetch_false(self, db):

--- a/tests/testmodels.py
+++ b/tests/testmodels.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel, ConfigDict
 from tortoise import fields
 from tortoise.exceptions import NoValuesFetched, ValidationError
 from tortoise.fields import NO_ACTION
+from tortoise.fields.db_defaults import RandomHex, SqlDefault
 from tortoise.indexes import Index
 from tortoise.manager import Manager
 from tortoise.models import Model
@@ -890,6 +891,28 @@ class DefaultModel(Model):
     datetime_default = fields.DatetimeField(
         db_default=datetime.datetime(year=2020, month=5, day=20, tzinfo=UTC)
     )
+
+
+class SqlDefaultModel(Model):
+    """Model with SqlDefault expressions for db_default."""
+
+    name = fields.CharField(max_length=100)
+    created_at = fields.DatetimeField(db_default=SqlDefault("CURRENT_TIMESTAMP"))
+    tracking_id = fields.CharField(max_length=36, null=True, db_default=RandomHex())
+
+    class Meta:
+        table = "sql_default_model"
+
+
+class NoFetchDefaultModel(Model):
+    """Model with fetch_db_defaults = False."""
+
+    int_val = fields.IntField(db_default=1)
+    char_val = fields.CharField(max_length=20, db_default="test")
+
+    class Meta:
+        table = "no_fetch_default"
+        fetch_db_defaults = False
 
 
 class RequiredPKModel(Model):

--- a/tests/testmodels.py
+++ b/tests/testmodels.py
@@ -17,7 +17,7 @@ from pydantic import BaseModel, ConfigDict
 from tortoise import fields
 from tortoise.exceptions import NoValuesFetched, ValidationError
 from tortoise.fields import NO_ACTION
-from tortoise.fields.db_defaults import RandomHex, SqlDefault
+from tortoise.fields.db_defaults import Now, RandomHex, SqlDefault
 from tortoise.indexes import Index
 from tortoise.manager import Manager
 from tortoise.models import Model
@@ -897,7 +897,8 @@ class SqlDefaultModel(Model):
     """Model with SqlDefault expressions for db_default."""
 
     name = fields.CharField(max_length=100)
-    created_at = fields.DatetimeField(db_default=SqlDefault("CURRENT_TIMESTAMP"))
+    created_at = fields.DatetimeField(db_default=Now())
+    counter = fields.IntField(db_default=SqlDefault("0"))
     tracking_id = fields.CharField(max_length=36, null=True, db_default=RandomHex())
 
     class Meta:

--- a/tortoise/backends/base/client.py
+++ b/tortoise/backends/base/client.py
@@ -41,6 +41,7 @@ class Capabilities:
     :param support_json_attributes: indicated if the db supports accessing json attributes
     :param can_rollback_ddl: Whether the database supports transactional DDL.
         Used to determine if migrations can be run atomically.
+    :param support_returning: Indicates that this DB supports INSERT ... RETURNING.
     """
 
     def __init__(
@@ -62,6 +63,7 @@ class Capabilities:
         support_for_posix_regex_queries: bool = False,
         support_json_attributes: bool = False,
         can_rollback_ddl: bool = False,
+        support_returning: bool = False,
     ) -> None:
         super().__setattr__("_mutable", True)
 
@@ -77,6 +79,7 @@ class Capabilities:
         self.support_for_posix_regex_queries = support_for_posix_regex_queries
         self.support_json_attributes = support_json_attributes
         self.can_rollback_ddl = can_rollback_ddl
+        self.support_returning = support_returning
         super().__setattr__("_mutable", False)
 
     def __setattr__(self, attr: str, value: Any) -> None:

--- a/tortoise/backends/base/executor.py
+++ b/tortoise/backends/base/executor.py
@@ -19,7 +19,6 @@ from tortoise.fields.relational import (
     RelationalField,
 )
 from tortoise.query_utils import QueryModifier
-from tortoise.utils import chunk
 
 if TYPE_CHECKING:  # pragma: nocoverage
     from tortoise.backends.base.client import BaseDBAsyncClient
@@ -186,58 +185,196 @@ class BaseExecutor:
     def parameter(self, pos: int) -> Parameter:
         return Parameter(idx=pos + 1)
 
+    def _has_db_default_values(self, instance: Model, columns: list[str]) -> bool:
+        """Check whether any column on the instance still holds a DatabaseDefault sentinel."""
+        from tortoise.fields.base import DatabaseDefault
+
+        if not self.model._meta.db_default_db_columns:
+            return False
+        for field_name in columns:
+            if isinstance(getattr(instance, field_name, None), DatabaseDefault):
+                return True
+        return False
+
+    def _build_insert_with_defaults(
+        self,
+        instance: Model,
+        columns: list[str] | None = None,
+        has_generated: bool = True,
+        ignore_conflicts: bool = False,
+    ) -> tuple[str, list[Any], list[str]]:
+        """Build an INSERT query where DatabaseDefault fields are omitted.
+
+        Returns ``(sql_string, values_list, db_default_columns)`` where:
+        - *values_list* only contains bind values for non-DatabaseDefault fields.
+        - *db_default_columns* lists the DB column names that were omitted from
+          the INSERT (they will use the DB-level DEFAULT).
+        """
+        from tortoise.fields.base import DatabaseDefault
+
+        if columns is None:
+            columns = self.regular_columns
+
+        active_db_columns: list[str] = []
+        values: list[Any] = []
+        db_default_columns: list[str] = []
+
+        for field_name in columns:
+            field_object = self.model._meta.fields_map[field_name]
+            value = getattr(instance, field_name)
+            db_col = self.model._meta.fields_db_projection[field_name]
+            if isinstance(value, DatabaseDefault):
+                db_default_columns.append(db_col)
+            else:
+                active_db_columns.append(db_col)
+                values.append(field_object.to_db_value(value, instance))
+
+        table = self.model._meta.basetable
+
+        if active_db_columns:
+            insert_terms = [self.parameter(i) for i in range(len(active_db_columns))]
+            query = (
+                self.db.query_class.into(table).columns(*active_db_columns).insert(*insert_terms)
+            )
+        else:
+            query = self.db.query_class.into(table).default_values()
+
+        query = self._add_returning_to_insert(query, has_generated, db_default_columns)
+        if ignore_conflicts:
+            query = query.on_conflict().do_nothing()
+        return str(query), values, db_default_columns
+
+    def _get_returning_fields(
+        self,
+        has_generated: bool,
+        db_default_columns: list[str],
+    ) -> list[str]:
+        """Compute the list of column names for a RETURNING clause.
+
+        Combines generated fields (when *has_generated* is True) with
+        *db_default_columns*, deduplicating in order.
+        """
+        returning_fields: list[str] = []
+        if has_generated and (generated_fields := self.model._meta.generated_db_fields):
+            returning_fields.extend(generated_fields)
+        for col in db_default_columns:
+            if col not in returning_fields:
+                returning_fields.append(col)
+        return returning_fields
+
+    def _add_returning_to_insert(
+        self,
+        query: QueryBuilder,
+        has_generated: bool,
+        db_default_columns: list[str],
+    ) -> QueryBuilder:
+        """Hook for backends to add RETURNING clause.
+
+        Base implementation does nothing (backends without RETURNING support).
+        Override in PostgreSQL and SQLite executors.
+        """
+        return query
+
+    async def _execute_insert_dynamic(
+        self,
+        instance: Model,
+        columns: list[str],
+        has_generated: bool,
+    ) -> Any:
+        """Execute a dynamic INSERT (with DEFAULT keywords) and return the raw result.
+
+        Calls ``_build_insert_with_defaults`` to produce the SQL, then
+        executes it via the DB client.
+        """
+        query, values, _db_default_columns = self._build_insert_with_defaults(
+            instance, columns=columns, has_generated=has_generated
+        )
+        return await self.db.execute_insert(query, values)
+
     async def execute_insert(self, instance: Model) -> None:
         if not instance._custom_generated_pk:
-            values = [
-                self.model._meta.fields_map[field_name].to_db_value(
-                    getattr(instance, field_name), instance
+            has_db_defaults = self._has_db_default_values(instance, self.regular_columns)
+
+            if has_db_defaults:
+                insert_result = await self._execute_insert_dynamic(
+                    instance, self.regular_columns, has_generated=True
                 )
-                for field_name in self.regular_columns
-            ]
-            insert_result = await self.db.execute_insert(self.insert_query, values)
+            else:
+                values = [
+                    self.model._meta.fields_map[field_name].to_db_value(
+                        getattr(instance, field_name), instance
+                    )
+                    for field_name in self.regular_columns
+                ]
+                insert_result = await self.db.execute_insert(self.insert_query, values)
             await self._process_insert_result(instance, insert_result)
 
         else:
-            values = [
-                self.model._meta.fields_map[field_name].to_db_value(
-                    getattr(instance, field_name), instance
+            has_db_defaults = self._has_db_default_values(instance, self.regular_columns_all)
+
+            if has_db_defaults:
+                insert_result = await self._execute_insert_dynamic(
+                    instance, self.regular_columns_all, has_generated=False
                 )
-                for field_name in self.regular_columns_all
-            ]
-            await self.db.execute_insert(self.insert_query_all, values)
-
-    async def execute_bulk_insert(
-        self,
-        instances: Iterable[Model],
-        batch_size: int | None = None,
-    ) -> None:
-        for instance_chunk in chunk(instances, batch_size):
-            values_lists_all = []
-            values_lists = []
-            for instance in instance_chunk:
-                if instance._custom_generated_pk:
-                    values_lists_all.append(
-                        [
-                            self.model._meta.fields_map[field_name].to_db_value(
-                                getattr(instance, field_name), instance
-                            )
-                            for field_name in self.regular_columns_all
-                        ]
+                await self._process_insert_result(instance, insert_result)
+            else:
+                values = [
+                    self.model._meta.fields_map[field_name].to_db_value(
+                        getattr(instance, field_name), instance
                     )
-                else:
-                    values_lists.append(
-                        [
-                            self.model._meta.fields_map[field_name].to_db_value(
-                                getattr(instance, field_name), instance
-                            )
-                            for field_name in self.regular_columns
-                        ]
-                    )
+                    for field_name in self.regular_columns_all
+                ]
+                await self.db.execute_insert(self.insert_query_all, values)
 
-            if values_lists_all:
-                await self.db.execute_many(self.insert_query_all, values_lists_all)
-            if values_lists:
-                await self.db.execute_many(self.insert_query, values_lists)
+    async def _fetch_db_defaults_after_insert(self, instance: Model) -> None:
+        """Fetch DB-applied default values via SELECT after INSERT.
+
+        Called only for non-RETURNING backends when db_default fields
+        were set to DEFAULT in the INSERT.
+        Guarded by Meta.fetch_db_defaults.
+        """
+        from tortoise.fields.base import DatabaseDefault
+
+        if not self.model._meta.fetch_db_defaults:
+            return
+
+        db_default_db_columns = self.model._meta.db_default_db_columns
+        if not db_default_db_columns:
+            return
+
+        # Determine which fields still have DatabaseDefault (not populated by RETURNING)
+        fields_to_fetch = []
+        db_projection_reverse = self.model._meta.fields_db_projection_reverse
+        for db_col in db_default_db_columns:
+            model_field = db_projection_reverse.get(db_col, db_col)
+            if isinstance(getattr(instance, model_field, None), DatabaseDefault):
+                fields_to_fetch.append(db_col)
+
+        if not fields_to_fetch:
+            return
+
+        # Need PK to SELECT
+        if instance.pk is None:
+            return
+
+        # Build SELECT via pypika for proper quoting
+        table = self.model._meta.basetable
+        pk_col = self.model._meta.db_pk_column
+        query = (
+            self.db.query_class.from_(table)
+            .select(*fields_to_fetch)
+            .where(table[pk_col] == self.parameter(0))
+        )
+        pk_value = self.model._meta.pk.to_db_value(instance.pk, instance)
+        _, rows = await self.db.execute_query(str(query), [pk_value])
+
+        if rows:
+            row = rows[0]
+            for db_col in fields_to_fetch:
+                model_field = db_projection_reverse.get(db_col, db_col)
+                field_object = self.model._meta.fields_map[model_field]
+                raw_value = row.get(db_col)
+                setattr(instance, model_field, field_object.to_python_value(raw_value))
 
     def get_update_sql(
         self,
@@ -291,28 +428,49 @@ class BaseExecutor:
     async def execute_update(
         self, instance: type[Model] | Model, update_fields: Iterable[str] | None
     ) -> int:
-        values = []
-        expressions = {}
-        for field in update_fields or self.model._meta.fields_db_projection.keys():
+        from tortoise.fields.base import DatabaseDefault
+
+        user_specified = update_fields is not None
+        source_fields: list[str] = (
+            list(update_fields)
+            if update_fields is not None
+            else list(self.model._meta.fields_db_projection.keys())
+        )
+
+        effective_fields: list[str] = []
+        for field in source_fields:
             field_obj = self.model._meta.fields_map[field]
             if field_obj.pk:
-                if update_fields:
+                if user_specified:
                     raise OperationalError(
                         f"Can't update pk field, use `{self.model.__name__}.create` instead."
                     )
                 continue
             if field_obj.generated:
-                if update_fields:
+                if user_specified:
                     raise OperationalError(f"Can't update generated field {field}")
                 continue
+            instance_field = getattr(instance, field)
+            if isinstance(instance_field, DatabaseDefault):
+                continue
+            effective_fields.append(field)
+
+        if not effective_fields:
+            return 0
+
+        values = []
+        expressions = {}
+        for field in effective_fields:
             instance_field = getattr(instance, field)
             if isinstance(instance_field, Expression):
                 expressions[field] = instance_field
             else:
+                field_obj = self.model._meta.fields_map[field]
                 values.append(field_obj.to_db_value(instance_field, instance))
+
         values.append(self.model._meta.pk.to_db_value(instance.pk, instance))
         return (
-            await self.db.execute_query(self.get_update_sql(update_fields, expressions), values)
+            await self.db.execute_query(self.get_update_sql(effective_fields, expressions), values)
         )[0]
 
     async def execute_delete(self, instance: type[Model] | Model) -> int:

--- a/tortoise/backends/base/executor.py
+++ b/tortoise/backends/base/executor.py
@@ -12,6 +12,7 @@ from pypika_tortoise.queries import QueryBuilder
 
 from tortoise.exceptions import OperationalError
 from tortoise.expressions import Expression, ResolveContext
+from tortoise.fields.base import DatabaseDefault
 from tortoise.fields.relational import (
     BackwardFKRelation,
     BackwardOneToOneRelation,
@@ -187,7 +188,6 @@ class BaseExecutor:
 
     def _has_db_default_values(self, instance: Model, columns: list[str]) -> bool:
         """Check whether any column on the instance still holds a DatabaseDefault sentinel."""
-        from tortoise.fields.base import DatabaseDefault
 
         if not self.model._meta.db_default_db_columns:
             return False
@@ -210,7 +210,6 @@ class BaseExecutor:
         - *db_default_columns* lists the DB column names that were omitted from
           the INSERT (they will use the DB-level DEFAULT).
         """
-        from tortoise.fields.base import DatabaseDefault
 
         if columns is None:
             columns = self.regular_columns
@@ -333,7 +332,6 @@ class BaseExecutor:
         were set to DEFAULT in the INSERT.
         Guarded by Meta.fetch_db_defaults.
         """
-        from tortoise.fields.base import DatabaseDefault
 
         if not self.model._meta.fetch_db_defaults:
             return
@@ -428,7 +426,6 @@ class BaseExecutor:
     async def execute_update(
         self, instance: type[Model] | Model, update_fields: Iterable[str] | None
     ) -> int:
-        from tortoise.fields.base import DatabaseDefault
 
         user_specified = update_fields is not None
         source_fields: list[str] = (

--- a/tortoise/backends/base_postgres/client.py
+++ b/tortoise/backends/base_postgres/client.py
@@ -51,6 +51,7 @@ class BasePostgresClient(BaseDBAsyncClient, abc.ABC):
         support_for_no_key_update=True,
         support_json_attributes=True,
         can_rollback_ddl=True,
+        support_returning=True,
     )
     connection_class: AsyncConnection | Connection | None = None
     loop: AbstractEventLoop | None = None

--- a/tortoise/backends/base_postgres/executor.py
+++ b/tortoise/backends/base_postgres/executor.py
@@ -6,6 +6,7 @@ from functools import partial
 from typing import TYPE_CHECKING, cast
 
 from pypika_tortoise.dialects import PostgreSQLQueryBuilder
+from pypika_tortoise.queries import QueryBuilder
 from pypika_tortoise.terms import Term, ValueWrapper
 
 from tortoise import Model
@@ -86,9 +87,22 @@ class BasePostgresExecutor(BaseExecutor):
             query = query.on_conflict().do_nothing()
         return query
 
+    def _add_returning_to_insert(
+        self,
+        query: QueryBuilder,
+        has_generated: bool,
+        db_default_columns: list[str],
+    ) -> QueryBuilder:
+        returning_fields = self._get_returning_fields(has_generated, db_default_columns)
+        if returning_fields:
+            query = query.returning(*returning_fields)  # type: ignore[operator]
+        return query
+
     async def _process_insert_result(self, instance: Model, results: dict | None) -> None:
         if results:
-            generated_fields = self.model._meta.generated_db_fields
             db_projection = instance._meta.fields_db_projection_reverse
-            for key, val in zip(generated_fields, results):
-                setattr(instance, db_projection[key], val)
+            for key, val in results.items():
+                if key in db_projection:
+                    model_field = db_projection[key]
+                    field_object = self.model._meta.fields_map[model_field]
+                    setattr(instance, model_field, field_object.to_python_value(val))

--- a/tortoise/backends/mysql/executor.py
+++ b/tortoise/backends/mysql/executor.py
@@ -131,8 +131,11 @@ class MySQLExecutor(BaseExecutor):
         if (
             isinstance(pk_field_object, (SmallIntField, IntField, BigIntField))
             and pk_field_object.generated
+            and not instance._custom_generated_pk
         ):
             instance.pk = results
+        if self.model._meta.db_default_db_columns:
+            await self._fetch_db_defaults_after_insert(instance)
 
         # MySQL can only generate a single ROWID
         #   so if any other primary key, it won't generate what we want.

--- a/tortoise/backends/odbc/executor.py
+++ b/tortoise/backends/odbc/executor.py
@@ -9,5 +9,8 @@ class ODBCExecutor(BaseExecutor):
         if (
             isinstance(pk_field_object, (SmallIntField, IntField, BigIntField))
             and pk_field_object.generated
+            and not instance._custom_generated_pk
         ):
             instance.pk = results
+        if self.model._meta.db_default_db_columns:
+            await self._fetch_db_defaults_after_insert(instance)

--- a/tortoise/backends/psycopg/executor.py
+++ b/tortoise/backends/psycopg/executor.py
@@ -7,18 +7,14 @@ from tortoise.backends.base_postgres.executor import BasePostgresExecutor
 
 
 class PsycopgExecutor(BasePostgresExecutor):
-    async def _process_insert_result(self, instance: Model, results: dict | tuple | None) -> None:
+    async def _process_insert_result(self, instance: Model, results: dict | None) -> None:
         if results:
             db_projection = instance._meta.fields_db_projection_reverse
-
-            if isinstance(results, dict):
-                for key, val in results.items():
-                    setattr(instance, db_projection[key], val)
-            else:
-                generated_fields = self.model._meta.generated_db_fields
-
-                for key, val in zip(generated_fields, results):
-                    setattr(instance, db_projection[key], val)
+            for key, val in results.items():
+                if key in db_projection:
+                    model_field = db_projection[key]
+                    field_object = self.model._meta.fields_map[model_field]
+                    setattr(instance, model_field, field_object.to_python_value(val))
 
     def parameter(self, pos: int) -> Parameter:
         return Parameter("%s")

--- a/tortoise/backends/sqlite/client.py
+++ b/tortoise/backends/sqlite/client.py
@@ -61,6 +61,7 @@ class SqliteClient(BaseDBAsyncClient):
         support_for_update=False,
         support_update_limit_order_by=False,
         can_rollback_ddl=True,
+        support_returning=True,
     )
 
     def __init__(self, file_path: str, **kwargs: Any) -> None:
@@ -286,6 +287,7 @@ class SqliteClientWithRegexpSupport(SqliteClient):
         support_update_limit_order_by=False,
         support_for_posix_regex_queries=True,
         can_rollback_ddl=True,
+        support_returning=True,
     )
 
     async def create_connection(self, with_db: bool) -> None:

--- a/tortoise/backends/sqlite/executor.py
+++ b/tortoise/backends/sqlite/executor.py
@@ -1,6 +1,9 @@
 import datetime
 import sqlite3
 from decimal import Decimal
+from typing import Any
+
+from pypika_tortoise.queries import QueryBuilder
 
 from tortoise import Model
 from tortoise.backends.base.executor import BaseExecutor
@@ -26,13 +29,55 @@ class SqliteExecutor(BaseExecutor):
         insensitive_posix_regex: insensitive_posix_sqlite_regexp,
     }
 
-    async def _process_insert_result(self, instance: Model, results: int) -> None:
-        pk_field_object = self.model._meta.pk
-        if (
-            isinstance(pk_field_object, (SmallIntField, IntField, BigIntField))
-            and pk_field_object.generated
-        ):
-            instance.pk = results
+    def _add_returning_to_insert(
+        self,
+        query: QueryBuilder,
+        has_generated: bool,
+        db_default_columns: list[str],
+    ) -> QueryBuilder:
+        returning_fields = self._get_returning_fields(has_generated, db_default_columns)
+        if returning_fields:
+            query = query.returning(*returning_fields)  # type: ignore[operator]
+        return query
+
+    async def _execute_insert_dynamic(
+        self,
+        instance: Model,
+        columns: list[str],
+        has_generated: bool,
+    ) -> Any:
+        """Execute dynamic INSERT with RETURNING via execute_query.
+
+        SQLite's ``execute_insert`` only returns ``lastrowid``.
+        When we have a RETURNING clause, we use ``execute_query`` instead,
+        which returns ``(count, rows)``.  We return ``dict(rows[0])`` so
+        that ``_process_insert_result`` receives a dict (the RETURNING path).
+        """
+        query, values, db_default_columns = self._build_insert_with_defaults(
+            instance, columns=columns, has_generated=has_generated
+        )
+        if db_default_columns:
+            _, rows = await self.db.execute_query(query, values)
+            if rows:
+                return dict(rows[0])
+            return None
+        return await self.db.execute_insert(query, values)
+
+    async def _process_insert_result(self, instance: Model, results: Any) -> None:
+        if isinstance(results, int):
+            pk_field_object = self.model._meta.pk
+            if (
+                isinstance(pk_field_object, (SmallIntField, IntField, BigIntField))
+                and pk_field_object.generated
+            ):
+                instance.pk = results
+        elif isinstance(results, dict):
+            db_projection = instance._meta.fields_db_projection_reverse
+            for key, val in results.items():
+                if key in db_projection:
+                    model_field = db_projection[key]
+                    field_object = self.model._meta.fields_map[model_field]
+                    setattr(instance, model_field, field_object.to_python_value(val))
 
         # SQLite can only generate a single ROWID
         #   so if any other primary key, it won't generate what we want.

--- a/tortoise/contrib/pydantic/creator.py
+++ b/tortoise/contrib/pydantic/creator.py
@@ -413,10 +413,8 @@ class PydanticModelCreator:
                     PydanticField(default=field.default, **fconfig),
                 )
             else:
-                if (
-                    json_schema_extra.get("nullable")
-                    or field.has_db_default()
-                    or (self._exclude_read_only and json_schema_extra.get("readOnly"))
+                if json_schema_extra.get("nullable") or (
+                    self._exclude_read_only and json_schema_extra.get("readOnly")
                 ):
                     # see: https://docs.pydantic.dev/latest/migration/#required-optional-and-nullable-fields
                     fconfig["default"] = None

--- a/tortoise/contrib/pydantic/creator.py
+++ b/tortoise/contrib/pydantic/creator.py
@@ -177,7 +177,7 @@ def pydantic_queryset_creator(
     )
     model.__doc__ = _cleandoc(cls)
     model.model_config["title"] = name or f"{submodel.model_config['title']}_list"
-    model.model_config["submodel"] = submodel  # type: ignore
+    model.model_config["submodel"] = submodel  # type: ignore[typeddict-unknown-key]
     return model
 
 
@@ -378,7 +378,7 @@ class PydanticModelCreator:
             **common_fields,
         )
         model.__doc__ = _cleandoc(self._cls)
-        model.model_config["orig_model"] = self._cls  # type: ignore
+        model.model_config["orig_model"] = self._cls  # type: ignore[typeddict-unknown-key]
         _MODEL_INDEX[self._hash] = model
         return model
 
@@ -413,8 +413,10 @@ class PydanticModelCreator:
                     PydanticField(default=field.default, **fconfig),
                 )
             else:
-                if json_schema_extra.get("nullable") or (
-                    self._exclude_read_only and json_schema_extra.get("readOnly")
+                if (
+                    json_schema_extra.get("nullable")
+                    or field.has_db_default()
+                    or (self._exclude_read_only and json_schema_extra.get("readOnly"))
                 ):
                     # see: https://docs.pydantic.dev/latest/migration/#required-optional-and-nullable-fields
                     fconfig["default"] = None

--- a/tortoise/fields/base.py
+++ b/tortoise/fields/base.py
@@ -41,6 +41,38 @@ class _DB_DEFAULT_NOT_SET:
 DB_DEFAULT_NOT_SET = _DB_DEFAULT_NOT_SET()
 
 
+class DatabaseDefault:
+    """Sentinel indicating that the database should apply its default value.
+
+    When a field has ``db_default`` and the user does not provide a value,
+    this object is set as the attribute value on the model instance.
+
+    During INSERT compilation it is detected via ``isinstance()`` checks:
+    - Single-insert path: columns with DatabaseDefault are omitted from the
+      INSERT statement, so the DB applies its DEFAULT.
+    - Bulk-insert path: columns where *all* instances hold DatabaseDefault
+      are omitted; mixed usage raises ``OperationalError``.
+    """
+
+    def __init__(self, field: Field) -> None:
+        self.field = field
+
+    def __repr__(self) -> str:
+        return f"DatabaseDefault({self.field.model_field_name!r})"
+
+    def __str__(self) -> str:
+        return "<DB_DEFAULT>"
+
+    def __bool__(self) -> bool:
+        """Returns False so that ``if instance.field:`` is falsy for unset db_default fields.
+
+        This is consistent with "no value has been set yet". Users who need to
+        distinguish between DatabaseDefault and other falsy values should use
+        ``isinstance(value, DatabaseDefault)``.
+        """
+        return False
+
+
 class OnDelete(StrEnum):
     CASCADE = "CASCADE"
     RESTRICT = "RESTRICT"
@@ -318,7 +350,18 @@ class Field(Generic[VALUE], metaclass=_FieldMeta):
 
         It needs to be non-nullable and not have a default or be DB-generated to be required.
         """
-        return self.default is None and not self.null and not self.generated
+        return (
+            self.default is None
+            and not self.null
+            and not self.generated
+            and not self.has_db_default()
+        )
+
+    def get_db_default_value(self) -> DatabaseDefault | None:
+        """Return a DatabaseDefault instance if this field has a db_default, else None."""
+        if self.has_db_default():
+            return DatabaseDefault(self)
+        return None
 
     @property
     def constraints(self) -> dict:

--- a/tortoise/fields/db_defaults.py
+++ b/tortoise/fields/db_defaults.py
@@ -11,10 +11,17 @@ class SqlDefault:
         The SQL string is emitted verbatim into DDL statements.
         Never construct it from untrusted user input.
 
+    .. note::
+        For common expressions that differ across database dialects, prefer the
+        provided convenience subclasses (:class:`Now`, :class:`RandomHex`) over
+        raw SQL strings.  For example, MySQL requires ``CURRENT_TIMESTAMP(6)``
+        for ``DATETIME(6)`` columns, which :class:`Now` handles automatically.
+
     Example::
 
         class MyModel(Model):
-            created_at = fields.DatetimeField(db_default=SqlDefault("CURRENT_TIMESTAMP"))
+            counter = fields.IntField(db_default=SqlDefault("0"))
+            created_at = fields.DatetimeField(db_default=Now())
     """
 
     def __init__(self, sql: str) -> None:

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -213,6 +213,8 @@ class MetaInfo:
         "db_native_fields",
         "db_default_fields",
         "db_complex_fields",
+        "db_default_db_columns",
+        "fetch_db_defaults",
         "_default_ordering",
         "_ordering_validated",
     )
@@ -255,6 +257,8 @@ class MetaInfo:
         self.db_native_fields: list[tuple[str, str, Field]] = []
         self.db_default_fields: list[tuple[str, str, Field]] = []
         self.db_complex_fields: list[tuple[str, str, Field]] = []
+        self.db_default_db_columns: tuple[str, ...] = ()
+        self.fetch_db_defaults: bool = getattr(meta, "fetch_db_defaults", True)
 
     @property
     def full_name(self) -> str:
@@ -339,6 +343,13 @@ class MetaInfo:
             if field.generated
         ]
         self.generated_db_fields = tuple(generated_fields)
+
+        db_default_cols = [
+            (field.source_field or field.model_field_name)
+            for field in self.fields_map.values()
+            if field.has_db_default() and not field.generated
+        ]
+        self.db_default_db_columns = tuple(db_default_cols)
 
         self._ordering_validated = True
         for field_name, _ in self._default_ordering:
@@ -738,10 +749,15 @@ class Model(metaclass=ModelMeta):
                 setattr(self, key, field_default())
             else:
                 default = field_object.default
-                if default is None or isinstance(default, (int, float, str, bool, bytes)):
-                    setattr(self, key, default)
+                if default is not None:
+                    if isinstance(default, (int, float, str, bool, bytes)):
+                        setattr(self, key, default)
+                    else:
+                        setattr(self, key, deepcopy(default))
+                elif field_object.has_db_default():
+                    setattr(self, key, field_object.get_db_default_value())
                 else:
-                    setattr(self, key, deepcopy(default))
+                    setattr(self, key, None)
 
     def __setattr__(self, key, value) -> None:
         # set field value override async default function
@@ -1037,6 +1053,8 @@ class Model(metaclass=ModelMeta):
                 _setattr(self, key, field_default())
             elif field_default is not None:
                 _setattr(self, key, field_default)
+            elif default_field.has_db_default():
+                _setattr(self, key, default_field.get_db_default_value())
             else:
                 _setattr(self, key, None)
 
@@ -1446,12 +1464,22 @@ class Model(metaclass=ModelMeta):
                 User(name="...", email="...")
             ])
 
+        **db_default behaviour:** Fields with ``db_default`` that are not explicitly
+        set will use the database DEFAULT. However, within a single ``bulk_create``
+        call, each ``db_default`` field must be treated consistently across *all*
+        instances — either every instance provides an explicit value, or none of
+        them do.  Mixing explicit values and database defaults for the same field
+        raises :exc:`~tortoise.exceptions.OperationalError`.
+
         :param on_conflict: On conflict index name
         :param update_fields: Update fields when conflicts
         :param ignore_conflicts: Ignore conflicts when inserting
         :param objects: List of objects to bulk create
         :param batch_size: How many objects are created in a single query
         :param using_db: Specific DB connection to use instead of default bound
+
+        :raises OperationalError: If a ``db_default`` field has mixed usage across
+            instances (some provide a value, others rely on the database default).
         """
         return cls._db_queryset(using_db, for_write=True).bulk_create(
             objects, batch_size, ignore_conflicts, update_fields, on_conflict

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -22,6 +22,7 @@ from tortoise.exceptions import (
     ParamsError,
 )
 from tortoise.expressions import Expression, Q, RawSQL, ResolveContext, ResolveResult
+from tortoise.fields.base import DatabaseDefault
 from tortoise.fields.relational import (
     ForeignKeyFieldInstance,
     OneToOneFieldInstance,
@@ -2042,7 +2043,6 @@ class BulkCreateQuery(AwaitableQuery, Generic[MODEL]):
         use DatabaseDefault for that field). Raises OperationalError if a
         field has mixed usage (some instances provide a value, others don't).
         """
-        from tortoise.fields.base import DatabaseDefault
 
         fields_map = self.model._meta.fields_map
         db_default_field_names = [fn for fn in columns if fields_map[fn].has_db_default()]
@@ -2077,87 +2077,72 @@ class BulkCreateQuery(AwaitableQuery, Generic[MODEL]):
         table = self.model._meta.basetable
         return str(self._db.query_class.into(table).default_values())
 
+    def _filter_columns(self, omit_fields: set[str], include_generated: bool = False) -> list[str]:
+        """Prepare INSERT columns, filtering out omitted db_default fields."""
+        _, columns = self._executor._prepare_insert_columns(include_generated=include_generated)
+        if not omit_fields:
+            return columns
+        field_names = (
+            self._executor.regular_columns_all
+            if include_generated
+            else self._executor.regular_columns
+        )
+        return [c for fn, c in zip(field_names, columns) if fn not in omit_fields]
+
+    def _apply_on_conflict(
+        self,
+        insert_query: QueryBuilder,
+        insert_query_all: QueryBuilder,
+        update_fields: Iterable[str],
+        omit_fields: set[str],
+    ) -> tuple[QueryBuilder, QueryBuilder]:
+        """Apply ON CONFLICT ... DO UPDATE to both query variants."""
+        effective_update_fields = (
+            [f for f in update_fields if f not in omit_fields]
+            if omit_fields
+            else list(update_fields)
+        )
+        alias = f"new_{self.model._meta.db_table}"
+        insert_query = insert_query.as_(alias).on_conflict(*(self._on_conflict or []))
+        insert_query_all = insert_query_all.as_(alias).on_conflict(*(self._on_conflict or []))
+        for update_field in effective_update_fields:
+            insert_query = insert_query.do_update(update_field)
+            insert_query_all = insert_query_all.do_update(update_field)
+        return insert_query, insert_query_all
+
     def _make_queries(self, omit_fields: set[str] | None = None) -> tuple[str, str]:
         if omit_fields is None:
             omit_fields = set()
 
-        if self._ignore_conflicts or self._update_fields:
-            _, columns = self._executor._prepare_insert_columns()
-            if omit_fields:
-                columns = [
-                    c
-                    for fn, c in zip(self._executor.regular_columns, columns)
-                    if fn not in omit_fields
-                ]
-            if columns:
-                insert_query = self._executor._prepare_insert_statement(
-                    columns, ignore_conflicts=self._ignore_conflicts
-                )
-            else:
-                return self._build_default_values_sql(), self._build_default_values_sql()
-            insert_query_all = insert_query
-            if self.model._meta.generated_db_fields:
-                _, columns_all = self._executor._prepare_insert_columns(include_generated=True)
-                if omit_fields:
-                    columns_all = [
-                        c
-                        for fn, c in zip(self._executor.regular_columns_all, columns_all)
-                        if fn not in omit_fields
-                    ]
-                if columns_all:
-                    insert_query_all = self._executor._prepare_insert_statement(
-                        columns_all,
-                        has_generated=False,
-                        ignore_conflicts=self._ignore_conflicts,
-                    )
-                else:
-                    return self._build_default_values_sql(), self._build_default_values_sql()
-            if self._update_fields:
-                effective_update_fields = (
-                    [f for f in self._update_fields if f not in omit_fields]
-                    if omit_fields
-                    else list(self._update_fields)
-                )
-                alias = f"new_{self.model._meta.db_table}"
-                insert_query_all = insert_query_all.as_(alias).on_conflict(
-                    *(self._on_conflict or [])
-                )
-                insert_query = insert_query.as_(alias).on_conflict(*(self._on_conflict or []))
-                for update_field in effective_update_fields:
-                    insert_query_all = insert_query_all.do_update(update_field)
-                    insert_query = insert_query.do_update(update_field)
-            return insert_query.get_sql(), insert_query_all.get_sql()
-        else:
-            if omit_fields:
-                _, columns = self._executor._prepare_insert_columns()
-                columns = [
-                    c
-                    for fn, c in zip(self._executor.regular_columns, columns)
-                    if fn not in omit_fields
-                ]
-                if columns:
-                    insert_sql = str(self._executor._prepare_insert_statement(columns))
-                else:
-                    insert_sql = self._build_default_values_sql()
-
-                insert_sql_all = insert_sql
-                if self.model._meta.generated_db_fields:
-                    _, columns_all = self._executor._prepare_insert_columns(include_generated=True)
-                    columns_all = [
-                        c
-                        for fn, c in zip(self._executor.regular_columns_all, columns_all)
-                        if fn not in omit_fields
-                    ]
-                    if columns_all:
-                        insert_sql_all = str(
-                            self._executor._prepare_insert_statement(
-                                columns_all, has_generated=False
-                            )
-                        )
-                    else:
-                        insert_sql_all = self._build_default_values_sql()
-                return insert_sql, insert_sql_all
+        if not (self._ignore_conflicts or self._update_fields) and not omit_fields:
             return self._executor.insert_query, self._executor.insert_query_all
+
+        default_sql = self._build_default_values_sql()
+
+        columns = self._filter_columns(omit_fields)
+        if not columns:
+            return default_sql, default_sql
+        insert_query = self._executor._prepare_insert_statement(
+            columns, ignore_conflicts=self._ignore_conflicts
+        )
+
+        insert_query_all = insert_query
+        if self.model._meta.generated_db_fields:
+            columns_all = self._filter_columns(omit_fields, include_generated=True)
+            if not columns_all:
+                return default_sql, default_sql
+            insert_query_all = self._executor._prepare_insert_statement(
+                columns_all,
+                has_generated=False,
+                ignore_conflicts=self._ignore_conflicts,
+            )
+
+        if self._update_fields:
+            insert_query, insert_query_all = self._apply_on_conflict(
+                insert_query, insert_query_all, self._update_fields, omit_fields
+            )
+
+        return insert_query.get_sql(), insert_query_all.get_sql()
 
     async def _execute_many(
         self,

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -18,6 +18,7 @@ from tortoise.exceptions import (
     FieldError,
     IntegrityError,
     MultipleObjectsReturned,
+    OperationalError,
     ParamsError,
 )
 from tortoise.expressions import Expression, Q, RawSQL, ResolveContext, ResolveResult
@@ -881,6 +882,10 @@ class QuerySet(AwaitableQuery[MODEL]):
         This method inserts the provided list of objects into the database in an efficient manner
         (generally only 1 query, no matter how many objects there are).
 
+        Fields with ``db_default`` that are not explicitly set will use the database
+        DEFAULT.  Within a single call, each ``db_default`` field must be treated
+        consistently: either **all** instances supply a value or **none** do.
+
         :param on_conflict: On conflict index name
         :param update_fields: Update fields when conflicts
         :param ignore_conflicts: Ignore conflicts when inserting
@@ -888,6 +893,8 @@ class QuerySet(AwaitableQuery[MODEL]):
         :param batch_size: How many objects are created in a single query
 
         :raises ValueError: If params do not meet specifications
+        :raises OperationalError: If a ``db_default`` field has mixed usage across
+            instances (some provide a value, others rely on the database default).
         """
         if ignore_conflicts and update_fields:
             raise ValueError(
@@ -2028,71 +2035,201 @@ class BulkCreateQuery(AwaitableQuery, Generic[MODEL]):
         self._update_fields = update_fields
         self._on_conflict = on_conflict
 
-    def _make_queries(self) -> tuple[str, str]:
-        self._executor = self._db.executor_class(model=self.model, db=self._db)
+    def _analyze_db_default_fields(self, columns: list[str]) -> set[str]:
+        """Classify each db_default field across all instances.
+
+        Returns a set of field names to omit from the INSERT (all instances
+        use DatabaseDefault for that field). Raises OperationalError if a
+        field has mixed usage (some instances provide a value, others don't).
+        """
+        from tortoise.fields.base import DatabaseDefault
+
+        fields_map = self.model._meta.fields_map
+        db_default_field_names = [fn for fn in columns if fields_map[fn].has_db_default()]
+        if not db_default_field_names:
+            return set()
+
+        omit_fields: set[str] = set()
+        for field_name in db_default_field_names:
+            has_default = False
+            has_value = False
+            for instance in self._objects:
+                if isinstance(getattr(instance, field_name), DatabaseDefault):
+                    has_default = True
+                else:
+                    has_value = True
+                if has_default and has_value:
+                    raise OperationalError(
+                        f"Cannot use bulk_create() when field '{field_name}' has "
+                        f"db_default and some instances provide explicit values while "
+                        f"others rely on the database default. Either: "
+                        f"(a) set the value explicitly on ALL instances, "
+                        f"(b) omit it from ALL instances to use the database default, or "
+                        f"(c) split into separate bulk_create() calls."
+                    )
+            if has_default and not has_value:
+                omit_fields.add(field_name)
+
+        return omit_fields
+
+    def _build_default_values_sql(self) -> str:
+        """Build INSERT SQL for when all columns are omitted."""
+        table = self.model._meta.basetable
+        return str(self._db.query_class.into(table).default_values())
+
+    def _make_queries(self, omit_fields: set[str] | None = None) -> tuple[str, str]:
+        if omit_fields is None:
+            omit_fields = set()
+
         if self._ignore_conflicts or self._update_fields:
             _, columns = self._executor._prepare_insert_columns()
-            insert_query = self._executor._prepare_insert_statement(
-                columns, ignore_conflicts=self._ignore_conflicts
-            )
+            if omit_fields:
+                columns = [
+                    c
+                    for fn, c in zip(self._executor.regular_columns, columns)
+                    if fn not in omit_fields
+                ]
+            if columns:
+                insert_query = self._executor._prepare_insert_statement(
+                    columns, ignore_conflicts=self._ignore_conflicts
+                )
+            else:
+                return self._build_default_values_sql(), self._build_default_values_sql()
             insert_query_all = insert_query
             if self.model._meta.generated_db_fields:
                 _, columns_all = self._executor._prepare_insert_columns(include_generated=True)
-                insert_query_all = self._executor._prepare_insert_statement(
-                    columns_all,
-                    has_generated=False,
-                    ignore_conflicts=self._ignore_conflicts,
-                )
+                if omit_fields:
+                    columns_all = [
+                        c
+                        for fn, c in zip(self._executor.regular_columns_all, columns_all)
+                        if fn not in omit_fields
+                    ]
+                if columns_all:
+                    insert_query_all = self._executor._prepare_insert_statement(
+                        columns_all,
+                        has_generated=False,
+                        ignore_conflicts=self._ignore_conflicts,
+                    )
+                else:
+                    return self._build_default_values_sql(), self._build_default_values_sql()
             if self._update_fields:
+                effective_update_fields = (
+                    [f for f in self._update_fields if f not in omit_fields]
+                    if omit_fields
+                    else list(self._update_fields)
+                )
                 alias = f"new_{self.model._meta.db_table}"
                 insert_query_all = insert_query_all.as_(alias).on_conflict(
                     *(self._on_conflict or [])
                 )
                 insert_query = insert_query.as_(alias).on_conflict(*(self._on_conflict or []))
-                for update_field in self._update_fields:
+                for update_field in effective_update_fields:
                     insert_query_all = insert_query_all.do_update(update_field)
                     insert_query = insert_query.do_update(update_field)
             return insert_query.get_sql(), insert_query_all.get_sql()
         else:
+            if omit_fields:
+                _, columns = self._executor._prepare_insert_columns()
+                columns = [
+                    c
+                    for fn, c in zip(self._executor.regular_columns, columns)
+                    if fn not in omit_fields
+                ]
+                if columns:
+                    insert_sql = str(self._executor._prepare_insert_statement(columns))
+                else:
+                    insert_sql = self._build_default_values_sql()
+
+                insert_sql_all = insert_sql
+                if self.model._meta.generated_db_fields:
+                    _, columns_all = self._executor._prepare_insert_columns(include_generated=True)
+                    columns_all = [
+                        c
+                        for fn, c in zip(self._executor.regular_columns_all, columns_all)
+                        if fn not in omit_fields
+                    ]
+                    if columns_all:
+                        insert_sql_all = str(
+                            self._executor._prepare_insert_statement(
+                                columns_all, has_generated=False
+                            )
+                        )
+                    else:
+                        insert_sql_all = self._build_default_values_sql()
+                return insert_sql, insert_sql_all
             return self._executor.insert_query, self._executor.insert_query_all
 
-    async def _execute_many(self, insert_sql: str, insert_sql_all: str) -> None:
+    async def _execute_many(
+        self,
+        insert_sql: str,
+        insert_sql_all: str,
+        effective_columns: list[str],
+        effective_columns_all: list[str],
+    ) -> None:
         fields_map = self.model._meta.fields_map
         for instance_chunk in chunk(self._objects, self._batch_size):
             values_lists_all = []
             values_lists = []
+            count_default_all = 0
+            count_default = 0
             for instance in instance_chunk:
                 if instance._custom_generated_pk:
-                    values_lists_all.append(
-                        [
-                            fields_map[field_name].to_db_value(
-                                getattr(instance, field_name), instance
-                            )
-                            for field_name in self._executor.regular_columns_all
-                        ]
-                    )
+                    if effective_columns_all:
+                        values_lists_all.append(
+                            [
+                                fields_map[field_name].to_db_value(
+                                    getattr(instance, field_name), instance
+                                )
+                                for field_name in effective_columns_all
+                            ]
+                        )
+                    else:
+                        count_default_all += 1
                 else:
-                    values_lists.append(
-                        [
-                            fields_map[field_name].to_db_value(
-                                getattr(instance, field_name), instance
-                            )
-                            for field_name in self._executor.regular_columns
-                        ]
-                    )
+                    if effective_columns:
+                        values_lists.append(
+                            [
+                                fields_map[field_name].to_db_value(
+                                    getattr(instance, field_name), instance
+                                )
+                                for field_name in effective_columns
+                            ]
+                        )
+                    else:
+                        count_default += 1
             if values_lists_all:
                 await self._db.execute_many(insert_sql_all, values_lists_all)
             if values_lists:
                 await self._db.execute_many(insert_sql, values_lists)
+            # When all columns are omitted, execute DEFAULT VALUES individually
+            for _ in range(count_default_all):
+                await self._db.execute_insert(insert_sql_all, [])
+            for _ in range(count_default):
+                await self._db.execute_insert(insert_sql, [])
 
     def __await__(self) -> Generator[Any, None, None]:
         self._choose_db_if_not_chosen(True)
-        insert_sql, insert_sql_all = self._make_queries()
-        return self._execute_many(insert_sql, insert_sql_all).__await__()
+        self._executor = self._db.executor_class(model=self.model, db=self._db)
+        self._objects = list(self._objects)  # materialize for multi-pass
+
+        omit_fields = self._analyze_db_default_fields(self._executor.regular_columns)
+
+        insert_sql, insert_sql_all = self._make_queries(omit_fields)
+        effective_columns = [c for c in self._executor.regular_columns if c not in omit_fields]
+        effective_columns_all = [
+            c for c in self._executor.regular_columns_all if c not in omit_fields
+        ]
+        return self._execute_many(
+            insert_sql, insert_sql_all, effective_columns, effective_columns_all
+        ).__await__()
 
     def sql(self, params_inline=False) -> str:
         self._choose_db_if_not_chosen()
-        insert_sql, insert_sql_all = self._make_queries()
+        self._executor = self._db.executor_class(model=self.model, db=self._db)
+        self._objects = list(self._objects)
+
+        omit_fields = self._analyze_db_default_fields(self._executor.regular_columns)
+        insert_sql, insert_sql_all = self._make_queries(omit_fields)
 
         if all(o._custom_generated_pk for o in self._objects):
             return insert_sql_all

--- a/uv.lock
+++ b/uv.lock
@@ -1004,7 +1004,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1452,9 +1452,9 @@ wheels = [
 name = "iso8601"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b9/f3/ef59cee614d5e0accf6fd0cbba025b93b272e626ca89fb70a3e9187c5d15/iso8601-2.1.0.tar.gz", hash = "sha256:6b1d3829ee8921c4301998c909f7829fa9ed3cbdac0d3b16af2d743aed1ba8df" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/f3/ef59cee614d5e0accf6fd0cbba025b93b272e626ca89fb70a3e9187c5d15/iso8601-2.1.0.tar.gz", hash = "sha256:6b1d3829ee8921c4301998c909f7829fa9ed3cbdac0d3b16af2d743aed1ba8df", size = 6522, upload-time = "2023-10-03T00:25:39.317Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/0c/f37b6a241f0759b7653ffa7213889d89ad49a2b76eb2ddf3b57b2738c347/iso8601-2.1.0-py3-none-any.whl", hash = "sha256:aac4145c4dcb66ad8b648a02830f5e2ff6c24af20f4f482689be402db2429242" },
+    { url = "https://files.pythonhosted.org/packages/6c/0c/f37b6a241f0759b7653ffa7213889d89ad49a2b76eb2ddf3b57b2738c347/iso8601-2.1.0-py3-none-any.whl", hash = "sha256:aac4145c4dcb66ad8b648a02830f5e2ff6c24af20f4f482689be402db2429242", size = 7545, upload-time = "2023-10-03T00:25:32.304Z" },
 ]
 
 [[package]]
@@ -2134,9 +2134,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ptyprocess" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f" }
+sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523" },
+    { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772, upload-time = "2023-11-25T06:56:14.81Z" },
 ]
 
 [[package]]
@@ -2676,11 +2676,11 @@ wheels = [
 
 [[package]]
 name = "pypika-tortoise"
-version = "0.6.3"
+version = "0.6.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cc/28/86ec1bccb2609d20349def444ef9dfe84aeccc984caa62f4634d50fee164/pypika_tortoise-0.6.3.tar.gz", hash = "sha256:6e17f00e77e78468836cb5c63eb6dc01445f83b1167e4f29f1c678949179c079", size = 80689, upload-time = "2025-11-26T22:07:08.293Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/06/89fe5fff93c5a01dbdeb9f3d843a7e997dc6e3a87222a260a164ff91fb81/pypika_tortoise-0.6.5.tar.gz", hash = "sha256:64d96c9b88450f6360ad22a7063933b6a90961a7317f04b2b63c98fd5d705506", size = 81468, upload-time = "2026-03-13T20:44:54.439Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/6a/da5ba6830dd16cea2804163a2cecc1b2a85b8e06c61f0abb0477069d013d/pypika_tortoise-0.6.3-py3-none-any.whl", hash = "sha256:762e508093f4d73d3654cdde5bce8f92f8f41d999993c44d972d4f1703a663df", size = 46918, upload-time = "2025-11-26T22:07:07.052Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/b8/502910eb8b315f719d8f6a6509f13a38b6c4c05378f14ac151ff347bff0a/pypika_tortoise-0.6.5-py3-none-any.whl", hash = "sha256:9194ac6ce6ac9bdfc6e959c831c5788ef05ee1371e82ba281b0eb75f4a2bd4f1", size = 47936, upload-time = "2026-03-13T20:44:53.541Z" },
 ]
 
 [[package]]
@@ -3452,7 +3452,7 @@ requires-dist = [
     { name = "orjson", marker = "extra == 'accel'" },
     { name = "psycopg", extras = ["binary", "pool"], marker = "extra == 'psycopg'", specifier = ">=3.0.12,<4.0.0" },
     { name = "ptpython", marker = "extra == 'ptpython'", specifier = ">=3.0.0" },
-    { name = "pypika-tortoise", specifier = ">=0.6.3,<1.0.0" },
+    { name = "pypika-tortoise", specifier = ">=0.6.5,<1.0.0" },
     { name = "tomlkit", marker = "python_full_version < '3.11'", specifier = ">=0.11.4,<1.0.0" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.1.0" },
     { name = "uvloop", marker = "implementation_name == 'cpython' and sys_platform != 'win32' and extra == 'accel'" },


### PR DESCRIPTION
Fixes #2140

Fetch db_default values for created rows
Turned on by default, works through RETURNING on sqlite and pg, extra query on mysql and odbc
Auto query can be turned off through Meta class of Model