### PR TITLE
[WIP] Add new string functions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,9 @@ version = { source = "file", path = "tortoise/__init__.py" }
 excludes = ["./**/.git", "./**/.*_cache", "examples"]
 include = ["CHANGELOG.rst", "LICENSE", "README.rst"]
 
+[tool.uv.sources]
+pypika-tortoise = { git = "https://github.com/seladb/pypika-tortoise", branch = "add-functions" }
+
 [tool.mypy]
 pretty = true
 exclude = ["docs"]

--- a/tests/contrib/test_functions.py
+++ b/tests/contrib/test_functions.py
@@ -1,10 +1,20 @@
 import pytest
 import pytest_asyncio
 
-from tests.testmodels import IntFields
+from tests.testmodels import IntFields, Tournament
 from tortoise.contrib import test
+from tortoise.contrib.mysql.functions import LPad as MySqlLPad
 from tortoise.contrib.mysql.functions import Rand
-from tortoise.contrib.postgres.functions import Random as PostgresRandom
+from tortoise.contrib.mysql.functions import RPad as MySqlRPad
+from tortoise.contrib.postgres.functions import (
+    LPad as PostgresLPad,
+)
+from tortoise.contrib.postgres.functions import (
+    Random as PostgresRandom,
+)
+from tortoise.contrib.postgres.functions import (
+    RPad as PostgresRPad,
+)
 from tortoise.contrib.sqlite.functions import Random as SqliteRandom
 
 
@@ -43,3 +53,43 @@ async def test_sqlite_func_rand(db, intfields):
     sql = IntFields.all().annotate(randnum=SqliteRandom()).values("intnum", "randnum").sql()
     expected_sql = 'SELECT "intnum" "intnum",RANDOM() "randnum" FROM "intfields"'
     assert sql == expected_sql
+
+
+@test.requireCapability(dialect="postgres")
+@pytest.mark.asyncio
+async def test_postgres_func_lpad(db):
+    await Tournament.create(name="hello")
+    await Tournament.create(name="my world")
+    tournaments = await Tournament.annotate(pad_name=PostgresLPad("name", 12, "x"))
+    result = set(tournament.pad_name for tournament in tournaments)
+    assert result == {"xxxxmy world", "xxxxxxxhello"}
+
+
+@test.requireCapability(dialect="mysql")
+@pytest.mark.asyncio
+async def test_mysql_func_lpad(db):
+    await Tournament.create(name="hello")
+    await Tournament.create(name="my world")
+    tournaments = await Tournament.annotate(pad_name=MySqlLPad("name", 12, "x"))
+    result = set(tournament.pad_name for tournament in tournaments)
+    assert result == {"xxxxmy world", "xxxxxxxhello"}
+
+
+@test.requireCapability(dialect="postgres")
+@pytest.mark.asyncio
+async def test_postgres_func_rpad(db):
+    await Tournament.create(name="hello")
+    await Tournament.create(name="my world")
+    tournaments = await Tournament.annotate(pad_name=PostgresRPad("name", 12, "x"))
+    result = set(tournament.pad_name for tournament in tournaments)
+    assert result == {"my worldxxxx", "helloxxxxxxx"}
+
+
+@test.requireCapability(dialect="mysql")
+@pytest.mark.asyncio
+async def test_mysql_func_rpad(db):
+    await Tournament.create(name="hello")
+    await Tournament.create(name="my world")
+    tournaments = await Tournament.annotate(pad_name=MySqlRPad("name", 12, "x"))
+    result = set(tournament.pad_name for tournament in tournaments)
+    assert result == {"my worldxxxx", "helloxxxxxxx"}

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -14,9 +14,23 @@ from tests.testmodels import (
     Tournament,
 )
 from tortoise.contrib import test
-from tortoise.contrib.test.condition import In, NotEQ
+from tortoise.contrib.test import requireCapability
+from tortoise.contrib.test.condition import In, NotEQ, NotIn
 from tortoise.expressions import Case, F, Q, When
