### PR TITLE
Split a comma-joined host list into a sequence for asyncpg

### DIFF
--- a/tests/backends/test_db_url.py
+++ b/tests/backends/test_db_url.py
@@ -154,6 +154,32 @@ def test_postgres_no_port():
         }
 
 
+def test_postgres_multi_host():
+    # asyncpg accepts a list of hosts for primary/replica failover, so a
+    # comma-joined host list has to be split into one for it; psycopg
+    # forwards its kwargs straight to libpq, which already understands the
+    # joined string on its own and would double-split it if we touched it.
+    for scheme, engine in _postgres_scheme_engines.items():
+        res = expand_db_url(
+            f"{scheme}://postgres:moo@host1.example.com,host2.example.com:54321/test"
+        )
+        expected_host = (
+            ["host1.example.com", "host2.example.com"]
+            if engine == "tortoise.backends.asyncpg"
+            else "host1.example.com,host2.example.com"
+        )
+        assert res == {
+            "engine": engine,
+            "credentials": {
+                "database": "test",
+                "host": expected_host,
+                "password": "moo",
+                "port": 54321,
+                "user": "postgres",
+            },
+        }
+
+
 def test_postgres_nonint_port():
     for scheme in _postgres_scheme_engines:
         with pytest.raises(ConfigurationError):

--- a/tortoise/backends/base/config_generator.py
+++ b/tortoise/backends/base/config_generator.py
@@ -200,7 +200,22 @@ def expand_db_url(db_url: str, testing: bool = False) -> dict:
     vmap.update(db["vmap"])
     params[vmap["path"]] = path
     if vmap.get("hostname"):
-        params[vmap["hostname"]] = url.hostname or None
+        plain_hostname = url.hostname or None
+        parsed_hostname: str | list[str] | None = plain_hostname
+        if (
+            plain_hostname
+            and "," in plain_hostname
+            and db_backend in ("postgres", "postgresql", "asyncpg")
+        ):
+            # A comma-joined host list (host1,host2:5432) is libpq's own
+            # multi-host syntax for primary/replica failover. psycopg
+            # forwards this string straight through to libpq, which already
+            # parses it correctly on its own, but asyncpg.connect() wants
+            # the hosts as an actual sequence rather than one string with
+            # asyncpg's own DNS resolution otherwise trying (and failing)
+            # to look up the whole comma-joined string as a single name.
+            parsed_hostname = plain_hostname.split(",")
+        params[vmap["hostname"]] = parsed_hostname
     try:
         if vmap.get("port") and url.port:
             params[vmap["port"]] = int(url.port)


### PR DESCRIPTION
## Description
A postgres DB URL with more than one host, e.g. `postgres://user:pass@host1,host2:5432/db`, is libpq's own multi-host syntax for primary/replica failover. `urlparse` reads the whole comma-joined string back as a single hostname, so `asyncpg.connect()` ended up being asked to resolve `host1,host2` as one DNS name and failed with a plain `socket.gaierror` instead of trying each host in turn.

`expand_db_url` now splits the hostname into a list when it contains a comma and the backend is one of `postgres`/`postgresql`/`asyncpg`, since that's the form asyncpg's own `host` parameter accepts for exactly this case (it documents accepting "a sequence" of hosts, tried in order). psycopg is left untouched: it forwards its kwargs straight to libpq, which already parses the joined string correctly on its own, so splitting it there would just make libpq see a Python list where it expects the original string.

## Motivation and Context
Fixes #1924

## How Has This Been Tested?
Added `test_postgres_multi_host` to `tests/backends/test_db_url.py`, covering all four postgres-family schemes (`postgres`, `postgresql`, `asyncpg`, `psycopg`) against the same multi-host URL, asserting the asyncpg-family schemes get a list and psycopg keeps the joined string. Confirmed via `git stash` that it fails against the unmodified code (asserts a list where the code still returns the joined string) and passes with the fix.

- `python -m pytest tests/backends/test_db_url.py tests/test_connection.py`: 59 passed.
- `ruff check` and `ruff format --check`: clean.
- `mypy` on the changed file: 0 errors.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
