### PR TITLE
fix: replace bare except with except Exception in sphinx autodoc typehints script

### DIFF
--- a/docs/sphinx_autodoc_typehints.py
+++ b/docs/sphinx_autodoc_typehints.py
@@ -53,10 +53,10 @@ def format_annotation(annotation, fully_qualified=False):
                 if 'ForwardRef(' in str(bound):
                     try:
                         bound = bound._evaluate(sys.modules[annotation.__module__].__dict__, None)
-                    except:
+                    except Exception:
                         try:
                             bound = bound._evaluate(type_globals.__dict__, None)
-                        except:
+                        except Exception:
                             bound = bound.__forward_arg__
                 return format_annotation(bound, fully_qualified)
             return f'\\{annotation!r}'
@@ -237,7 +237,7 @@ def get_all_type_hints(obj, name):
     except NameError as exc:
         try:
             rv = get_type_hints(obj, localns=type_globals.__dict__)
-        except:
+        except Exception:
             logger.warning('Cannot resolve forward reference in type annotations of "%s": %s',
                            name, exc)
             rv = obj.__annotations__


### PR DESCRIPTION
Replace 3 bare `except:` clauses in `docs/sphinx_autodoc_typehints.py` with `except Exception:` — same intended behavior (forward-reference evaluation fallbacks and warning logging), but KeyboardInterrupt/SystemExit are no longer intercepted first. Verified: `python -m py_compile` passes.