### PR TITLE
docs: update contributing checks

### DIFF
--- a/docs/CONTRIBUTING.rst
+++ b/docs/CONTRIBUTING.rst
@@ -84,7 +84,7 @@ As this is a value that is different for different people, we have settled on:
 Style
 -----
 
-We try and automate as much as we can, so a simple ``make check`` will do automated style checking and linting, but these don't pick up on the non-obvious style preferences.
+We try and automate as much as we can, so a simple ``make check`` or ``pre-commit run --all-files`` will do automated style checking and linting, but these don't pick up on the non-obvious style preferences.
 
 Tortoise ORM follows a the following agreed upon style:
 


### PR DESCRIPTION
  ## Description

 Update the contribution guide to mention `pre-commit run --all-files` as an alternative way to run automated style and lint checks alongside `make check`.

  ## Motivation and Context

  The repository already provides a `.pre-commit-config.yaml` and documents `pre-commit install` in the development setup flow.
  Mentioning `pre-commit run --all-files` gives contributors a clearer way to manually run the configured hooks across the project.

  ## How Has This Been Tested?

  Ran:

  - `git diff --check`
  - `pre-commit run --files docs/CONTRIBUTING.rst`

  ## Checklist:

  - [x] My code follows the code style of this project.
  - [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
  - [ ] I have added the changelog accordingly.
  - [x] I have read the **CONTRIBUTING** document.
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.