### PR TITLE
Switch setup-uv action to immutable releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - uses: actions/cache@v5
         with:
           path: ~/.cache/pip
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - uses: actions/cache@v5
         with:
           path: ~/.cache/pip
@@ -119,7 +119,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - uses: actions/cache@v5
         with:
           path: ~/.cache/pip
@@ -165,7 +165,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - uses: actions/cache@v5
         with:
           path: ~/.cache/pip
@@ -227,7 +227,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - uses: actions/cache@v5
         with:
           path: ~/.cache/pip
@@ -256,7 +256,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.14"
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: Install dependencies
         run: make deps
       - name: Download all coverage artifacts

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -20,7 +20,7 @@ jobs:
           # 3.12 is the minimum required version for profiling enabled
           python-version: "3.12"
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Build dists
         run: make build

--- a/.github/workflows/gh-pages-release.yml
+++ b/.github/workflows/gh-pages-release.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.10"
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: Build docs
         run: make docs
       - name: Deploy release docs

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.10"
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: Build docs
         run: make docs
       - name: Deploy latest docs

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: Build dists
         run: make build
       - name: Pypi Publish


### PR DESCRIPTION
Updated `astral-sh/setup-uv `from `@v7` to a pinned commit hash for `v8.1.0`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
The setup-uv maintainers moved to an [immutable release model](https://github.com/astral-sh/setup-uv/releases/tag/v8.0.0) starting with v8. They no longer support floating major tags (like @v8), which means automation tools won't see new updates if we stay on @v7.

This change improves CI security by pinning to a specific hash and ensures the project is aligned with the new versioning scheme.


## How Has This Been Tested?
This is a CI-only change. I believe the workflows should trigger and run as usual using the new pinned version of the action.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Let me know if this is a change you'd want to roll out across the other repos or something else. thanks!