### PR TITLE
Fix invalid SQL on DELETE with backward relations/joins

### DIFF
--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -1428,18 +1428,55 @@ class DeleteQuery(AwaitableQuery):
 
     def _make_query(self) -> None:
         self.query = copy(self.model._meta.basequery)
-        if self.capabilities.support_update_limit_order_by and self._limit:
-            self.query._limit = self.query._wrapper_cls(self._limit)
+        self.resolve_filters()
+        
+        # If joins are detected, rewrite into an IN subquery to avoid JOINs in DELETE
+        if self._joined_tables:
+            pk_column = self.model._meta.db_pk_column
+            
+            # Create a pristine, completely separate SELECT query builder
+            subquery = self._db.query_class.from_(self.model._meta.basetable).select(
+                self.model._meta.basetable[pk_column]
+            )
+            
+            # Transfer the resolved wheres and havings criteria from our filter resolution
+            subquery._wheres = self.query._wheres
+            subquery._havings = self.query._havings
+            
+            # Apply joins directly to the subquery builder
+            subquery._joins = self.query._joins
+            
+            # Re-apply limits and sorting to the subquery if needed
+            if self._limit:
+                subquery._limit = subquery._wrapper_cls(self._limit)
+                
             self.resolve_ordering(
                 model=self.model,
                 table=self.model._meta.basetable,
                 orderings=self._orderings,
                 annotations=self._annotations,
             )
-        self.resolve_filters()
+            subquery._orderbys = self.query._orderbys
+            
+            # Reconstruct clean pristine delete statement pointing to our subquery
+            self.query = copy(self.model._meta.basequery)
+            self.query = self.query.where(
+                self.model._meta.basetable[pk_column].isin(subquery)
+            )
+        else:
+            # Traditional optimization path if no backward relations/joins exist
+            if self.capabilities.support_update_limit_order_by and self._limit:
+                self.query._limit = self.query._wrapper_cls(self._limit)
+                self.resolve_ordering(
+                    model=self.model,
+                    table=self.model._meta.basetable,
+                    orderings=self._orderings,
+                    annotations=self._annotations,
+                )
+
         self.query._delete_from = True
         return
-
+    
     def __await__(self) -> Generator[Any, None, int]:
         self._choose_db_if_not_chosen(True)
         self._make_query()

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -1429,27 +1429,27 @@ class DeleteQuery(AwaitableQuery):
     def _make_query(self) -> None:
         self.query = copy(self.model._meta.basequery)
         self.resolve_filters()
-        
+
         # If joins are detected, rewrite into an IN subquery to avoid JOINs in DELETE
         if self._joined_tables:
             pk_column = self.model._meta.db_pk_column
-            
+
             # Create a pristine, completely separate SELECT query builder
             subquery = self._db.query_class.from_(self.model._meta.basetable).select(
                 self.model._meta.basetable[pk_column]
             )
-            
+
             # Transfer the resolved wheres and havings criteria from our filter resolution
             subquery._wheres = self.query._wheres
             subquery._havings = self.query._havings
-            
+
             # Apply joins directly to the subquery builder
             subquery._joins = self.query._joins
-            
+
             # Re-apply limits and sorting to the subquery if needed
             if self._limit:
                 subquery._limit = subquery._wrapper_cls(self._limit)
-                
+
             self.resolve_ordering(
                 model=self.model,
                 table=self.model._meta.basetable,
@@ -1457,12 +1457,10 @@ class DeleteQuery(AwaitableQuery):
                 annotations=self._annotations,
             )
             subquery._orderbys = self.query._orderbys
-            
+
             # Reconstruct clean pristine delete statement pointing to our subquery
             self.query = copy(self.model._meta.basequery)
-            self.query = self.query.where(
-                self.model._meta.basetable[pk_column].isin(subquery)
-            )
+            self.query = self.query.where(self.model._meta.basetable[pk_column].isin(subquery))
         else:
             # Traditional optimization path if no backward relations/joins exist
             if self.capabilities.support_update_limit_order_by and self._limit:
@@ -1476,7 +1474,7 @@ class DeleteQuery(AwaitableQuery):
 
         self.query._delete_from = True
         return
-    
+
     def __await__(self) -> Generator[Any, None, int]:
         self._choose_db_if_not_chosen(True)
         self._make_query()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Refactored the `DeleteQuery._make_query` method to handle deletions when filtering across relations or implicit filters that require a table `JOIN`. 

Modern SQL backends like PostgreSQL and SQLite do not natively support standard `DELETE FROM table LEFT JOIN ...` syntax. This fix detects if joins are present (`self._joined_tables`) and refactors the statement into a clean, isolated `IN` subquery fallback.

## Motivation and Context

This fixes an issue where running a `.delete()` on queries involving backward relations or joined filters throws an operational/syntax error on PostgreSQL and SQLite

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

- Verified that simple deletes continue to use the optimized, direct standard execution path.
- Verified that deletes involving table joins successfully refactor into the `WHERE id IN (SELECT ...)` subquery format and execute without syntax errors
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have added the changelog accordingly.

