### PR TITLE
docs: add complex query example with grouping and date filters

### DIFF
--- a/docs/query.rst
+++ b/docs/query.rst
@@ -179,33 +179,40 @@ last 31 days can be written as:
 
 .. code-block:: python3
 
-    from datetime import datetime, timedelta, timezone
+    from datetime import date, timedelta
     from tortoise.functions import Sum
 
-    now = datetime.now(timezone.utc)
-    since = now - timedelta(days=31)
+    today = date.today()
+    since = today - timedelta(days=31)
 
     results = await (
-        Statistic.filter(date__gte=since, date__lte=now)
+        Statistic.filter(date__gte=since, date__lte=today)
         .annotate(post=Sum("posts"), fines=Sum("fine"))
-        .group_by("uid", "date")
+        .group_by("uid")
         .order_by("-post")
-        .values("uid", "post", "fines", "date")
+        .values("uid", "post", "fines")
     )
 
 This is roughly equivalent to the following SQL:
 
 .. code-block:: sql
 
-    SELECT uid, SUM(posts) AS post, SUM(fine) AS fines, date
+    SELECT uid, SUM(posts) AS post, SUM(fine) AS fines
     FROM statistic
-    WHERE date >= NOW() - INTERVAL '31 days' AND date <= NOW()
-    GROUP BY uid, date
+    WHERE date >= CURRENT_DATE - INTERVAL '31 days' AND date <= CURRENT_DATE
+    GROUP BY uid
     ORDER BY post DESC
 
 .. note::
 
     ``.group_by()`` must be called before ``.values()`` or ``.values_list()``.
+
+    The original issue included ``date`` in the ``SELECT`` list while grouping
+    only by ``uid``. To aggregate per ``uid`` across the whole date range, the
+    example above omits ``date`` from both ``GROUP BY`` and ``values``. The
+    filter values are plain dates, which is appropriate when ``date`` is a
+    ``DateField``; use ``datetime.now()`` instead if your field is a
+    ``DateTimeField``.
 
 .. _foreign_key:
 

--- a/docs/query.rst
+++ b/docs/query.rst
@@ -170,6 +170,42 @@ QuerySet also supports aggregation and database functions through ``.annotate()`
 
 Check `examples <https://github.com/tortoise/tortoise-orm/tree/master/examples>`_ to see it all in work
 
+Complex queries
+===============
+
+You can combine annotations, filters and grouping to express more complex SQL.
+For example, a query that aggregates ``posts`` and ``fine`` per ``uid`` over the
+last 31 days can be written as:
+
+.. code-block:: python3
+
+    from datetime import datetime, timedelta
+    from tortoise.functions import Sum
+
+    since = datetime.utcnow() - timedelta(days=31)
+
+    results = await (
+        Statistic.filter(date__gte=since, date__lte=datetime.utcnow())
+        .annotate(post=Sum("posts"), fines=Sum("fine"))
+        .group_by("uid")
+        .order_by("-post")
+        .values("uid", "post", "fines", "date")
+    )
+
+This is roughly equivalent to the following SQL:
+
+.. code-block:: sql
+
+    SELECT uid, SUM(posts) AS post, SUM(fine) AS fines, date
+    FROM statistic
+    WHERE date >= NOW() - INTERVAL '31 days' AND date <= NOW()
+    GROUP BY uid
+    ORDER BY post DESC
+
+.. note::
+
+    ``.group_by()`` must be called before ``.values()`` or ``.values_list()``.
+
 .. _foreign_key:
 
 Foreign Key

--- a/docs/query.rst
+++ b/docs/query.rst
@@ -179,15 +179,16 @@ last 31 days can be written as:
 
 .. code-block:: python3
 
-    from datetime import datetime, timedelta
+    from datetime import datetime, timedelta, timezone
     from tortoise.functions import Sum
 
-    since = datetime.utcnow() - timedelta(days=31)
+    now = datetime.now(timezone.utc)
+    since = now - timedelta(days=31)
 
     results = await (
-        Statistic.filter(date__gte=since, date__lte=datetime.utcnow())
+        Statistic.filter(date__gte=since, date__lte=now)
         .annotate(post=Sum("posts"), fines=Sum("fine"))
-        .group_by("uid")
+        .group_by("uid", "date")
         .order_by("-post")
         .values("uid", "post", "fines", "date")
     )
@@ -199,7 +200,7 @@ This is roughly equivalent to the following SQL:
     SELECT uid, SUM(posts) AS post, SUM(fine) AS fines, date
     FROM statistic
     WHERE date >= NOW() - INTERVAL '31 days' AND date <= NOW()
-    GROUP BY uid
+    GROUP BY uid, date
     ORDER BY post DESC
 
 .. note::


### PR DESCRIPTION
Fixes #418

Issue #418 asked how to write a report-style query in Tortoise that mirrors a raw SQL aggregation over a date range. The original example summed posts and fine per uid, filtered to the last 31 days, grouped by uid, and ordered by the aggregated sum. grigi noted in the thread that Tortoise didn't expose date-manipulation filters at the time, and the existing docs didn't show how to wire together annotate, filter, group_by, and values for this kind of query. They also pointed to Tortoise.get_connection('default').execute_query_dict(...) as a raw-SQL escape hatch, which we documented separately, but a first-party ORM example was still missing.

This change adds a "Complex queries" section to docs/query.rst with a concrete, copy-pasteable example. It uses date__gte and date__lte with plain date values, which avoids depending on database-specific date arithmetic and matches the DateField case from the report. The original SQL selected date while grouping only by uid; on strict databases that runs into the "column must appear in the GROUP BY clause or be used in an aggregate function" problem (see #359), so the example aggregates across the full date range and returns only uid, post, and fines. A note reminds readers to use datetime.now() instead of date.today() when the field is a DateTimeField, and that group_by() must come before values() or values_list().

I built the docs locally and confirmed the new section renders correctly.