### PR TITLE
feat: add postgresql:// scheme as alias for asyncpg

### DIFF
--- a/tests/backends/test_db_url.py
+++ b/tests/backends/test_db_url.py
@@ -7,6 +7,7 @@ from tortoise.exceptions import ConfigurationError
 
 _postgres_scheme_engines = {
     "postgres": "tortoise.backends.asyncpg",
+    "postgresql": "tortoise.backends.asyncpg",
     "asyncpg": "tortoise.backends.asyncpg",
     "psycopg": "tortoise.backends.psycopg",
 }

--- a/tortoise/backends/base/config_generator.py
+++ b/tortoise/backends/base/config_generator.py
@@ -128,6 +128,7 @@ DB_LOOKUP: dict[str, dict[str, Any]] = {
 }
 # Create an alias for backwards compatibility
 DB_LOOKUP["postgres"] = DB_LOOKUP["asyncpg"]
+# "postgresql" is the scheme accepted by libpq and pydantic's PostgresDsn
 DB_LOOKUP["postgresql"] = DB_LOOKUP["asyncpg"]
 
 

--- a/tortoise/backends/base/config_generator.py
+++ b/tortoise/backends/base/config_generator.py
@@ -9,6 +9,7 @@ from typing import Any
 from tortoise.exceptions import ConfigurationError
 
 urlparse.uses_netloc.append("postgres")
+urlparse.uses_netloc.append("postgresql")
 urlparse.uses_netloc.append("asyncpg")
 urlparse.uses_netloc.append("psycopg")
 urlparse.uses_netloc.append("sqlite")
@@ -127,6 +128,7 @@ DB_LOOKUP: dict[str, dict[str, Any]] = {
 }
 # Create an alias for backwards compatibility
 DB_LOOKUP["postgres"] = DB_LOOKUP["asyncpg"]
+DB_LOOKUP["postgresql"] = DB_LOOKUP["asyncpg"]
 
 
 def _quote_url_userinfo(db_url: str) -> str:
@@ -211,7 +213,7 @@ def expand_db_url(db_url: str, testing: bool = False) -> dict:
         # asyncpg accepts None for password, but aiomysql not
         params[vmap["password"]] = (
             None
-            if (not url.password and db_backend in {"postgres", "asyncpg", "psycopg"})
+            if (not url.password and db_backend in {"postgres", "postgresql", "asyncpg", "psycopg"})
             else urlparse.unquote(url.password or "")
         )
 


### PR DESCRIPTION
## Summary
Adds `postgresql://` as a supported database URL scheme, aliasing to the asyncpg backend — matching the behavior of `postgres://`.

The [official PostgreSQL documentation](https://www.postgresql.org/docs/current/libpq-connect.html) lists both `postgres://` and `postgresql://` as valid connection URIs, and [pydantic's PostgresDsn](https://github.com/pydantic/pydantic) already accepts both. Previously only `postgres://` worked in Tortoise ORM.

## Changes
- `tortoise/backends/base/config_generator.py`: Added `postgresql` to `urlparse.uses_netloc`, `DB_LOOKUP` aliases, and the password-null check
- `tests/backends/test_db_url.py`: Added `postgresql` to `_postgres_scheme_engines` dict so all existing postgres scheme tests run against it

## Related Issue
Fixes #2147