### PR TITLE
fix: MySQL DATETIME incompatibility in migration recorder

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,13 @@ Changelog
 1.1
 ===
 
+1.1.8
+-----
+
+Fixed
+^^^^^
+- Fix MySQL DATETIME incompatibility in migration recorder.
+
 1.1.7
 -----
 

--- a/tortoise/migrations/recorder.py
+++ b/tortoise/migrations/recorder.py
@@ -74,7 +74,13 @@ class MigrationRecorder:
         return [MigrationKey(app_label=row["app"], name=row["name"]) for row in rows]
 
     async def record_applied(self, app: str, name: str) -> None:
-        applied_at = datetime.now(timezone.utc).isoformat()
+        now = datetime.now(timezone.utc)
+        if self._dialect == "mysql":
+            # MySQL DATETIME does not support timezone or ISO 8601 with offset
+            applied_at = now.strftime("%Y-%m-%d %H:%M:%S.%f")
+        else:
+            # Preserve timezone-aware format for databases that support it (e.g. PostgreSQL)
+            applied_at = now.isoformat()
         query = (
             f"INSERT INTO {self._quote(self.table_name)} "  # nosec B608
             f"({self._quote('app')}, {self._quote('name')}, {self._quote('applied_at')}) "


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR updates the migration recorder to use dialect-specific formatting for applied_at.

For MySQL, the value is now formatted as a MySQL-compatible DATETIME(6) string: `%Y-%m-%d %H:%M:%S.%f`



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently, record_applied uses `datetime.now(timezone.utc).isoformat()` for all dialects.
For other dialects, the existing timezone-aware ISO 8601 format is preserved (like `2026-04-21T03:44:08.811329+00:00`). This format is accepted by PostgreSQL, but it is not accepted by MySQL DATETIME / DATETIME(6) columns, causing migration recording to fail with an error like:
`Incorrect datetime value: '2026-04-21T03:44:08.811329+00:00' for column 'applied_at'`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally with MySQL.

Before this change, running migrations failed when Tortoise tried to insert the applied_at value into tortoise_migrations, due to an incompatible datetime format.

After this change, migrations completed successfully and the record was inserted correctly.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

