### PR TITLE
fix(migrations): use parameterized queries in MigrationRecorder

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,13 @@ Changelog
 1.1
 ===
 
+1.1.8
+-----
+
+Fixed
+^^^^^
+- ``MigrationRecorder`` now uses parameterized queries; fixes MariaDB/MySQL rejecting ISO-8601 ``applied_at`` values. (#2132)
+
 1.1.7
 -----
 

--- a/tests/migrations/test_recorder.py
+++ b/tests/migrations/test_recorder.py
@@ -124,3 +124,20 @@ async def test_recorder_sqlite_placeholders() -> None:
     delete_query = connection.queries[0][0]
     assert '"app" = ?' in delete_query
     assert '"name" = ?' in delete_query
+
+
+@pytest.mark.asyncio
+async def test_recorder_oracle_placeholders() -> None:
+    connection = FakeConnection("oracle")
+    recorder = MigrationRecorder(connection)
+
+    await recorder.record_applied("app", "0001_initial")
+    await recorder.record_unapplied("app", "0001_initial")
+
+    insert_query = connection.inserts[0][0]
+    assert 'INSERT INTO "tortoise_migrations"' in insert_query
+    assert "VALUES (?, ?, ?)" in insert_query
+
+    delete_query = connection.queries[0][0]
+    assert '"app" = ?' in delete_query
+    assert '"name" = ?' in delete_query

--- a/tests/migrations/test_recorder.py
+++ b/tests/migrations/test_recorder.py
@@ -7,14 +7,19 @@ from tortoise.migrations.recorder import MigrationRecorder
 class FakeConnection:
     def __init__(self, dialect: str) -> None:
         self.capabilities = Capabilities(dialect)
-        self.executed: list[str] = []
-        self.queries: list[str] = []
+        self.executed_scripts: list[str] = []
+        self.inserts: list[tuple[str, list]] = []
+        self.queries: list[tuple[str, list | None]] = []
 
     async def execute_script(self, query: str) -> None:
-        self.executed.append(query)
+        self.executed_scripts.append(query)
 
-    async def execute_query(self, query: str):
-        self.queries.append(query)
+    async def execute_insert(self, query: str, values: list) -> int:
+        self.inserts.append((query, values))
+        return 1
+
+    async def execute_query(self, query: str, values: list | None = None):
+        self.queries.append((query, values))
         return None, []
 
 
@@ -26,11 +31,17 @@ async def test_recorder_quotes_mysql_identifiers() -> None:
     await recorder.record_applied("app", "0001_initial")
     await recorder.applied_migrations()
 
-    assert connection.executed
-    assert "INSERT INTO `tortoise_migrations`" in connection.executed[0]
-    assert "(`app`, `name`, `applied_at`)" in connection.executed[0]
+    assert connection.inserts
+    insert_query, insert_values = connection.inserts[0]
+    assert "INSERT INTO `tortoise_migrations`" in insert_query
+    assert "(`app`, `name`, `applied_at`)" in insert_query
+    assert "%s" in insert_query
+    assert insert_values[0] == "app"
+    assert insert_values[1] == "0001_initial"
+
     assert connection.queries
-    assert "SELECT `app`, `name`" in connection.queries[0]
+    select_query = connection.queries[0][0]
+    assert "SELECT `app`, `name`" in select_query
 
 
 @pytest.mark.asyncio
@@ -40,6 +51,76 @@ async def test_recorder_quotes_mssql_identifiers() -> None:
 
     await recorder.record_unapplied("app", "0001_initial")
 
-    assert connection.executed
-    assert "DELETE FROM [tortoise_migrations]" in connection.executed[0]
-    assert "WHERE [app] = 'app'" in connection.executed[0]
+    assert connection.queries
+    delete_query, delete_values = connection.queries[0]
+    assert "DELETE FROM [tortoise_migrations]" in delete_query
+    assert "[app] = ?" in delete_query
+    assert "[name] = ?" in delete_query
+    assert delete_values == ["app", "0001_initial"]
+
+
+@pytest.mark.asyncio
+async def test_recorder_uses_parameterized_insert() -> None:
+    """Ensure record_applied uses parameterized queries instead of string interpolation.
+
+    This is critical for MariaDB compatibility \u2014 MariaDB rejects ISO 8601
+    datetime strings with timezone info (e.g. '2026-03-04T18:06:51+00:00').
+    See https://github.com/tortoise/tortoise-orm/issues/2132
+    """
+    from datetime import datetime
+
+    connection = FakeConnection("mysql")
+    recorder = MigrationRecorder(connection)
+
+    await recorder.record_applied("models", "0001_init")
+
+    assert len(connection.inserts) == 1
+    query, values = connection.inserts[0]
+    # Query must use placeholders, not inline values
+    assert "VALUES (%s, %s, %s)" in query
+    assert values[0] == "models"
+    assert values[1] == "0001_init"
+    assert isinstance(values[2], datetime)
+
+
+@pytest.mark.asyncio
+async def test_recorder_uses_parameterized_delete() -> None:
+    """Ensure record_unapplied uses parameterized queries."""
+    connection = FakeConnection("mysql")
+    recorder = MigrationRecorder(connection)
+
+    await recorder.record_unapplied("models", "0001_init")
+
+    assert len(connection.queries) == 1
+    query, values = connection.queries[0]
+    assert "WHERE `app` = %s" in query
+    assert "`name` = %s" in query
+    assert values == ["models", "0001_init"]
+
+
+@pytest.mark.asyncio
+async def test_recorder_postgres_placeholders() -> None:
+    connection = FakeConnection("postgres")
+    recorder = MigrationRecorder(connection)
+
+    await recorder.record_applied("app", "0001_initial")
+
+    assert len(connection.inserts) == 1
+    query, values = connection.inserts[0]
+    assert "VALUES ($1, $2, $3)" in query
+
+
+@pytest.mark.asyncio
+async def test_recorder_sqlite_placeholders() -> None:
+    connection = FakeConnection("sqlite")
+    recorder = MigrationRecorder(connection)
+
+    await recorder.record_applied("app", "0001_initial")
+    await recorder.record_unapplied("app", "0001_initial")
+
+    insert_query = connection.inserts[0][0]
+    assert "VALUES (?, ?, ?)" in insert_query
+
+    delete_query = connection.queries[0][0]
+    assert '"app" = ?' in delete_query
+    assert '"name" = ?' in delete_query

--- a/tests/migrations/test_runtime_migrations.py
+++ b/tests/migrations/test_runtime_migrations.py
@@ -24,11 +24,17 @@ class FakeConnection:
         self.connection_name = "default"
         self._applied = applied or []
         self.executed_scripts: list[str] = []
+        self.inserts: list[tuple[str, list]] = []
+        self.queries: list[tuple[str, list | None]] = []
 
     async def execute_query(self, query: str, values: list | None = None):
-        _ = (query, values)
+        self.queries.append((query, values))
         rows = [{"app": key.app_label, "name": key.name} for key in self._applied]
         return 0, rows
+
+    async def execute_insert(self, query: str, values: list) -> int:
+        self.inserts.append((query, values))
+        return 1
 
     async def execute_script(self, query: str) -> None:
         self.executed_scripts.append(query)
@@ -395,8 +401,8 @@ async def test_recorder_reads_and_writes() -> None:
 
     await recorder.record_applied("app", "0002_second")
     await recorder.record_unapplied("app", "0001_initial")
-    assert any("INSERT INTO" in query for query in connection.executed_scripts)
-    assert any("DELETE FROM" in query for query in connection.executed_scripts)
+    assert any("INSERT INTO" in q for q, _ in connection.inserts)
+    assert any("DELETE FROM" in q for q, _ in connection.queries)
 
 
 @pytest.mark.asyncio

--- a/tortoise/migrations/recorder.py
+++ b/tortoise/migrations/recorder.py
@@ -6,15 +6,6 @@ from tortoise import fields
 from tortoise.migrations.graph import MigrationKey
 from tortoise.models import Model
 
-# Parameter placeholder per dialect.
-_DIALECT_PLACEHOLDER: dict[str, str] = {
-    "mysql": "%s",
-    "sqlite": "?",
-    "postgres": "${}",
-    "mssql": "?",
-    "oracle": "?",
-}
-
 
 class MigrationRecorder:
     def __init__(self, connection, *, table_name: str = "tortoise_migrations") -> None:
@@ -35,14 +26,12 @@ class MigrationRecorder:
         return f'"{name}"'
 
     def _placeholder(self, pos: int) -> str:
-        """Return a positional parameter placeholder suitable for the current dialect.
-
-        ``pos`` is 1-based (first parameter is 1).
-        """
-        template = _DIALECT_PLACEHOLDER.get(self._dialect, "?")
-        if "{}" in template:
-            return template.format(pos)
-        return template
+        if self._dialect == "mysql":
+            return "%s"
+        if self._dialect == "postgres":
+            return f"${pos}"
+        # sqlite, mssql, oracle: ?-style (native or via ODBC)
+        return "?"
 
     def _make_model(self, table_name: str) -> type[Model]:
         class MigrationRecord(Model):
@@ -108,7 +97,3 @@ class MigrationRecorder:
             f"AND {self._quote('name')} = {self._placeholder(2)}"
         )
         await self.connection.execute_query(query, [app, name])
