### PR TITLE
docs: add config.py example to FastAPI documentation

### DIFF
--- a/docs/examples/fastapi.rst
+++ b/docs/examples/fastapi.rst
@@ -29,3 +29,7 @@ tests.py
 main.py
 -------
 .. literalinclude::  ../../examples/fastapi/main.py
+
+config.py
+-------
+.. literalinclude::  ../../examples/fastapi/config.py


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added the missing config.py reference to the FastAPI examples documentation to make the examples easier to reproduce.

## Motivation and Context
Currently in the documentation the tortoise-orm initialization is skipped in the fastapi example. So, it's difficult to new users to reproduce the example. 

https://github.com/tortoise/tortoise-orm/issues/2181

