### PR TITLE
fix: MSSQL connection left in busy state after insert

### DIFF
--- a/tortoise/backends/mssql/client.py
+++ b/tortoise/backends/mssql/client.py
@@ -135,3 +135,11 @@ class TransactionWrapper(ODBCTransactionWrapper, MSSQLClient):
             raise TransactionManagementError("No savepoint to rollback to")
         self._savepoint = None
         self._finalized = True
+
+    @translate_exceptions
+    async def execute_many(self, query: str, values: list) -> None:
+        async with self.acquire_connection() as connection:
+            self.log.debug("%s: %s", query, values)
+            cursor = await connection.cursor()
+            for row_values in values:
+                await cursor.execute(f"SET NOCOUNT ON; {query}", row_values)

--- a/tortoise/backends/mssql/client.py
+++ b/tortoise/backends/mssql/client.py
@@ -65,12 +65,8 @@ class MSSQLClient(ODBCClient):
         async with self.acquire_connection() as connection:
             self.log.debug("%s: %s", query, values)
             async with connection.cursor() as cursor:
-                await cursor.execute(f"SET NOCOUNT ON; {query}; SELECT @@IDENTITY", values)
-                row = await cursor.fetchone()
-                # Drain any remaining result sets so the connection isn't left busy
-                while await cursor.nextset():
-                    pass
-                return row[0]
+                await cursor.executemany(f"SET NOCOUNT ON; {query}; SELECT @@IDENTITY", values)
+                return (await cursor.fetchone())[0]
 
     async def db_delete(self) -> None:
         if not self.database:

--- a/tortoise/backends/mssql/client.py
+++ b/tortoise/backends/mssql/client.py
@@ -65,7 +65,7 @@ class MSSQLClient(ODBCClient):
         async with self.acquire_connection() as connection:
             self.log.debug("%s: %s", query, values)
             async with connection.cursor() as cursor:
-                await cursor.executemany(f"SET NOCOUNT ON; {query}; SELECT @@IDENTITY", values)
+                await cursor.execute(f"SET NOCOUNT ON; {query}; SELECT @@IDENTITY", values)
                 return (await cursor.fetchone())[0]
 
     async def db_delete(self) -> None:

--- a/tortoise/backends/mssql/client.py
+++ b/tortoise/backends/mssql/client.py
@@ -68,6 +68,20 @@ class MSSQLClient(ODBCClient):
                 await cursor.execute(f"SET NOCOUNT ON; {query}; SELECT @@IDENTITY", values)
                 return (await cursor.fetchone())[0]
 
+    @translate_exceptions
+    async def execute_many(self, query: str, values: list) -> None:
+        async with self.acquire_connection() as connection:
+            self.log.debug("%s: %s", query, values)
+            async with connection.cursor() as cursor:
+                try:
+                    for row_values in values:
+                        await cursor.execute(f"SET NOCOUNT ON; {query}", row_values)
+                except Exception:
+                    await cursor.rollback()
+                    raise
+                else:
+                    await cursor.commit()
+
     async def db_delete(self) -> None:
         if not self.database:
             return

--- a/tortoise/backends/mssql/client.py
+++ b/tortoise/backends/mssql/client.py
@@ -66,7 +66,11 @@ class MSSQLClient(ODBCClient):
             self.log.debug("%s: %s", query, values)
             async with connection.cursor() as cursor:
                 await cursor.execute(f"SET NOCOUNT ON; {query}; SELECT @@IDENTITY", values)
-                return (await cursor.fetchone())[0]
+                row = await cursor.fetchone()
+                # Drain any remaining result sets so the connection isn't left busy
+                while await cursor.nextset():
+                    pass
+                return row[0]
 
     async def db_delete(self) -> None:
         if not self.database:

--- a/tortoise/backends/odbc/client.py
+++ b/tortoise/backends/odbc/client.py
@@ -133,6 +133,9 @@ class ODBCClient(BaseDBAsyncClient, ABC):
                     raise
                 else:
                     await cursor.commit()
+                    # Drain any result sets to avoid "Connection is busy" on the next command
+                    while await cursor.nextset():
+                        pass
 
     @translate_exceptions
     async def execute_query(self, query: str, values: list | None = None) -> tuple[int, list[dict]]:

--- a/tortoise/backends/odbc/client.py
+++ b/tortoise/backends/odbc/client.py
@@ -133,9 +133,6 @@ class ODBCClient(BaseDBAsyncClient, ABC):
                     raise
                 else:
                     await cursor.commit()
-                    # Drain any result sets to avoid "Connection is busy" on the next command
-                    while await cursor.nextset():
-                        pass
 
     @translate_exceptions
     async def execute_query(self, query: str, values: list | None = None) -> tuple[int, list[dict]]:

--- a/tortoise/backends/odbc/client.py
+++ b/tortoise/backends/odbc/client.py
@@ -127,7 +127,7 @@ class ODBCClient(BaseDBAsyncClient, ABC):
             self.log.debug("%s: %s", query, values)
             async with connection.cursor() as cursor:
                 try:
-                    await cursor.executemany(query, values)
+                    await cursor.executemany(f"SET NOCOUNT ON; {query}", values)
                 except Exception:
                     await cursor.rollback()
                     raise

--- a/tortoise/backends/odbc/client.py
+++ b/tortoise/backends/odbc/client.py
@@ -127,7 +127,7 @@ class ODBCClient(BaseDBAsyncClient, ABC):
             self.log.debug("%s: %s", query, values)
             async with connection.cursor() as cursor:
                 try:
-                    await cursor.executemany(f"SET NOCOUNT ON; {query}", values)
+                    await cursor.executemany(query, values)
                 except Exception:
                     await cursor.rollback()
                     raise


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We recently see a lot of these errors in MSSQL CI which relies on `pyodbc`:
```
[HY000] [Microsoft][ODBC Driver 18 for SQL Server]Connection is busy with results for another command (0) (SQLExecDirectW)
```
`bulk_create` routes through `execute_many`, which uses `cursor.executemany()`. By default, MSSQL sends a "rows affected" message after each statement executed by `executemany`. These messages accumulate as pending result sets on the connection, and since they are never consumed, the connection is left in a busy state when returned to the pool, causing the next operation to fail.

The fix is to override `execute_many` in `MSSQLClient` to replace `cursor.executemany()` with an explicit loop of individual `cursor.execute()` calls, each prefixed with `SET NOCOUNT ON`. This suppresses the row-count messages at the source, preventing them from accumulating on the connection.

**NOTE**: There is potentially a small performance cost from the extra Python overhead, but the inserted data will be identical.

## Motivation and Context

Fix failing CI in MSSQL.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Run MSSQL in CI and make sure the error doesn't show up.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

