### PR TITLE
fix: use subquery for DELETE with JOINs on SQLite/PostgreSQL

### DIFF
--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -1391,7 +1391,19 @@ class DeleteQuery(AwaitableQuery):
                 annotations=self._annotations,
             )
         self.resolve_filters()
-        self.query._delete_from = True
+        if self._joined_tables:
+            table = self.model._meta.basetable
+            pk_attr = self.model._meta.pk_attr
+            source_pk = self.model._meta.fields_map[pk_attr].source_field or pk_attr
+            self.query._selects = []
+            self.query._select_other(Field(source_pk, table=table))
+            subquery = self.query
+            self.query = self._db.query_class.from_(table).where(
+                Field(source_pk, table=table).isin(subquery)
+            )
+            self.query._delete_from = True
+        else:
+            self.query._delete_from = True
         return
 
     def __await__(self) -> Generator[Any, None, int]:


### PR DESCRIPTION
## Summary
- Deleting through backward relations generates `DELETE FROM table LEFT OUTER JOIN ...` which is invalid SQL in SQLite and PostgreSQL
- Only MySQL supports DELETE with JOIN syntax

## Root Cause
`DeleteQuery._make_query()` sets `_delete_from = True` on the query after `resolve_filters()` adds JOINs for relation-based filters. The resulting SQL uses DELETE with JOIN, which only MySQL supports.

## Fix
After `resolve_filters()`, check if `_joined_tables` is non-empty. If JOINs are present, convert the query to use a subquery approach:
```sql
DELETE FROM table WHERE pk IN (SELECT pk FROM table LEFT JOIN ... WHERE ...)
```
This is valid SQL across all supported databases.

## Testing
- Verified the subquery approach generates valid SQL for SQLite and PostgreSQL
- Non-join DELETE queries are unaffected (same code path as before)

Fixes #1981
Fixes #1167

Made with [Cursor](https://cursor.com)