### PR TITLE
fix: reorder delete model operations

### DIFF
--- a/tests/migrations/test_operations_state.py
+++ b/tests/migrations/test_operations_state.py
@@ -278,6 +278,61 @@ def test_delete_model_fail_on_refs(state_with_model: State):
         operation.state_forward("models", state_with_model)
 
 
+def test_delete_model_with_fk(state_with_model: State):
+    state = state_with_model
+    CreateModel(
+        name="TestModel2",
+        fields=[
+            ("id", fields.IntField(pk=True)),
+            ("reference", ForeignKeyFieldInstance("models.TestModel", related_name="children")),
+        ],
+    ).state_forward("models", state)
+
+    DeleteModel("TestModel2").state_forward("models", state)
+
+    assert ("models", "TestModel2") not in state.models
+    with pytest.raises(KeyError):
+        state.apps.get_model("models.TestModel2")
+    # Target model still intact
+    state.apps.get_model("models.TestModel")
+
+
+def test_delete_model_with_o2o(state_with_model: State):
+    state = state_with_model
+    CreateModel(
+        name="TestModel2",
+        fields=[
+            ("id", fields.IntField(pk=True)),
+            ("reference", OneToOneFieldInstance("models.TestModel", related_name="o2o_rel")),
+        ],
+    ).state_forward("models", state)
+
+    DeleteModel("TestModel2").state_forward("models", state)
+
+    assert ("models", "TestModel2") not in state.models
+    with pytest.raises(KeyError):
+        state.apps.get_model("models.TestModel2")
+    state.apps.get_model("models.TestModel")
+
+
+def test_delete_model_with_m2m(state_with_model: State):
+    state = state_with_model
+    CreateModel(
+        name="TestModel2",
+        fields=[
+            ("id", fields.IntField(pk=True)),
+            ("reference", ManyToManyFieldInstance("models.TestModel", related_name="m2m_rel")),
+        ],
+    ).state_forward("models", state)
+
+    DeleteModel("TestModel2").state_forward("models", state)
+
+    assert ("models", "TestModel2") not in state.models
+    with pytest.raises(KeyError):
+        state.apps.get_model("models.TestModel2")
+    state.apps.get_model("models.TestModel")
+
+
 def test_alter_options(state_with_model: State):
     operation = AlterModelOptions(name="TestModel", options={"ordering": ["-id"]})
     operation.state_forward("models", state_with_model)

--- a/tortoise/migrations/operations.py
+++ b/tortoise/migrations/operations.py
@@ -334,8 +334,8 @@ class DeleteModel(TortoiseOperation):
 
             models_to_reload.add(state.apps.split_reference(field.model_name))
 
-        state.reload_models(models_to_reload)
         state.apps.unregister_model(app_label, self.name)
+        state.reload_models(models_to_reload)
 
     async def database_forward(
         self,

--- a/tortoise/migrations/schema_generator/state.py
+++ b/tortoise/migrations/schema_generator/state.py
@@ -137,6 +137,8 @@ def get_related_models_recursive(model: type[Model]) -> set[tuple[str, str]]:
     rel_models = get_related_models(model)
 
     for rel_model in rel_models:
+        if rel_model._meta.app is None:
+            continue
         model_tuple = (_require_app_label(rel_model), rel_model.__name__)
         if model_tuple in seen:
             continue


### PR DESCRIPTION
Fix ordering of operation in delete model, so reloading of models state doesn't load unregistered model

Fixes #2144