### PR TITLE
feat: rewrote the method for getting m2m objects

### DIFF
--- a/tests/fields/test_m2m_uuid.py
+++ b/tests/fields/test_m2m_uuid.py
@@ -163,3 +163,15 @@ async def test__add_uninstantiated(db, m2m_uuid_models):
     two = await UUIDM2MRelatedModel.create()
     with pytest.raises(OperationalError, match=r"You should first call .save\(\) on"):
         await two.models.add(one)
+
+
+@pytest.mark.asyncio
+async def test_prefetch_related(db, m2m_uuid_models):
+    UUIDPkModel, UUIDM2MRelatedModel = m2m_uuid_models
+    one = await UUIDPkModel.create()
+    two = await UUIDM2MRelatedModel.create()
+    await one.peers.add(two)
+
+    fetched = await UUIDPkModel.get(pk=one.pk).prefetch_related("peers")
+
+    assert list(fetched.peers) == [two]

--- a/tests/test_prefetching.py
+++ b/tests/test_prefetching.py
@@ -155,6 +155,32 @@ async def test_prefetch_m2m_to_attr(db):
 
 
 @pytest.mark.asyncio
+async def test_prefetch_m2m_annotate(db):
+    tournament = await Tournament.create(name="tournament")
+    team = await Team.create(name="1")
+    event = await Event.create(name="First", tournament=tournament)
+    await event.participants.add(team)
+    event = await Event.first().prefetch_related(
+        Prefetch("participants", Team.annotate(count_events=Count("events")))
+    )
+    for team in event.participants:
+        assert team.count_events == 1
+
+
+@pytest.mark.asyncio
+async def test_prefetch_m2m_select_related(db):
+    tournament = await Tournament.create(name="tournament")
+    team = await Team.create(name="1")
+    event = await Event.create(name="First", tournament=tournament)
+    await team.events.add(event)
+    team = await Team.first().prefetch_related(
+        Prefetch("events", Event.all().select_related("tournament"))
+    )
+    for event in team.events:
+        assert event.tournament == tournament
+
+
+@pytest.mark.asyncio
 async def test_prefetch_o2o_to_attr(db):
     tournament = await Tournament.create(name="tournament")
     event = await Event.create(name="First", tournament=tournament)

--- a/tests/test_prefetching.py
+++ b/tests/test_prefetching.py
@@ -181,6 +181,35 @@ async def test_prefetch_m2m_select_related(db):
 
 
 @pytest.mark.asyncio
+async def test_prefetch_m2m_order_by(db):
+    tournament = await Tournament.create(name="tournament")
+    team_1 = await Team.create(name="1")
+    team_2 = await Team.create(name="2")
+    event = await Event.create(name="First", tournament=tournament)
+    await event.participants.add(team_1, team_2)
+    event_1 = await Event.first().prefetch_related(
+        Prefetch("participants", Team.all().order_by("name"))
+    )
+    event_2 = await Event.first().prefetch_related(
+        Prefetch("participants", Team.all().order_by("-name"))
+    )
+    assert [team.name for team in event_1.participants] == ["1", "2"]
+    assert [team.name for team in event_2.participants] == ["2", "1"]
+
+
+@pytest.mark.asyncio
+async def test_prefetch_m2m_only(db):
+    tournament = await Tournament.create(name="tournament")
+    team = await Team.create(name="1")
+    event = await Event.create(name="First", tournament=tournament)
+    await team.events.add(event)
+    team = await Team.first().prefetch_related(Prefetch("events", Event.all().only("name")))
+    assert len(team.events) == 1
+    for event in team.events:
+        assert bool(event.pk)
+
+
+@pytest.mark.asyncio
 async def test_prefetch_o2o_to_attr(db):
     tournament = await Tournament.create(name="tournament")
     event = await Event.create(name="First", tournament=tournament)

