### PR TITLE
fix: clamp count() at 0 when offset exceeds total

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,7 +21,7 @@ Added
 Fixed
 ^^^^^
 - ``MigrationRecorder`` now uses parameterized queries; fixes MariaDB/MySQL rejecting ISO-8601 ``applied_at`` values. (#2132)
-- ``QuerySet.count()`` now matches the limited query result for the LIMIT/OFFSET edge cases: it returns ``0`` (instead of a negative number) when ``offset()`` exceeds the total row count, and ``0`` (instead of the total) for ``limit(0)``.
+- ``QuerySet.count()`` now matches the limited query result for the LIMIT/OFFSET edge cases: it returns ``0`` (instead of a negative number) when ``offset()`` exceeds the total row count, and ``0`` (instead of the total) for ``limit(0)``. (#2208)
 
 1.1.7
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Added
 Fixed
 ^^^^^
 - ``MigrationRecorder`` now uses parameterized queries; fixes MariaDB/MySQL rejecting ISO-8601 ``applied_at`` values. (#2132)
+- ``QuerySet.count()`` now matches the limited query result for the LIMIT/OFFSET edge cases: it returns ``0`` (instead of a negative number) when ``offset()`` exceeds the total row count, and ``0`` (instead of the total) for ``limit(0)``.
 
 1.1.7
 -----

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -93,9 +93,7 @@ async def test_limit_zero_count(db, intfields_data):
     # limit(0) means zero rows, so count() must be 0 (not the total), matching
     # the actual limited query.
     assert await IntFields.all().limit(0).count() == 0
-    assert await IntFields.all().limit(0).count() == len(
-        await IntFields.all().limit(0)
-    )
+    assert await IntFields.all().limit(0).count() == len(await IntFields.all().limit(0))
 
 
 @pytest.mark.asyncio
@@ -121,9 +119,7 @@ async def test_offset_count_beyond_total(db, intfields_data):
     # An offset past the total must report 0, not a negative count (the SQL
     # LIMIT/OFFSET would return zero rows).
     assert await IntFields.all().offset(100).count() == 0
-    assert await IntFields.all().offset(100).count() == len(
-        await IntFields.all().offset(100)
-    )
+    assert await IntFields.all().offset(100).count() == len(await IntFields.all().offset(100))
 
 
 @pytest.mark.asyncio

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -89,6 +89,16 @@ async def test_limit_count(db, intfields_data):
 
 
 @pytest.mark.asyncio
+async def test_limit_zero_count(db, intfields_data):
+    # limit(0) means zero rows, so count() must be 0 (not the total), matching
+    # the actual limited query.
+    assert await IntFields.all().limit(0).count() == 0
+    assert await IntFields.all().limit(0).count() == len(
+        await IntFields.all().limit(0)
+    )
+
+
+@pytest.mark.asyncio
 async def test_limit_negative(db, intfields_data):
     with pytest.raises(ParamsError, match="Limit should be non-negative number"):
         await IntFields.all().limit(-10)
@@ -104,6 +114,16 @@ async def test_limit_zero(db, intfields_data):
 @pytest.mark.asyncio
 async def test_offset_count(db, intfields_data):
     assert await IntFields.all().offset(10).count() == 20
+
+
+@pytest.mark.asyncio
+async def test_offset_count_beyond_total(db, intfields_data):
+    # An offset past the total must report 0, not a negative count (the SQL
+    # LIMIT/OFFSET would return zero rows).
+    assert await IntFields.all().offset(100).count() == 0
+    assert await IntFields.all().offset(100).count() == len(
+        await IntFields.all().offset(100)
+    )
 
 
 @pytest.mark.asyncio

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -1571,8 +1571,13 @@ class CountQuery(AwaitableQuery):
         _, result = await self._db.execute_query(*self.query.get_parameterized_sql())
         if not result:
             return 0
-        count = list(dict(result[0]).values())[0] - self._offset
-        if self._limit and count > self._limit:
+        # COUNT(*) ignores LIMIT/OFFSET, so the offset is applied here. Clamp at
+        # 0: when the offset is past the total, SQL would return 0 rows, not a
+        # negative count.
+        count = max(0, list(dict(result[0]).values())[0] - self._offset)
+        # Use ``is not None`` so an explicit ``limit(0)`` clamps to 0 instead of
+        # being treated as "no limit" by a truthiness check.
+        if self._limit is not None and count > self._limit:
             return self._limit
         return count
 


### PR DESCRIPTION
## Description

`QuerySet.count()` returns a **negative** number when `offset()` is larger than the total row count.

`COUNT(*)` ignores `LIMIT`/`OFFSET`, so `CountQuery` applies the offset in Python by subtracting it (`tortoise/queryset.py`):

```python
count = list(dict(result[0]).values())[0] - self._offset
```

When `offset > total`, this goes negative. For example, with 5 rows:

```python
await Item.all().offset(100).count()        # -> -95
len(await Item.all().offset(100))           # ->  0   (what SQL LIMIT/OFFSET actually returns)
```

The fix clamps the result at `0`, matching the row count the equivalent query would actually return.

## Motivation and Context

A count should never be negative; callers using `.offset(...).count()` (e.g. for pagination "remaining" math) get a nonsensical value.

## How Has This Been Tested

Added `test_offset_count_beyond_total` in `tests/test_queryset.py`: with the 30-row `IntFields` fixture, `offset(100).count()` must equal `0` and match `len(await ...offset(100))`. It fails before the fix (`-70`) and passes after. Added a `CHANGELOG.rst` entry under 1.1.8 → Fixed.
