### PR TITLE
refactor(migrations): reduce branch complexity in executor and operation_generator

### DIFF
--- a/tortoise/migrations/schema_generator/operation_generator.py
+++ b/tortoise/migrations/schema_generator/operation_generator.py
@@ -62,6 +62,21 @@ class OperationGenerator:
         )
 
     @staticmethod
+    def _dependency_key_for_field(field: object) -> ModelKey | None:
+        if not isinstance(field, (ForeignKeyFieldInstance, ManyToManyFieldInstance)):
+            return None
+        ref = getattr(field, "model_name", None)
+        if not ref:
+            return None
+        if isinstance(ref, str):
+            parts = ref.split(".")
+            if len(parts) != 2:
+                return None
+            return parts[0], parts[1]
+        # model_name is a model class
+        return getattr(ref._meta, "app", ""), ref.__name__
+
+    @staticmethod
     def _sort_by_dependencies(keys: list[ModelKey], state: State) -> list[ModelKey]:
         """Sort model keys so that FK/M2M dependencies come before dependents."""
         key_set = set(keys)
@@ -70,21 +85,8 @@ class OperationGenerator:
         for key in keys:
             model_state = state.models[key]
             for field in model_state.fields.values():
-                if not isinstance(field, (ForeignKeyFieldInstance, ManyToManyFieldInstance)):
-                    continue
-                ref = getattr(field, "model_name", None)
-                if not ref:
-                    continue
-                if isinstance(ref, str):
-                    parts = ref.split(".")
-                    if len(parts) == 2:
-                        dep_key: ModelKey = (parts[0], parts[1])
-                    else:
-                        continue
-                else:
-                    # model_name is a model class
-                    dep_key = (getattr(ref._meta, "app", ""), ref.__name__)
-                if dep_key in key_set and dep_key != key:
+                dep_key = OperationGenerator._dependency_key_for_field(field)
+                if dep_key and dep_key in key_set and dep_key != key:
                     deps[key].add(dep_key)
 
         # Kahn's algorithm


### PR DESCRIPTION
## Description
This PR refactors `MigrationExecutor.migrate` and `OperationGenerator._sort_by_dependencies` to address `R0912` (too-many-branches). Complex conditional structures were decomposed.

## Motivation and Context
High cyclomatic complexity was hindering code clarity and maintainability.

## How Has This Been Tested?
- Ran the existing migration and dependency test suite in a local environment.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.