-from tortoise.functions import Coalesce, Count, Length, Lower, Max, Trim, Upper
+from tortoise.functions import (
+    Coalesce,
+    Count,
+    Length,
+    Lower,
+    LPad,
+    LTrim,
+    Max,
+    Replace,
+    RPad,
+    RTrim,
+    Trim,
+    Upper,
+)
 
 
 @pytest.mark.asyncio
@@ -377,6 +391,88 @@ async def test_filter_by_aggregation_field_trim(db):
     tournaments = await Tournament.annotate(trimmed_name=Trim("name")).filter(trimmed_name="1")
     assert len(tournaments) == 1
     assert {(t.name, t.trimmed_name) for t in tournaments} == {("  1 ", "1")}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ["name", "trim_chars", "trimmed_name"],
+    [
+        ("xxxhellox", "x", "hello"),
+        ("ababhelloab", "ab", "hello"),
+    ],
+)
+async def test_filter_by_trim_with_chars(db, name, trim_chars, trimmed_name):
+    await Tournament.create(name=name)
+    tournaments = await Tournament.annotate(trimmed_name=Trim("name", trim_chars)).filter(
+        trimmed_name=trimmed_name
+    )
+
+    assert len(tournaments) == 1
+    assert {(t.name, t.trimmed_name) for t in tournaments} == {(name, trimmed_name)}
+
+
+@pytest.mark.asyncio
+async def test_filter_by_ltrim(db):
+    await Tournament.create(name="  hello ")
+    tournaments = await Tournament.annotate(trimmed_name=LTrim("name")).filter(
+        trimmed_name="hello "
+    )
+
+    assert len(tournaments) == 1
+    assert {(t.name, t.trimmed_name) for t in tournaments} == {("  hello ", "hello ")}
+
+
+@pytest.mark.asyncio
+async def test_filter_by_rtrim(db):
+    await Tournament.create(name="  hello ")
+    tournaments = await Tournament.annotate(trimmed_name=RTrim("name")).filter(
+        trimmed_name="  hello"
+    )
+
+    assert len(tournaments) == 1
+    assert {(t.name, t.trimmed_name) for t in tournaments} == {("  hello ", "  hello")}
+
+
+@requireCapability(dialect=NotIn("sqlite"))
+@pytest.mark.asyncio
+async def test_lpad(db):
+    await Tournament.create(name="hello")
+    await Tournament.create(name="my world")
+    tournaments = await Tournament.annotate(pad_name=LPad("name", 12, "x"))
+    result = set(tournament.pad_name for tournament in tournaments)
+    assert result == {"xxxxmy world", "xxxxxxxhello"}
+
+
+@requireCapability(dialect=NotIn("sqlite"))
+@pytest.mark.asyncio
+async def test_rpad(db):
+    await Tournament.create(name="hello")
+    await Tournament.create(name="my world")
+    tournaments = await Tournament.annotate(pad_name=RPad("name", 12, "x"))
+    result = set(tournament.pad_name for tournament in tournaments)
+    assert result == {"my worldxxxx", "helloxxxxxxx"}
+
+
+@pytest.mark.asyncio
+async def test_replace(db):
+    await Tournament.create(name="Tournament A")
+    await Tournament.create(name="Tournament B")
+    tournaments = await Tournament.annotate(replaced_name=Replace("name", "Tournament", "Contest"))
+    result = {t.replaced_name for t in tournaments}
+    assert result == {"Contest A", "Contest B"}
+
+
+@pytest.mark.asyncio
+async def test_filter_by_replace(db):
+    await Tournament.create(name="1st Tournament")
+    await Tournament.create(name="2nd Tournament")
+    await Tournament.create(name="3rd Place")
+
+    tournaments = await Tournament.annotate(
+        replaced_name=Replace("name", "Tournament", "Contest")
+    ).filter(replaced_name="1st Contest")
+    assert len(tournaments) == 1
+    assert {(t.name, t.replaced_name) for t in tournaments} == {("1st Tournament", "1st Contest")}
 
 
 @test.requireCapability(dialect=NotEQ("mssql"))

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -14,19 +14,16 @@ from tests.testmodels import (
     Tournament,
 )
 from tortoise.contrib import test