-
-    @staticmethod
-    def _escape(value: str) -> str:
-        return value.replace("'", "''")

--- a/tortoise/migrations/recorder.py
+++ b/tortoise/migrations/recorder.py
@@ -6,6 +6,15 @@ from tortoise import fields
 from tortoise.migrations.graph import MigrationKey
 from tortoise.models import Model
 
+# Parameter placeholder per dialect.
+_DIALECT_PLACEHOLDER: dict[str, str] = {
+    "mysql": "%s",
+    "sqlite": "?",
+    "postgres": "${}",
+    "mssql": "?",
+    "oracle": "?",
+}
+
 
 class MigrationRecorder:
     def __init__(self, connection, *, table_name: str = "tortoise_migrations") -> None:
@@ -24,6 +33,16 @@ class MigrationRecorder:
         if self._dialect == "mssql":
             return f"[{name}]"
         return f'"{name}"'
+
+    def _placeholder(self, pos: int) -> str:
+        """Return a positional parameter placeholder suitable for the current dialect.
+
+        ``pos`` is 1-based (first parameter is 1).
+        """
+        template = _DIALECT_PLACEHOLDER.get(self._dialect, "?")
+        if "{}" in template:
+            return template.format(pos)
+        return template
 
     def _make_model(self, table_name: str) -> type[Model]:
         class MigrationRecord(Model):