--- a/tortoise/backends/base/executor.py
+++ b/tortoise/backends/base/executor.py
@@ -608,41 +608,41 @@ class BaseExecutor:
         model_pk = self.model._meta.pk
         instance_pks = [model_pk.to_db_value(instance.pk, instance) for instance in instance_list]
 
-        related_objects = await queryset.filter(
-            **{f"{field_object.related_name}__in": instance_pks}
-        )
+        related_model_pk = queryset.model._meta.pk
+        model_field_name_pk = related_model_pk.model_field_name
+        fields_for_select = queryset._fields_for_select
+        if fields_for_select and model_field_name_pk not in fields_for_select:
+            queryset = queryset.only(*queryset._fields_for_select, model_field_name_pk)
 
         relation_map: dict = {}
-        if related_objects:
-            related_pk_map: dict = {obj.pk: obj for obj in related_objects}
-            related_model_pk = queryset.model._meta.pk
-            related_pks = [related_model_pk.to_db_value(pk, None) for pk in related_pk_map]
+        related_objects_by_pks = {
+            obj.pk: obj
+            for obj in await queryset.filter(**{f"{field_object.related_name}__in": instance_pks})
+        }
+        if related_objects_by_pks:
             through_table = Table(field_object.through, schema=field_object.through_schema)
             backward_field = through_table[field_object.backward_key]
             forward_field = through_table[field_object.forward_key]
 
