### PR TITLE
fix(queryset): preserve select_for_update in values and values_list

### DIFF
--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -777,6 +777,19 @@ async def test_select_for_update(db, intfields_data):
 
 
 @pytest.mark.asyncio
+async def test_select_for_update_values(db, intfields_data):
+    qs = IntFields.filter(pk=1)
+    object.__setattr__(qs.capabilities, "_mutable", True)
+    qs.capabilities.support_for_update = True
+    sql_values = qs.select_for_update().values("id").sql()
+    sql_values_list = qs.select_for_update().values_list("id", flat=True).sql()
+
+    assert "FOR UPDATE" in sql_values
+    assert "FOR UPDATE" in sql_values_list
+
+
+
+@pytest.mark.asyncio
 async def test_select_related(db):
     tournament = await Tournament.create(name="1")
     reporter = await Reporter.create(name="Reporter")

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -788,7 +788,6 @@ async def test_select_for_update_values(db, intfields_data):
     assert "FOR UPDATE" in sql_values_list
 
 
-
 @pytest.mark.asyncio
 async def test_select_related(db):
     tournament = await Tournament.create(name="1")

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -698,6 +698,11 @@ class QuerySet(AwaitableQuery[MODEL]):
             group_bys=self._group_bys,
             force_indexes=self._force_indexes,
             use_indexes=self._use_indexes,
+            select_for_update=self._select_for_update,
+            select_for_update_nowait=self._select_for_update_nowait,
+            select_for_update_skip_locked=self._select_for_update_skip_locked,
+            select_for_update_of=self._select_for_update_of,
+            select_for_update_no_key=self._select_for_update_no_key,
         )
 
     def values(self, *args: str, **kwargs: str) -> ValuesQuery[Literal[False]]:
@@ -753,6 +758,11 @@ class QuerySet(AwaitableQuery[MODEL]):
             group_bys=self._group_bys,
             force_indexes=self._force_indexes,
             use_indexes=self._use_indexes,
+            select_for_update=self._select_for_update,
+            select_for_update_nowait=self._select_for_update_nowait,
+            select_for_update_skip_locked=self._select_for_update_skip_locked,
+            select_for_update_of=self._select_for_update_of,
+            select_for_update_no_key=self._select_for_update_no_key,
         )
 
     def delete(self) -> DeleteQuery:
@@ -1709,6 +1719,11 @@ class ValuesListQuery(FieldSelectQuery, Generic[SINGLE]):
         "_force_indexes",
         "_use_indexes",
         "_fields_to_select_sql",
+        "_select_for_update",
+        "_select_for_update_nowait",
+        "_select_for_update_skip_locked",
+        "_select_for_update_of",
+        "_select_for_update_no_key",
     )
 
     def __init__(
@@ -1729,6 +1744,11 @@ class ValuesListQuery(FieldSelectQuery, Generic[SINGLE]):
         group_bys: tuple[str, ...],
         force_indexes: set[str],
         use_indexes: set[str],
+        select_for_update: bool = False,
+        select_for_update_nowait: bool = False,
+        select_for_update_skip_locked: bool = False,
+        select_for_update_of: set[str] | None = None,
+        select_for_update_no_key: bool = False,
     ) -> None:
         super().__init__(model, annotations)
         if flat and (len(fields_for_select_list) != 1):
@@ -1750,6 +1770,11 @@ class ValuesListQuery(FieldSelectQuery, Generic[SINGLE]):
         self._group_bys = group_bys
         self._force_indexes = force_indexes
         self._use_indexes = use_indexes
+        self._select_for_update = select_for_update
+        self._select_for_update_nowait = select_for_update_nowait
+        self._select_for_update_skip_locked = select_for_update_skip_locked
+        self._select_for_update_of = select_for_update_of or set()
+        self._select_for_update_no_key = select_for_update_no_key
         self._fields_to_select_sql = {
             *self._fields_for_select_list,
             *(key for key, value in self.fields.items() if value in self._fields_for_select_list),
@@ -1778,6 +1803,13 @@ class ValuesListQuery(FieldSelectQuery, Generic[SINGLE]):
             self.query._distinct = True
         if self._group_bys:
             self.query._groupbys = self._resolve_group_bys(*self._group_bys)
+        if self._select_for_update:
+            self.query = self.query.for_update(
+                self._select_for_update_nowait,
+                self._select_for_update_skip_locked,
+                self._select_for_update_of,
+                self._select_for_update_no_key,
+            )
 
         if self._force_indexes:
             self.query._force_indexes = []
@@ -1842,6 +1874,11 @@ class ValuesQuery(FieldSelectQuery, Generic[SINGLE]):
         "_group_bys",
         "_force_indexes",
         "_use_indexes",
+        "_select_for_update",
+        "_select_for_update_nowait",
+        "_select_for_update_skip_locked",
+        "_select_for_update_of",
+        "_select_for_update_no_key",
     )
 
     def __init__(
@@ -1861,6 +1898,11 @@ class ValuesQuery(FieldSelectQuery, Generic[SINGLE]):
         group_bys: tuple[str, ...],
         force_indexes: set[str],
         use_indexes: set[str],
+        select_for_update: bool = False,
+        select_for_update_nowait: bool = False,
+        select_for_update_skip_locked: bool = False,
+        select_for_update_of: set[str] | None = None,
+        select_for_update_no_key: bool = False,
     ) -> None:
         super().__init__(model, annotations)
         self._fields_for_select = fields_for_select
@@ -1876,6 +1918,11 @@ class ValuesQuery(FieldSelectQuery, Generic[SINGLE]):
         self._group_bys = group_bys
         self._force_indexes = force_indexes
         self._use_indexes = use_indexes
+        self._select_for_update = select_for_update
+        self._select_for_update_nowait = select_for_update_nowait
+        self._select_for_update_skip_locked = select_for_update_skip_locked
+        self._select_for_update_of = select_for_update_of or set()
+        self._select_for_update_no_key = select_for_update_no_key
 
     def _make_query(self) -> None:
         self._joined_tables = []
@@ -1906,6 +1953,13 @@ class ValuesQuery(FieldSelectQuery, Generic[SINGLE]):
             self.query._distinct = True
         if self._group_bys:
             self.query._groupbys = self._resolve_group_bys(*self._group_bys)
+        if self._select_for_update:
+            self.query = self.query.for_update(
+                self._select_for_update_nowait,
+                self._select_for_update_skip_locked,
+                self._select_for_update_of,
+                self._select_for_update_no_key,
+            )
 
         if self._force_indexes:
             self.query._force_indexes = []


### PR DESCRIPTION
Fixes #2250

When `values()` or `values_list()` was chained after `select_for_update()`, the select_for_update parameters were not passed to `ValuesQuery` / `ValuesListQuery`, causing the SQL generator to drop `FOR UPDATE` clauses and lose row locking behavior.

This change passes and preserves `select_for_update` parameters in `ValuesQuery` and `ValuesListQuery`.