### PR TITLE
feat: add back `as_query` method to `AwaitableQuery`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Added
 - ``QuerySet.contains()`` method to check if an object exists in a queryset.
 - Added comprehensive EXPLAIN support for MySQL and PostgreSQL.
 - Built-in ``DomainNameValidator``, ``URLValidator``, and ``EmailValidator`` classes for common validation patterns. (#2162)
+- `AwaitableQuery.as_query()` was added back (#2194)
 
 Fixed
 ^^^^^

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -1140,3 +1140,42 @@ async def test_union_with_annotate_raises(db):
 
     with pytest.raises(ParamsError, match="Union queries do not support annotations"):
         await qs1.union(qs2)
+
+
+@pytest.mark.asyncio
+async def test_as_query_queryset(db):
+    sql = IntFields.all().as_query().get_sql()
+    assert sql.startswith("SELECT")
+
+
+@pytest.mark.asyncio
+async def test_as_query_update(db):
+    sql = IntFields.filter(intnum=10).update(intnum=99).as_query().get_sql()
+    assert sql.startswith("UPDATE")
+
+
+@pytest.mark.asyncio
+async def test_as_query_delete(db):
+    sql = IntFields.filter(intnum=10).delete().as_query().get_sql()
+    assert sql.startswith("DELETE")
+
+
+@pytest.mark.asyncio
+async def test_as_query_exists(db):
+    sql = IntFields.filter(intnum=10).exists().as_query().get_sql()
+    assert "SELECT 1" in sql
+
+
+@pytest.mark.asyncio
+async def test_as_query_count(db):
+    sql = IntFields.filter(intnum=10).count().as_query().get_sql()
+    assert "COUNT(*)" in sql
+
+
+@pytest.mark.asyncio
+async def test_as_query_union_count(db):
+    qs1 = IntFields.filter(intnum__gte=50).only("id", "intnum")
+    qs2 = IntFields.filter(intnum__lt=50).only("id", "intnum")
+    sql = qs1.union(qs2).count().as_query().get_sql()
+    assert "UNION" in sql
+    assert "COUNT(*)" in sql

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -316,6 +316,12 @@ class AwaitableQuery(_ChooseDBMixin[MODEL], Generic[MODEL]):
             sql, _ = self.query.get_parameterized_sql()
         return sql
 
+    def as_query(self) -> QueryBuilder:
+        """Return the internal pypika query object."""
+        self._choose_db_if_not_chosen()
+        self._make_query()
+        return self.query
+
     def _make_query(self) -> None:
         raise NotImplementedError()  # pragma: nocoverage
 


### PR DESCRIPTION
## Description
Addresses https://github.com/tortoise/tortoise-orm/issues/2056: bring back `AwaitableQuery.as_query()`.

## Motivation and Context
 As described in https://github.com/tortoise/tortoise-orm/issues/2056 there are cases where users have complex queries and need access to the internal pypika layer. The `as_query()` method used to exist but was removed in https://github.com/tortoise/tortoise-orm/pull/1777. I don't see a reason why not to add it back.

## How Has This Been Tested?
Yes, tests added int this PR.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

