### PR TITLE
Fix filtering by FK instance to use to_field instead of pk

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Added
 
 Fixed
 ^^^^^
+- Filtering by a related model instance on a ``ForeignKeyField``/``OneToOneField`` declared with a non-primary-key ``to_field`` now uses the ``to_field`` value instead of the instance's primary key, so the generated query targets the correct column. (#2225)
 - ``MigrationRecorder`` now uses parameterized queries; fixes MariaDB/MySQL rejecting ISO-8601 ``applied_at`` values. (#2132)
 - ``db_default`` on ``ForeignKeyField``/``OneToOneField`` now propagates to the underlying ``<fk>_id`` column, so ``CREATE TABLE`` emits the ``DEFAULT`` clause for FK columns. (#2199)
 - ``MigrationRecorder`` no longer emits tortoise's own ``pk`` field ``DeprecationWarning`` when applying migrations; it now builds its bookkeeping model with ``primary_key=True``. (#2203)

--- a/tests/test_relations_with_unique.py
+++ b/tests/test_relations_with_unique.py
@@ -44,3 +44,19 @@ async def test_relation_with_unique(db):
     assert fetched_principal.name == "Sang-Heon Jeon3"
     fetched_school = await School.filter(name="School1").prefetch_related("principal").first()
     assert fetched_school.name == "School1"
+
+
+@pytest.mark.asyncio
+async def test_filter_by_fk_instance_uses_to_field(db):
+    # https://github.com/tortoise/tortoise-orm/issues/2225
+    # School's primary key is `uuid`, but Student.school points to to_field="id"
+    # (a non-PK unique field). Filtering by a School instance must use the
+    # `to_field` value (school.id), not the primary key (school.uuid).
+    school = await School.create(id=42, name="School1")
+    await Student.create(name="Sang-Heon Jeon1", school=school)
+
+    assert school.pk != school.id
+
+    found = await Student.filter(school=school).first()
+    assert found is not None
+    assert found.name == "Sang-Heon Jeon1"

--- a/tortoise/expressions.py
+++ b/tortoise/expressions.py
@@ -437,9 +437,10 @@ class Q:
             key in resolve_context.model._meta.fk_fields
             or key in resolve_context.model._meta.o2o_fields
         ):
-            field_object = resolve_context.model._meta.fields_map[key]
+            field_object = cast(RelationalField, resolve_context.model._meta.fields_map[key])
             filter_key = cast(str, field_object.source_field)
-            filter_value = getattr(value, "pk", value)
+            to_field_name = field_object.to_field_instance.model_field_name
+            filter_value = getattr(value, to_field_name, value)
         elif key in resolve_context.model._meta.m2m_fields:
             filter_value = getattr(value, "pk", value)
         elif (


### PR DESCRIPTION
Fixes #2225

When a `ForeignKeyField`/`OneToOneField` is declared with a `to_field` that points to a non-primary-key column, filtering by a related model instance used the instance's primary key instead of the `to_field` value.

In `Q._get_actual_filter_params`, the fk/o2o branch did `filter_value = getattr(value, "pk", value)`, hardcoding `.pk`. So for a FK with `to_field="app_id"`, `Model.filter(fk=instance)` generated SQL comparing the `<fk>_id` column (which stores the `to_field` value) against `instance.pk`, targeting the wrong value and, when the types differ (e.g. a UUID pk vs an int `to_field`), raising type errors or silently returning wrong results.

This resolves the `to_field` column via `field_object.to_field_instance.model_field_name` and reads that attribute off the instance. For the default case where `to_field` is the primary key, `to_field_instance.model_field_name` is the pk attribute, so `getattr` returns `value.pk` exactly as before; raw-value filters (`filter(fk=7)`) still fall through to the value via `getattr`'s default.

The existing test models already expose this shape: `School`'s primary key is `uuid`, while `Student.school` uses `to_field="id"` (a non-pk unique field). The added regression test in `tests/test_relations_with_unique.py` creates a `School` whose `id` differs from its pk and asserts `Student.filter(school=school)` finds the student; it fails on the current code (filters by the pk) and passes with this change. The full `test_relations` and `test_relations_with_unique` suites pass.
