### PR TITLE
fix: MSSQL connection left in busy state after insert

### DIFF
--- a/tortoise/backends/mssql/client.py
+++ b/tortoise/backends/mssql/client.py
@@ -65,7 +65,7 @@ class MSSQLClient(ODBCClient):
         async with self.acquire_connection() as connection:
             self.log.debug("%s: %s", query, values)
             async with connection.cursor() as cursor:
-                await cursor.execute(f"SET NOCOUNT ON; {query}; SELECT @@IDENTITY", values)
+                await cursor.execute(f"{query}; SELECT @@IDENTITY", values)
                 return (await cursor.fetchone())[0]
 
     async def db_delete(self) -> None:

--- a/tortoise/backends/mssql/client.py
+++ b/tortoise/backends/mssql/client.py
@@ -65,7 +65,7 @@ class MSSQLClient(ODBCClient):
         async with self.acquire_connection() as connection:
             self.log.debug("%s: %s", query, values)
             async with connection.cursor() as cursor:
-                await cursor.execute(f"{query}; SELECT @@IDENTITY", values)
+                await cursor.execute(f"SET NOCOUNT ON; {query}; SELECT @@IDENTITY", values)
                 return (await cursor.fetchone())[0]
 
     async def db_delete(self) -> None:

--- a/tortoise/backends/odbc/client.py
+++ b/tortoise/backends/odbc/client.py
@@ -186,8 +186,8 @@ class ODBCTransactionWrapper(TransactionalDBClient):
     async def execute_many(self, query: str, values: list) -> None:
         async with self.acquire_connection() as connection:
             self.log.debug("%s: %s", query, values)
-            cursor = await connection.cursor()
-            await cursor.executemany(query, values)
+            async with connection.cursor() as cursor:
+                await cursor.executemany(query, values)
 
     async def begin(self) -> None:
         self._finalized = False


### PR DESCRIPTION
Close cursor properly in `ODBCTransactionWrapper.execute_many`.

## Description

We recently see a lot of these errors in MSSQL CI which relies on `pyodbc`:
```
[HY000] [Microsoft][ODBC Driver 18 for SQL Server]Connection is busy with results for another command (0) (SQLExecDirectW)
```

`bulk_create` routes through `execute_many`, which doesn't close the cursor properly in `ODBCTransactionWrapper.execute_many`. This PR tries to fix that.

## Motivation and Context

Fix failing CI in MSSQL

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Run MSSQL in CI and make sure the error doesn't show up.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

