### PR TITLE
fix(migrations): migration serialization bugs for PK fields

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Added
 Fixed
 ^^^^^
 - ``MigrationRecorder`` now uses parameterized queries; fixes MariaDB/MySQL rejecting ISO-8601 ``applied_at`` values. (#2132)
+- Fix migration ``deconstruct()`` and ``CreateModel`` serialization for PK fields with ``generated=False`` or ``source_field``. (#2195)
 
 1.1.7
 -----

--- a/tests/fields/test_db_default.py
+++ b/tests/fields/test_db_default.py
@@ -213,6 +213,29 @@ def test_deconstruct_with_both_default_and_db_default():
     assert kwargs["db_default"] == 2
 
 
+def test_deconstruct_pk_generated_false():
+    f = fields.IntField(primary_key=True, generated=False)
+    f.model_field_name = "test_field"
+    path, args, kwargs = f.deconstruct()
+    assert kwargs.get("generated") is False
+    assert kwargs.get("primary_key") is True
+
+
+def test_deconstruct_pk_generated_default():
+    f = fields.IntField(primary_key=True)
+    f.model_field_name = "test_field"
+    path, args, kwargs = f.deconstruct()
+    assert kwargs.get("generated") is True
+    assert kwargs.get("primary_key") is True
+
+
+def test_deconstruct_non_pk_generated_false():
+    f = fields.IntField(generated=False)
+    f.model_field_name = "test_field"
+    path, args, kwargs = f.deconstruct()
+    assert "generated" not in kwargs
+
+
 # ============================================================================
 # Sentinel behavior
 # ============================================================================

--- a/tests/migrations/test_writer.py
+++ b/tests/migrations/test_writer.py
@@ -292,6 +292,37 @@ def test_writer_excludes_fk_source_field(tmp_path: Path, monkeypatch) -> None:
     _write_migration(tmp_path, monkeypatch, "0005_fk_source", operations, expected)
 
 
+def test_writer_includes_pk_with_source_field(tmp_path: Path, monkeypatch) -> None:
+    operations = [
+        CreateModel(
+            name="Widget",
+            fields=[
+                ("id", fields.IntField(primary_key=True, source_field="id")),
+                ("name", fields.CharField(max_length=100)),
+            ],
+        )
+    ]
+    expected = textwrap.dedent(
+        """\
+        from tortoise import migrations
+        from tortoise.migrations import operations as ops
+        from tortoise import fields
+
+        class Migration(migrations.Migration):
+            operations = [
+                ops.CreateModel(
+                    name='Widget',
+                    fields=[
+                        ('id', fields.IntField(source_field='id', generated=True, primary_key=True, unique=True, db_index=True)),
+                        ('name', fields.CharField(max_length=100)),
+                    ],
+                ),
+            ]
+        """
+    )
+    _write_migration(tmp_path, monkeypatch, "0011_pk_source", operations, expected)
+
+
 def test_writer_serializes_on_delete_enum(tmp_path: Path, monkeypatch) -> None:
     operations = [
         CreateModel(

--- a/tortoise/fields/base.py
+++ b/tortoise/fields/base.py
@@ -551,7 +551,7 @@ class Field(Generic[VALUE], metaclass=_FieldMeta):
         kwargs: dict[str, Any] = {}
         if self.source_field:
             kwargs["source_field"] = self.source_field
-        if self.generated:
+        if self.generated or self.pk:
             kwargs["generated"] = self.generated
         if self.pk:
             kwargs["primary_key"] = self.pk

--- a/tortoise/migrations/writer.py
+++ b/tortoise/migrations/writer.py
@@ -484,7 +484,7 @@ class MigrationWriter:
         for name, field in operation.fields:
             if field is None:
                 continue
-            if name in source_fields:
+            if name in source_fields and not getattr(field, "pk", False):
                 continue
             field_expr = self._render_field(field, imports)
             field_lines.append(f"{indent}        ({name!r}, {field_expr}),")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes 2 bugs that were discovered in https://github.com/tortoise/tortoise-orm/issues/2176

## Motivation and Context

Two bugs in migration serialization when a PK field is configured with
non-default attributes:
1. **`generated=False` on PK fields was lost during serialization** —
   `Field.deconstruct()` only emitted `generated` when the value was
   truthy. If a PK field explicitly set `generated=False`, the kwarg was
   omitted, causing the field to revert to its per-engine default
   (`True` for IntField) on deserialization. The fix includes the
   `generated` kwarg whenever `self.pk` is true, preserving the explicit
   value.
2. **PK fields with `source_field="<FIELD_NAME>"` were dropped from CreateModel** —
   `MigrationWriter._format_create_model()` collected all `source_field`
   values and skipped any field whose `name` appeared in that set. When a
   PK field had `source_field="<FIELD_NAME>"`, its own name matched the set entry
   and it was incorrectly excluded from the migration output. The fix
   exempts PK fields from this deduplication logic.

## How Has This Been Tested?
- Added tests for deconstructing with different options of `generated` in PK and non-PK fields
- Added test for a migration with `source_field` that is similar to the field name

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

