### PR TITLE
Fix TSVectorField returned value conversion

### DIFF
--- a/tests/contrib/postgres/test_tsvector_field.py
+++ b/tests/contrib/postgres/test_tsvector_field.py
@@ -22,3 +22,13 @@ async def test_tsvector_generated_sql(db_tsvector):
         "GENERATED ALWAYS AS (SETWEIGHT(TO_TSVECTOR('english',COALESCE(\"title\", '')),'A')"
         " || SETWEIGHT(TO_TSVECTOR('english',COALESCE(\"body\", '')),'B')) STORED"
     )
+
+
+@pytest.mark.asyncio
+async def test_tsvector_generated_field_save(db_tsvector):
+    """Test TSVector generated fields can be returned after insert."""
+    skip_if_not_postgres()
+    entry = await TSVectorEntry.create(title="Tortoise ORM", body="Async Python ORM")
+
+    assert isinstance(entry.search_vector, str)
+    assert entry.search_vector

--- a/tortoise/contrib/postgres/fields.py
+++ b/tortoise/contrib/postgres/fields.py
@@ -7,8 +7,9 @@ from tortoise.exceptions import ConfigurationError
 from tortoise.fields import Field
 
 
-class TSVectorField(Field):
+class TSVectorField(Field[str]):
     SQL_TYPE = "TSVECTOR"
+    field_type = str
     allows_generated = True
 
     def __init__(


### PR DESCRIPTION
## Summary

Fixes #2204.

`TSVectorField` now declares its Python field type as `str`, so generated TSVECTOR values returned by PostgreSQL after insert can pass through `to_python_value()` without raising `TypeError`.

## Root Cause

`TSVectorField` inherited the base `Field` default `field_type`, which is not a valid runtime type for `isinstance()`. PostgreSQL returns generated columns after insert, and the returned TSVECTOR value is converted through `field_object.to_python_value(val)`, triggering `isinstance(value, self.field_type)`.

## Changes

- Type `TSVectorField` as `Field[str]`
- Set `TSVectorField.field_type = str`
- Add a regression test that creates a model with a generated `TSVectorField` and asserts the returned field is a non-empty string

## Validation

- `uv run python - <<'PY' ... PY` lightweight conversion check passed
- `uv run ruff check tortoise/contrib/postgres/fields.py tests/contrib/postgres/test_tsvector_field.py` passed
- `uv run --group test --extra asyncpg pytest tests/contrib/postgres/test_tsvector_field.py -q` ran, but skipped locally because `TORTOISE_TEST_DB` is not configured for PostgreSQL