-from tortoise.contrib.test import requireCapability
-from tortoise.contrib.test.condition import In, NotEQ, NotIn
+from tortoise.contrib.test.condition import In, NotEQ
 from tortoise.expressions import Case, F, Q, When
 from tortoise.functions import (
     Coalesce,
     Count,
     Length,
     Lower,
-    LPad,
     LTrim,
     Max,
     Replace,
-    RPad,
     RTrim,
     Trim,
     Upper,
@@ -431,26 +428,6 @@ async def test_filter_by_rtrim(db):
 
     assert len(tournaments) == 1
     assert {(t.name, t.trimmed_name) for t in tournaments} == {("  hello ", "  hello")}
-
-
-@requireCapability(dialect=NotIn("sqlite"))
-@pytest.mark.asyncio
-async def test_lpad(db):
-    await Tournament.create(name="hello")
-    await Tournament.create(name="my world")
-    tournaments = await Tournament.annotate(pad_name=LPad("name", 12, "x"))
-    result = set(tournament.pad_name for tournament in tournaments)
-    assert result == {"xxxxmy world", "xxxxxxxhello"}
-
-
-@requireCapability(dialect=NotIn("sqlite"))
-@pytest.mark.asyncio
-async def test_rpad(db):
-    await Tournament.create(name="hello")
-    await Tournament.create(name="my world")
-    tournaments = await Tournament.annotate(pad_name=RPad("name", 12, "x"))
-    result = set(tournament.pad_name for tournament in tournaments)
-    assert result == {"my worldxxxx", "helloxxxxxxx"}
 
 
 @pytest.mark.asyncio

--- a/tortoise/contrib/mysql/functions.py
+++ b/tortoise/contrib/mysql/functions.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
-from pypika_tortoise.terms import Function
+from pypika_tortoise import functions
+from pypika_tortoise.terms import Function, Term
+
+from tortoise.expressions import CombinedExpression, F
+from tortoise.functions import Function as TortoiseFunction
 
 
 class Rand(Function):
@@ -13,3 +17,39 @@ class Rand(Function):
     def __init__(self, seed: int | None = None, alias=None) -> None:
         super().__init__("RAND", seed, alias=alias)
         self.args = [self.wrap_constant(seed)] if seed is not None else []
+
+
+class LPad(TortoiseFunction):
+    """
+    Pads the left side of a string with a specified character to reach a certain length.
+
+    :samp:`LPad("{FIELD_NAME}", length, fill_text)`
+    """
+
+    def __init__(
+        self,
+        field: str | F | CombinedExpression | TortoiseFunction | Term,
+        length: int,
+        fill_text: str = " ",
+    ) -> None:
+        super().__init__(field, length, fill_text)
+
+    database_func = functions.LPad
+
+
+class RPad(TortoiseFunction):
+    """
+    Pads the right side of a string with a specified character to reach a certain length.
+
+    :samp:`RPad("{FIELD_NAME}", length, fill_text)`
+    """
+
+    def __init__(
+        self,
+        field: str | F | CombinedExpression | TortoiseFunction | Term,
+        length: int,
+        fill_text: str = " ",
+    ) -> None:
+        super().__init__(field, length, fill_text)
+
+    database_func = functions.RPad

--- a/tortoise/contrib/postgres/functions.py
+++ b/tortoise/contrib/postgres/functions.py
@@ -1,4 +1,8 @@
+from pypika_tortoise import functions
 from pypika_tortoise.terms import Function, Term
+
+from tortoise.expressions import CombinedExpression, F
+from tortoise.functions import Function as TortoiseFunction
 
 
 class ToTsVector(Function):
@@ -37,3 +41,39 @@ class Random(Function):
 
     def __init__(self, alias=None) -> None:
         super().__init__("RANDOM", alias=alias)
+
+
+class LPad(TortoiseFunction):
+    """
+    Pads the left side of a string with a specified character to reach a certain length.
+
+    :samp:`LPad("{FIELD_NAME}", length, fill_text)`
+    """
+
+    def __init__(
+        self,
+        field: str | F | CombinedExpression | TortoiseFunction | Term,
+        length: int,
+        fill_text: str = " ",
+    ) -> None:
+        super().__init__(field, length, fill_text)
+
+    database_func = functions.LPad
+
+
+class RPad(TortoiseFunction):
+    """
+    Pads the right side of a string with a specified character to reach a certain length.
+
+    :samp:`RPad("{FIELD_NAME}", length, fill_text)`
+    """
+
+    def __init__(
+        self,
+        field: str | F | CombinedExpression | TortoiseFunction | Term,
+        length: int,
+        fill_text: str = " ",
+    ) -> None:
+        super().__init__(field, length, fill_text)
+
+    database_func = functions.RPad

--- a/tortoise/functions.py
+++ b/tortoise/functions.py
@@ -1,6 +1,9 @@
-from pypika_tortoise import SqlContext, functions
+from typing import Any
 
-from tortoise.expressions import Aggregate, Function
+from pypika_tortoise import SqlContext, functions
+from pypika_tortoise.terms import Term
+
+from tortoise.expressions import Aggregate, CombinedExpression, F, Function
 
 ##############################################################################
 # Standard functions
@@ -15,6 +18,93 @@ class Trim(Function):
     """
 
     database_func = functions.Trim
+
+    def __init__(
+        self,
+        field: str | F | CombinedExpression | Function | Term,
+        trim_chars: str = " ",
+        *default_values: Any,
+    ) -> None:
+        super().__init__(field, trim_chars, *default_values)
+
+    database_func = functions.Trim
+
+
+class LTrim(Function):
+    """
+    Trims whitespace from the left side of text.
+
+    :samp:`LTrim("{FIELD_NAME}")`
+    """
+
+    database_func = functions.LTrim
+
+
+class RTrim(Function):
+    """
+    Trims whitespace from the right side of text.
+
+    :samp:`RTrim("{FIELD_NAME}")`
+    """
+
+    database_func = functions.RTrim
+
+
+class LPad(Function):
+    """
+    Pads the left side of a string with a specified character to reach a certain length.
+
+    :samp:`LPad("{FIELD_NAME}", length, fill_text)`
+    """
+
+    def __init__(
+        self,
+        field: str | F | CombinedExpression | Function | Term,
+        length: int,
+        fill_text: str = " ",
+        *default_values: Any,
+    ) -> None:
+        super().__init__(field, length, fill_text, *default_values)
+
+    database_func = functions.LPad
+
+
+class RPad(Function):
+    """
+    Pads the right side of a string with a specified character to reach a certain length.
+
+    :samp:`RPad("{FIELD_NAME}", length, fill_text)`
+    """
+
+    def __init__(
+        self,
+        field: str | F | CombinedExpression | Function | Term,
+        length: int,
+        fill_text: str = " ",
+        *default_values: Any,
+    ) -> None:
+        super().__init__(field, length, fill_text, *default_values)
+
+    database_func = functions.RPad
+
+
+class Replace(Function):
+    """
+    Replaces all occurrences of a search string with a replacement string.
+
+    :samp:`Replace("{FIELD_NAME}", "search", "replacement")`
+    """
+
+    def __init__(
+        self,
+        field: str | F | CombinedExpression | Function | Term,
+        search: str,
+        replacement: str,
+        *default_values: Any,
+    ) -> None:
+        super().__init__(field, search, replacement, *default_values)
+
+    database_func = functions.Replace
 
 
 class Length(Function):

--- a/tortoise/functions.py
+++ b/tortoise/functions.py
@@ -50,44 +50,6 @@ class RTrim(Function):
     database_func = functions.RTrim
 
 
-class LPad(Function):
-    """
-    Pads the left side of a string with a specified character to reach a certain length.
-
-    :samp:`LPad("{FIELD_NAME}", length, fill_text)`
-    """
-
-    def __init__(
-        self,
-        field: str | F | CombinedExpression | Function | Term,
-        length: int,
-        fill_text: str = " ",
-        *default_values: Any,
-    ) -> None:
-        super().__init__(field, length, fill_text, *default_values)
-
-    database_func = functions.LPad
-
-
-class RPad(Function):
-    """
-    Pads the right side of a string with a specified character to reach a certain length.
-
-    :samp:`RPad("{FIELD_NAME}", length, fill_text)`
-    """
-
-    def __init__(
-        self,
-        field: str | F | CombinedExpression | Function | Term,
-        length: int,
-        fill_text: str = " ",
-        *default_values: Any,
-    ) -> None:
-        super().__init__(field, length, fill_text, *default_values)
-
-    database_func = functions.RPad
-
-
 class Replace(Function):
     """
     Replaces all occurrences of a search string with a replacement string.

--- a/uv.lock
+++ b/uv.lock
@@ -2677,11 +2677,7 @@ wheels = [
 [[package]]
 name = "pypika-tortoise"
 version = "0.6.5"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/06/89fe5fff93c5a01dbdeb9f3d843a7e997dc6e3a87222a260a164ff91fb81/pypika_tortoise-0.6.5.tar.gz", hash = "sha256:64d96c9b88450f6360ad22a7063933b6a90961a7317f04b2b63c98fd5d705506", size = 81468, upload-time = "2026-03-13T20:44:54.439Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/b8/502910eb8b315f719d8f6a6509f13a38b6c4c05378f14ac151ff347bff0a/pypika_tortoise-0.6.5-py3-none-any.whl", hash = "sha256:9194ac6ce6ac9bdfc6e959c831c5788ef05ee1371e82ba281b0eb75f4a2bd4f1", size = 47936, upload-time = "2026-03-13T20:44:53.541Z" },
-]
+source = { git = "https://github.com/seladb/pypika-tortoise?branch=add-functions#c4c65e2e0c5067834ac7a18e86593eac3a24ec5f" }
 
 [[package]]
 name = "pytest"
@@ -3452,7 +3448,7 @@ requires-dist = [
     { name = "orjson", marker = "extra == 'accel'" },
     { name = "psycopg", extras = ["binary", "pool"], marker = "extra == 'psycopg'", specifier = ">=3.0.12,<4.0.0" },
     { name = "ptpython", marker = "extra == 'ptpython'", specifier = ">=3.0.0" },
-    { name = "pypika-tortoise", specifier = ">=0.6.5,<1.0.0" },
+    { name = "pypika-tortoise", git = "https://github.com/seladb/pypika-tortoise?branch=add-functions" },
     { name = "tomlkit", marker = "python_full_version < '3.11'", specifier = ">=0.11.4,<1.0.0" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.1.0" },
     { name = "uvloop", marker = "implementation_name == 'cpython' and sys_platform != 'win32' and extra == 'accel'" },


### PR DESCRIPTION
Update existing and add new string functions.

## Description
- Update `Trim` to accept the characters to trim
- Add new string functions: `RTrim`, `LTrim`, `RPad`, `LPad`, `Replace`
- Noe: `RPad` and `LPad` are not available in SQLite

## Motivation and Context
This aligns with what's available in [Django](https://docs.djangoproject.com/en/6.0/ref/models/database-functions/#text-functions)

## How Has This Been Tested?
- Added tests for existing and new functions

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

