### PR TITLE
fix: DecimalField no longer strips the scale it just quantized to

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Added
 Fixed
 ^^^^^
 - ``QuerySet.distinct().count()`` no longer counts rows duplicated by a join (e.g. filtering on a m2m relation); it now counts distinct primary keys and matches the number of rows the query returns. (#2255)
+- ``DecimalField`` no longer strips the scale it just applied: ``to_python_value()`` called ``.normalize()`` immediately after ``.quantize()``, so a ``DecimalField(max_digits=12, decimal_places=2)`` holding ``100.00`` came back as ``Decimal('1E+2')`` and rendered as ``1E+2`` in strings, f-strings and JSON. (#2271)
 
 1.1.8
 -----

--- a/tests/fields/test_decimal.py
+++ b/tests/fields/test_decimal.py
@@ -309,3 +309,34 @@ async def test_aggregate_max_with_f_expression(db):
         .values("max_decimal")
     )
     assert values[0] == {"max_decimal": None}
+
+
+@pytest.mark.asyncio
+async def test_scale_is_preserved(db):
+    # Decimal.__eq__ compares numerically, so `== Decimal("27.27")` cannot see
+    # the scale. Assert on the string form, which is what reaches a template,
+    # an f-string or a JSON serializer.
+    obj0 = await testmodels.DecimalFields.create(decimal=Decimal("100.00"), decimal_nodec=10)
+    obj = await testmodels.DecimalFields.get(id=obj0.id)
+    assert str(obj.decimal) == "100.0000"
+    assert str(obj.decimal_nodec) == "10"
+    assert obj.decimal.as_tuple().exponent == -4
+    assert obj.decimal_nodec.as_tuple().exponent == 0
+
+
+def test_to_python_value_scale():
+    field = fields.DecimalField(max_digits=12, decimal_places=2)
+    for value, expected in (
+        ("100.00", "100.00"),
+        ("100", "100.00"),
+        ("10", "10.00"),
+        ("1000000", "1000000.00"),
+        ("0", "0.00"),
+        ("1234.5", "1234.50"),
+        ("12.3456", "12.35"),
+    ):
+        assert str(field.to_python_value(value)) == expected
+
+    field0 = fields.DecimalField(max_digits=12, decimal_places=0)
+    assert str(field0.to_python_value("10")) == "10"
+    assert str(field0.to_python_value("100")) == "100"

--- a/tortoise/fields/data.py
+++ b/tortoise/fields/data.py
@@ -382,7 +382,7 @@ class DecimalField(Field[T_DECIMAL], Decimal):  # type: ignore
 
     def to_python_value(self, value: Any) -> Decimal | None:
         if value is not None:
-            value = Decimal(value).quantize(self.quant).normalize()
+            value = Decimal(value).quantize(self.quant)
         return value
 
     @property


### PR DESCRIPTION
`DecimalField.to_python_value` does `Decimal(value).quantize(self.quant).normalize()`. `quantize`
sets the scale to `decimal_places`; `normalize` on the same expression strips it again. So a
`DecimalField(max_digits=12, decimal_places=2)` holding `100.00` becomes `Decimal('1E+2')`:

```
to_python_value('100.00')   -> Decimal('1E+2')      str -> 1E+2      f'${...}' -> $1E+2
to_python_value('10')       -> Decimal('1E+1')      str -> 1E+1
to_python_value('1000000')  -> Decimal('1E+6')      str -> 1E+6
to_python_value('12.34')    -> Decimal('12.34')
```

`Model.__init__` runs `to_python_value` on user input too, so it is written that way as well — the
SQLite column literally holds `'1E+2'` — and `pydantic_model_creator` then emits
`{"id":1,"price":"1E+2"}`.

**I believe this is the cause of #1549** (open since 2024-01-23, reporter's example: created as
`200.00`, got `2E+2`). The workaround on that thread attributes it to "how the decimal field is
saved in the database"; it reproduces with no database at all, from `to_python_value` alone — the
DB row is `1E+2` *because* tortoise wrote it that way.

**Why the existing tests can't see it:** `tests/fields/test_decimal.py`
asserts through `obj.decimal == Decimal("…")`, and `Decimal.__eq__` compares numerically —
`Decimal('1E+2') == Decimal('100.00')` is `True`. The whole file passes with the defect live *and*
with it fixed. `test_aggregate_sum_with_f_expression` expects `Decimal("4E+1")` for forty, which is
the shape of a value transcribed from a run rather than written by hand. The new tests assert on
`str()` and on `as_tuple().exponent` instead.

**Mutants.** Reverting `tortoise/fields/data.py` against `origin/develop` and keeping the new tests
fails both of them. Dropping the `quantize` as well (the "stop transforming it" reading) fails 14
tests in `test_decimal.py` and 16 suite-wide — the quantize is load-bearing, only the `normalize` is
the defect.

**Run:** under the repo's own `make deps`, `pytest` → `1914 passed, 148 skipped, 2 xfailed, 0
failed` (2064 collected). An earlier version of this description reported `2 failed`; those were
`test_recursive` and `test_version` failing only because the package was not pip-installed, and they
are gone under `make deps`. `ruff format --check`, `ruff check` (0.15.4, the version in `uv.lock`)
and `mypy` are clean on the changed files. Verified end to end on **SQLite and PostgreSQL 17.9**.
MySQL, MSSQL and Oracle are untested here, though `to_python_value` is backend-independent.

Worth noting for Postgres specifically: `NUMERIC(8,2)` re-imposes the scale on read, so a refetch
looks correct on `develop` while `obj.price` straight after `create()` is still `Decimal('1E+4')`.
The same row therefore reports two different scales in one request, and aggregates are wrong on both
backends.

One self-correction worth stating: my first version of the new test expected `12.345` → `12.35`.
`quantize` uses the context rounding, `ROUND_HALF_EVEN`, so it is `12.34`. My expectation was wrong,
not the code; the test now uses `12.3456` so it does not depend on the rounding mode.

AI assistance: found and drafted with Claude Code (Claude Opus 5, `claude-opus-5`), from a sweep for
field round trips that do not close, not from production use.