-            _, (_, through_rows) = await asyncio.gather(
-                self.__class__(
-                    model=queryset.model, db=self.db, prefetch_map=queryset._prefetch_map
-                )._execute_prefetch_queries(related_objects),
-                self.db.execute_query(
-                    *(
-                        self.db.query_class.from_(through_table)
-                        .select(backward_field, forward_field)
-                        .where(backward_field.isin(instance_pks))
-                        .where(forward_field.isin(related_pks))
-                        .get_parameterized_sql()
-                    )
-                ),
+            _, through_rows = await self.db.execute_query(
+                *(
+                    self.db.query_class.from_(through_table)
+                    .select(backward_field, forward_field)
+                    .where(backward_field.isin(instance_pks))
+                    .where(forward_field.isin(tuple(related_objects_by_pks)))
+                    .get_parameterized_sql()
+                )
             )
 
+            reverse_map: dict = {}
             for row in through_rows:
+                forward_key_value = related_model_pk.to_python_value(row[field_object.forward_key])
                 backward_key_value = model_pk.to_python_value(row[field_object.backward_key])
-                related_object = related_pk_map.get(
-                    related_model_pk.to_python_value(row[field_object.forward_key])
-                )
-                if related_object is not None:
-                    relation_map.setdefault(backward_key_value, []).append(related_object)
+                reverse_map.setdefault(forward_key_value, []).append(backward_key_value)
+
+            for related_object in related_objects_by_pks.values():
+                for instance_pk in reverse_map.get(related_object.pk, []):
+                    relation_map.setdefault(instance_pk, []).append(related_object)
 
         for instance in instance_list:
             getattr(instance, field)._set_result_for_query(

--- a/tortoise/backends/base/executor.py
+++ b/tortoise/backends/base/executor.py
@@ -601,23 +601,29 @@ class BaseExecutor:
         field: str,
         related_query: tuple[str | None, QuerySet],
     ) -> Iterable[Model]:
-        to_attr, queryset = related_query
+        to_attr, related_queryset = related_query
 
         field_object: ManyToManyFieldInstance = self.model._meta.fields_map[field]  # type: ignore
 
-        model_pk = self.model._meta.pk
-        instance_pks = [model_pk.to_db_value(instance.pk, instance) for instance in instance_list]
+        pk_field = self.model._meta.pk
+        instance_id_set: set = {
+            pk_field.to_db_value(instance.pk, instance) for instance in instance_list
+        }
 
-        related_model_pk = queryset.model._meta.pk
-        model_field_name_pk = related_model_pk.model_field_name
-        fields_for_select = queryset._fields_for_select
-        if fields_for_select and model_field_name_pk not in fields_for_select:
-            queryset = queryset.only(*queryset._fields_for_select, model_field_name_pk)
+        related_pk_field = related_queryset.model._meta.pk
+        related_pk_field_name = related_pk_field.model_field_name
+        fields_for_select = related_queryset._fields_for_select
+        if fields_for_select and related_pk_field_name not in fields_for_select:
+            related_queryset = related_queryset.only(
+                *related_queryset._fields_for_select, related_pk_field_name
+            )
 
         relation_map: dict = {}
         related_objects_by_pks = {
-            related_model_pk.to_db_value(obj.pk, obj): obj
-            for obj in await queryset.filter(**{f"{field_object.related_name}__in": instance_pks})
+            related_pk_field.to_db_value(obj.pk, obj): obj
+            for obj in await related_queryset.filter(
+                **{f"{field_object.related_name}__in": instance_id_set}
+            )
         }
         if related_objects_by_pks:
             through_table = Table(field_object.through, schema=field_object.through_schema)
@@ -628,7 +634,7 @@ class BaseExecutor:
                 *(
                     self.db.query_class.from_(through_table)
                     .select(backward_field, forward_field)
-                    .where(backward_field.isin(instance_pks))
+                    .where(backward_field.isin(instance_id_set))
                     .where(forward_field.isin(tuple(related_objects_by_pks)))
                     .get_parameterized_sql()
                 )
@@ -636,8 +642,8 @@ class BaseExecutor:
 
             reverse_map: dict = {}
             for row in through_rows:
-                forward_key_value = related_model_pk.to_python_value(row[field_object.forward_key])
-                backward_key_value = model_pk.to_python_value(row[field_object.backward_key])
+                forward_key_value = related_pk_field.to_python_value(row[field_object.forward_key])
+                backward_key_value = pk_field.to_python_value(row[field_object.backward_key])
                 reverse_map.setdefault(forward_key_value, []).append(backward_key_value)
 
             for related_object in related_objects_by_pks.values():
@@ -645,9 +651,8 @@ class BaseExecutor:
                     relation_map.setdefault(instance_pk, []).append(related_object)
 
         for instance in instance_list:
-            getattr(instance, field)._set_result_for_query(
-                relation_map.get(instance.pk, []), to_attr
-            )
+            relation_container = getattr(instance, field)
+            relation_container._set_result_for_query(relation_map.get(instance.pk, []), to_attr)
         return instance_list
 
     async def _prefetch_direct_relation(

--- a/tortoise/backends/base/executor.py
+++ b/tortoise/backends/base/executor.py
@@ -7,11 +7,11 @@ from collections.abc import Callable, Iterable, Sequence
 from copy import copy
 from typing import TYPE_CHECKING, Any, cast
 
-from pypika_tortoise import JoinType, Parameter, Table
+from pypika_tortoise import Parameter
 from pypika_tortoise.queries import QueryBuilder
 
 from tortoise.exceptions import OperationalError, UnSupportedError
-from tortoise.expressions import Expression, ResolveContext
+from tortoise.expressions import Expression, RawSQL, ResolveContext
 from tortoise.fields.base import DatabaseDefault
 from tortoise.fields.relational import (
     BackwardFKRelation,
@@ -19,7 +19,6 @@ from tortoise.fields.relational import (
     ManyToManyFieldInstance,
     RelationalField,
 )
-from tortoise.query_utils import QueryModifier
 
 if TYPE_CHECKING:  # pragma: nocoverage
     from tortoise.backends.base.client import BaseDBAsyncClient
@@ -602,85 +601,33 @@ class BaseExecutor:
         field: str,
         related_query: tuple[str | None, QuerySet],
     ) -> Iterable[Model]:
-        to_attr, related_query = related_query
-        instance_id_set: set = {
-            instance._meta.pk.to_db_value(instance.pk, instance) for instance in instance_list
-        }
+        to_attr, queryset = related_query
 
         field_object: ManyToManyFieldInstance = self.model._meta.fields_map[field]  # type: ignore
 
-        through_table = Table(field_object.through, schema=field_object.through_schema)
+        through = field_object.through
+        if field_object.through_schema:
+            through = f"{field_object.through_schema}.{through}"
 
-        subquery = (
-            self.db.query_class.from_(through_table)
-            .select(
-                through_table[field_object.backward_key].as_("_backward_relation_key"),
-                through_table[field_object.forward_key].as_("_forward_relation_key"),
-            )
-            .where(through_table[field_object.backward_key].isin(instance_id_set))
-        )
+        related_objects = await queryset.filter(
+            **{f"{field_object.related_name}__in": instance_list}
+        ).annotate(_backward_relation_key=RawSQL(f'"{through}"."{field_object.backward_key}"'))
 
-        related_query_table = related_query.model._meta.basetable
-        related_pk_field = related_query.model._meta.db_pk_column
-        related_query.resolve_ordering(related_query.model, related_query_table, [], {})
-        query = (
-            related_query.query.join(subquery)
-            .on(subquery._forward_relation_key == related_query_table[related_pk_field])
-            .select(
-                subquery._backward_relation_key.as_("_backward_relation_key"),
-                *[related_query_table[field].as_(field) for field in related_query.fields],
-            )
-        )
-
-        if related_query._q_objects:
-            joined_tables: list[Table] = []
-            modifier = QueryModifier()
-            for node in related_query._q_objects:
-                modifier &= node.resolve(
-                    ResolveContext(
-                        model=related_query.model,
-                        table=related_query_table,
-                        annotations=related_query._annotations,
-                        custom_filters=related_query._custom_filters,
-                    )
-                )
-
-            for join in modifier.joins:
-                if join[0] not in joined_tables:
-                    query = query.join(join[0], how=JoinType.left_outer).on(join[1])
-                    joined_tables.append(join[0])
-
-            if modifier.where_criterion:
-                query = query.where(modifier.where_criterion)
-
-            if modifier.having_criterion:
-                query = query.having(modifier.having_criterion)
-
-        _, raw_results = await self.db.execute_query(*query.get_parameterized_sql())
-        relations: list[tuple[Any, Any]] = []
-        related_object_list: list[Model] = []
-        model_pk, related_pk = self.model._meta.pk, field_object.related_model._meta.pk
-        for e in raw_results:
-            pk_values: tuple[Any, Any] = (
-                model_pk.to_python_value(e["_backward_relation_key"]),
-                related_pk.to_python_value(e[related_pk_field]),
-            )
-            relations.append(pk_values)
-            related_object_list.append(related_query.model._init_from_db(**e))
         await self.__class__(
-            model=related_query.model, db=self.db, prefetch_map=related_query._prefetch_map
-        )._execute_prefetch_queries(related_object_list)
-        related_object_map = {e.pk: e for e in related_object_list}
-        relation_map: dict[str, list] = {}
+            model=queryset.model, db=self.db, prefetch_map=queryset._prefetch_map
+        )._execute_prefetch_queries(related_objects)
 
-        for object_id, related_object_id in relations:
-            if object_id not in relation_map:
-                relation_map[object_id] = []
-            relation_map[object_id].append(related_object_map[related_object_id])
+        model_pk = self.model._meta.pk
+        relation_map: dict = {}
+        for obj in related_objects:
+            bk = model_pk.to_python_value(obj._backward_relation_key)
+            relation_map.setdefault(bk, []).append(obj)
+            del obj._backward_relation_key
 
         for instance in instance_list:
-            relation_container = getattr(instance, field)
-            relation_container._set_result_for_query(relation_map.get(instance.pk, []), to_attr)
+            getattr(instance, field)._set_result_for_query(
+                relation_map.get(instance.pk, []), to_attr
+            )
         return instance_list
 
     async def _prefetch_direct_relation(

--- a/tortoise/backends/base/executor.py
+++ b/tortoise/backends/base/executor.py
@@ -7,11 +7,11 @@ from collections.abc import Callable, Iterable, Sequence
 from copy import copy
 from typing import TYPE_CHECKING, Any, cast
 
-from pypika_tortoise import Parameter
-from pypika_tortoise.queries import QueryBuilder
+from pypika_tortoise.queries import QueryBuilder, Table
+from pypika_tortoise.terms import Parameter
 
 from tortoise.exceptions import OperationalError, UnSupportedError
-from tortoise.expressions import Expression, RawSQL, ResolveContext
+from tortoise.expressions import Expression, ResolveContext
 from tortoise.fields.base import DatabaseDefault
 from tortoise.fields.relational import (
     BackwardFKRelation,
@@ -605,24 +605,44 @@ class BaseExecutor:
 
         field_object: ManyToManyFieldInstance = self.model._meta.fields_map[field]  # type: ignore
 
-        through = field_object.through
-        if field_object.through_schema:
-            through = f"{field_object.through_schema}.{through}"
+        model_pk = self.model._meta.pk
+        instance_pks = [model_pk.to_db_value(instance.pk, instance) for instance in instance_list]
 
         related_objects = await queryset.filter(
-            **{f"{field_object.related_name}__in": instance_list}
-        ).annotate(_backward_relation_key=RawSQL(f'"{through}"."{field_object.backward_key}"'))
+            **{f"{field_object.related_name}__in": instance_pks}
+        )
 
-        await self.__class__(
-            model=queryset.model, db=self.db, prefetch_map=queryset._prefetch_map
-        )._execute_prefetch_queries(related_objects)
-
-        model_pk = self.model._meta.pk
         relation_map: dict = {}
-        for obj in related_objects:
-            bk = model_pk.to_python_value(obj._backward_relation_key)
-            relation_map.setdefault(bk, []).append(obj)
-            del obj._backward_relation_key
+        if related_objects:
+            related_pk_map: dict = {obj.pk: obj for obj in related_objects}
+            related_model_pk = queryset.model._meta.pk
+            related_pks = [related_model_pk.to_db_value(pk, None) for pk in related_pk_map]
+            through_table = Table(field_object.through, schema=field_object.through_schema)
+            backward_field = through_table[field_object.backward_key]
+            forward_field = through_table[field_object.forward_key]
+
+            _, (_, through_rows) = await asyncio.gather(
+                self.__class__(
+                    model=queryset.model, db=self.db, prefetch_map=queryset._prefetch_map
+                )._execute_prefetch_queries(related_objects),
+                self.db.execute_query(
+                    *(
+                        self.db.query_class.from_(through_table)
+                        .select(backward_field, forward_field)
+                        .where(backward_field.isin(instance_pks))
+                        .where(forward_field.isin(related_pks))
+                        .get_parameterized_sql()
+                    )
+                ),
+            )
+
+            for row in through_rows:
+                backward_key_value = model_pk.to_python_value(row[field_object.backward_key])
+                related_object = related_pk_map.get(
+                    related_model_pk.to_python_value(row[field_object.forward_key])
+                )
+                if related_object is not None:
+                    relation_map.setdefault(backward_key_value, []).append(related_object)
 
         for instance in instance_list:
             getattr(instance, field)._set_result_for_query(

--- a/tortoise/backends/base/executor.py
+++ b/tortoise/backends/base/executor.py
@@ -616,7 +616,7 @@ class BaseExecutor:
 
         relation_map: dict = {}
         related_objects_by_pks = {
-            obj.pk: obj
+            related_model_pk.to_db_value(obj.pk, obj): obj
             for obj in await queryset.filter(**{f"{field_object.related_name}__in": instance_pks})
         }
         if related_objects_by_pks:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The `_prefetch_m2m_relation` method of the `BaseExecutor` class has been rewritten. Now objects are received directly through the specified `queryset`, which allows you to correctly use `select_related`, `annotate`, etc.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`prefetch_related` (`m2m`) functionality becomes like in `Django`.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added tests to `tests/test_prefetching.py` with verification of receiving data from `annotate` and `select_related`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

