### PR TITLE
ci: pin third-party actions to full commit SHAs (matching the existing setup-uv pin)

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -26,7 +26,7 @@ jobs:
         run: make build
 
       - name: Run benchmarks
-        uses: CodSpeedHQ/action@v3
+        uses: CodSpeedHQ/action@76578c2a7ddd928664caa737f0e962e3085d4e7c # v3.8.1
         with:
           token: ${{ secrets.CODSPEED_TOKEN }}
           run: uv run --frozen pytest tests/benchmarks --codspeed

--- a/.github/workflows/gh-pages-release.yml
+++ b/.github/workflows/gh-pages-release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Build docs
         run: make docs
       - name: Deploy release docs
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3.9.3
         with:
           personal_token: ${{ secrets.PERSONAL_TOKEN }}
           publish_dir: build/html

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Build docs
         run: make docs
       - name: Deploy latest docs
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3.9.3
         with:
           personal_token: ${{ secrets.PERSONAL_TOKEN }}
           publish_dir: build/html

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Build dists
         run: make build
       - name: Pypi Publish
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d # v1.14.0
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
Hi, and thank you for Tortoise ORM.

CI supply-chain hardening that matches a practice you already follow. Every workflow already SHA-pins `astral-sh/setup-uv` (`…08807647… # v8.1.0`), but four third-party actions in secret-bearing jobs are still on mutable refs:

- `peaceiris/actions-gh-pages@v3` (×2, holds `PERSONAL_TOKEN` that pushes to `tortoise/tortoise.github.io`)
- `CodSpeedHQ/action@v3` (holds `CODSPEED_TOKEN`)
- `pypa/gh-action-pypi-publish@release/v1` (a mutable **branch**, holds `pypi_password`)

This PR pins each to the commit its current ref points at, with a version comment — same style as your setup-uv pin. I stayed on the v3 line for the two `@v3` actions (no major-version change) and used the current v1 release for pypi-publish. Dependabot's `github-actions` ecosystem can bump these going forward.

Verified SHAs: peaceiris v3.9.3 `373f7f2…`, CodSpeed v3.8.1 `76578c2…`, pypi-publish v1.14.0 `6733eb7…`.

For transparency: I used AI assistance to spot and draft this; I verified the refs and resolved the SHAs myself.