@@ -74,21 +93,21 @@ class MigrationRecorder:
         return [MigrationKey(app_label=row["app"], name=row["name"]) for row in rows]
 
     async def record_applied(self, app: str, name: str) -> None:
-        applied_at = datetime.now(timezone.utc).isoformat()
+        applied_at = datetime.now(timezone.utc)
         query = (
             f"INSERT INTO {self._quote(self.table_name)} "  # nosec B608
             f"({self._quote('app')}, {self._quote('name')}, {self._quote('applied_at')}) "
-            f"VALUES ('{self._escape(app)}', '{self._escape(name)}', '{applied_at}')"
+            f"VALUES ({self._placeholder(1)}, {self._placeholder(2)}, {self._placeholder(3)})"
         )
-        await self.connection.execute_script(query)
+        await self.connection.execute_insert(query, [app, name, applied_at])
 
     async def record_unapplied(self, app: str, name: str) -> None:
         query = (
             f"DELETE FROM {self._quote(self.table_name)} "  # nosec B608
-            f"WHERE {self._quote('app')} = '{self._escape(app)}' "
-            f"AND {self._quote('name')} = '{self._escape(name)}'"
+            f"WHERE {self._quote('app')} = {self._placeholder(1)} "
+            f"AND {self._quote('name')} = {self._placeholder(2)}"
         )
-        await self.connection.execute_script(query)
+        await self.connection.execute_query(query, [app, name])
 
     @staticmethod
     def _escape(value: str) -> str:


### PR DESCRIPTION
## Summary

Fixes #2132 — `tortoise migrate` failing on MariaDB (and some MySQL versions) with:

```
OperationalError: (1292, "Incorrect datetime value: '2026-…+00:00' for column 'applied_at'")
```

`MigrationRecorder.record_applied` was building the INSERT as a single string with `datetime.now(timezone.utc).isoformat()` interpolated in, then sending it via `execute_script`. MariaDB rejects the ISO-8601-with-offset format for `DATETIME` columns. MySQL ≥ 8 happens to accept it, which is why the bug only surfaced on MariaDB.

## Changes

- `tortoise/migrations/recorder.py`
  - `record_applied` and `record_unapplied` now use parameterized queries (`execute_insert` / `execute_query` with values), letting each driver bind a native `datetime` and quote `app`/`name` correctly.
  - New `_placeholder(pos)` helper returns the dialect-appropriate placeholder: `%s` (mysql), `$N` (postgres), `?` (sqlite, mssql, oracle).
  - Removed the now-unused `_escape` helper — values are no longer interpolated into SQL.
- `tests/migrations/test_recorder.py` — extended `FakeConnection` to capture parameterized inserts/queries; added per-dialect placeholder tests for mysql, postgres, sqlite, mssql, oracle, plus regression tests asserting `record_applied`/`record_unapplied` use placeholders rather than inline values.
- `tests/migrations/test_runtime_migrations.py` — updated the second `FakeConnection` (used by `test_recorder_reads_and_writes`) to mirror the same contract, and updated the test's assertions to look at the new collections.
- `CHANGELOG.rst` — entry under 1.1.8.

## Verified

End-to-end repro against `mariadb:11` in Docker, `aiomysql` driver:

| Branch | Result |
|---|---|
| `develop` (pre-fix) | `OperationalError 1292` — matches #2132 verbatim |
| this PR | row inserted and read back as a proper `datetime` |

Existing fake-based tests pass on every dialect including the new oracle case.

## Test plan

- [x] `pytest tests/migrations/test_recorder.py tests/migrations/test_runtime_migrations.py` — all pass locally
- [x] Manual repro against MariaDB 11.8 confirms the original error before the fix and absence of it after
- [ ] CI matrix (sqlite, mysql, postgres, mssql) green
- [ ] (follow-up, separate PR) consider adding a MariaDB job to CI so #2132-class regressions are caught automatically

Closes #2132. Supersedes #2183 (which addressed the same symptom for MySQL only via dialect-specific datetime formatting; this PR fixes the underlying parameterization so all dialects benefit).