### PR TITLE
feat: deprecate implicit on_delete default in ForeignKeyField, OneToOneField, ManyToManyField

### DIFF
--- a/tortoise/fields/relational.py
+++ b/tortoise/fields/relational.py
@@ -16,6 +16,8 @@ if TYPE_CHECKING:  # pragma: nocoverage
 
 MODEL = TypeVar("MODEL", bound="Model")
 
+_UNSET: object = object()  # sentinel for detecting omitted on_delete
+
 
 class _NoneAwaitable:
     __slots__ = ()
@@ -317,13 +319,21 @@ class ForeignKeyFieldInstance(RelationalField[MODEL]):
         self,
         model_name: type[Model] | str,
         related_name: str | None | Literal[False] = None,
-        on_delete: OnDelete = CASCADE,
+        on_delete: OnDelete = _UNSET,  # type: ignore[assignment]
         **kwargs: Any,
     ) -> None:
         super().__init__(None, **kwargs)  # type:ignore[arg-type]
         self.validate_model_name(model_name)
         self.model_name = model_name
         self.related_name = related_name
+        if on_delete is _UNSET:
+            warnings.warn(
+                "Not passing `on_delete` to ForeignKeyField is deprecated and will be an error "
+                "in a future release. Pass `on_delete` explicitly (e.g. on_delete=fields.CASCADE).",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            on_delete = CASCADE
         if on_delete not in set(OnDelete):
             raise ConfigurationError(
                 "on_delete can only be CASCADE, RESTRICT, SET_NULL, SET_DEFAULT or NO_ACTION"
@@ -360,7 +370,7 @@ class OneToOneFieldInstance(ForeignKeyFieldInstance[MODEL]):
         self,
         model_name: type[MODEL] | str,
         related_name: str | None | Literal[False] = None,
-        on_delete: OnDelete = CASCADE,
+        on_delete: OnDelete = _UNSET,  # type: ignore[assignment]
         **kwargs: Any,
     ) -> None:
         super().__init__(model_name, related_name, on_delete, unique=True, **kwargs)
@@ -386,7 +396,7 @@ class ManyToManyFieldInstance(RelationalField[MODEL]):
         forward_key: str | None = None,
         backward_key: str = "",
         related_name: str = "",
-        on_delete: OnDelete = CASCADE,
+        on_delete: OnDelete = _UNSET,  # type: ignore[assignment]
         field_type: type[MODEL] = None,  # type: ignore
         unique: bool = True,
         **kwargs: Any,
@@ -400,6 +410,14 @@ class ManyToManyFieldInstance(RelationalField[MODEL]):
                 stacklevel=2,
             )
             unique = kwargs.pop("create_unique_index")
+        if on_delete is _UNSET:
+            warnings.warn(
+                "Not passing `on_delete` to ManyToManyField is deprecated and will be an error "
+                "in a future release. Pass `on_delete` explicitly (e.g. on_delete=fields.CASCADE).",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            on_delete = CASCADE
         super().__init__(field_type, unique=unique, **kwargs)
         self.validate_model_name(model_name)
         self.model_name = model_name
@@ -459,7 +477,7 @@ def OneToOneField(
 def OneToOneField(
     to: type[MODEL] | str,
     related_name: str | None | Literal[False] = None,
-    on_delete: OnDelete = CASCADE,
+    on_delete: OnDelete = _UNSET,  # type: ignore[assignment]
     db_constraint: bool = True,
     null: bool = False,
     **kwargs: Any,
@@ -534,7 +552,7 @@ def ForeignKeyField(
 def ForeignKeyField(
     to: type[MODEL] | str,
     related_name: str | None | Literal[False] = None,
-    on_delete: OnDelete = CASCADE,
+    on_delete: OnDelete = _UNSET,  # type: ignore[assignment]
     db_constraint: bool = True,
     null: bool = False,
     **kwargs: Any,
@@ -589,7 +607,7 @@ def ManyToManyField(
     forward_key: str | None = None,
     backward_key: str = "",
     related_name: str = "",
-    on_delete: OnDelete = CASCADE,
+    on_delete: OnDelete = _UNSET,  # type: ignore[assignment]
     db_constraint: bool = True,
     unique: bool = True,
     **kwargs: Any,


### PR DESCRIPTION
## Summary

Closes #1801.

`ForeignKeyField`, `OneToOneField`, and `ManyToManyField` silently defaulted `on_delete` to `CASCADE`. This is dangerous — a developer who forgets to set `on_delete` may inadvertently cascade-delete data they didn't intend to.

This PR adds a `DeprecationWarning` when `on_delete` is omitted, making the implicit behaviour visible and encouraging explicit intent. The default behaviour is preserved for now to avoid a breaking change.

## Changes

- Added `_UNSET` sentinel in `tortoise/fields/relational.py` to detect when `on_delete` is not passed
- `ForeignKeyFieldInstance.__init__`: emits `DeprecationWarning` when `on_delete` is not explicitly provided
- `OneToOneFieldInstance.__init__`: same (delegates to `ForeignKeyFieldInstance`)
- `ManyToManyFieldInstance.__init__`: same
- All three public factory functions (`ForeignKeyField`, `OneToOneField`, `ManyToManyField`) updated to use the sentinel as default
- `@overload` signatures are unchanged (type checkers still see `OnDelete = CASCADE`) so no type-checking regressions

## Before / After

```python
# Before — silent CASCADE, no indication this is dangerous
class MyModel(Model):
    user = fields.ForeignKeyField("models.User")  # silently cascades on delete

# After — explicit warning shown at import/class-definition time
# DeprecationWarning: Not passing `on_delete` to ForeignKeyField is deprecated and will be an
# error in a future release. Pass `on_delete` explicitly (e.g. on_delete=fields.CASCADE).

# Correct usage going forward:
class MyModel(Model):
    user = fields.ForeignKeyField("models.User", on_delete=fields.CASCADE)
```

## Notes

- Backward compatible: existing code still works, just warns
- The warning fires at model class definition time (not at query time), so it's easy to catch
- Future release can make `on_delete` truly required by removing the sentinel fallback
