### PR TITLE
fix(migrations): emit Meta.constraints in CREATE TABLE (#2272)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Added
 ^^^^^
 - ``Q.__bool__()`` so ``Q`` objects with no filters/children (including nested empty ``Q`` children) are falsy.
 
+Fixed
+^^^^^
+- ``Meta.constraints`` (``UniqueConstraint`` / ``CheckConstraint``) are now emitted in ``CREATE TABLE`` by ``migrate`` and ``generate_schemas``. MySQL ``add_constraint`` honors the constraint ``name``. (#2272)
+
 1.1.8
 -----
 

--- a/tests/migrations/test_schema_editor_constraints.py
+++ b/tests/migrations/test_schema_editor_constraints.py
@@ -593,3 +593,29 @@ async def test_base_add_constraint_with_condition_raises() -> None:
     with pytest.raises(NotImplementedError, match="Partial unique indexes"):
         await editor.add_constraint(UserAccount, constraint)
     assert len(client.executed) == 0
+
+
+@pytest.mark.asyncio
+async def test_mysql_add_constraint_uses_custom_name() -> None:
+    """MySQL add_constraint must honor UniqueConstraint.name."""
+
+    class Like(Model):
+        id = fields.IntField(pk=True)
+        types = fields.CharField(max_length=10)
+        user_id = fields.IntField()
+        art_id = fields.IntField()
+
+        class Meta:
+            table = "like"
+            app = "models"
+
+    client = FakeClient("mysql")
+    editor = MySQLSchemaEditor(client)
+    constraint = UniqueConstraint(fields=("types", "user_id", "art_id"), name="unique_like")
+    await editor.add_constraint(Like, constraint)
+
+    assert len(client.executed) == 1
+    assert (
+        client.executed[0]
+        == "ALTER TABLE `like` ADD UNIQUE KEY `unique_like` (`types`, `user_id`, `art_id`)"
+    )

--- a/tests/migrations/test_schema_editor_sql.py
+++ b/tests/migrations/test_schema_editor_sql.py
@@ -6,11 +6,14 @@ import pytest
 
 from tests.utils.fake_client import FakeClient
 from tortoise import fields
+from tortoise.backends.base.schema_generator import BaseSchemaGenerator
 from tortoise.contrib.postgres.fields import TSVectorField
 from tortoise.contrib.postgres.indexes import GinIndex
 from tortoise.indexes import Index
+from tortoise.migrations.constraints import CheckConstraint, UniqueConstraint
 from tortoise.migrations.schema_editor.base import BaseSchemaEditor
 from tortoise.migrations.schema_editor.base_postgres import BasePostgresSchemaEditor
+from tortoise.migrations.schema_editor.mysql import MySQLSchemaEditor
 from tortoise.migrations.schema_generator.state_apps import StateApps
 from tortoise.models import Model
 
@@ -282,3 +285,175 @@ async def test_create_model_includes_db_default_on_fk() -> None:
     assert 'CREATE TABLE "app"' in sql
     assert '"dc_id"' in sql
     assert "DEFAULT 2" in sql
+
+
+@pytest.mark.asyncio
+async def test_create_model_includes_meta_constraints() -> None:
+    """CreateModel must emit named UniqueConstraint and CheckConstraint in CREATE TABLE."""
+
+    class Like(Model):
+        id = fields.IntField(pk=True)
+        types = fields.CharField(max_length=10)
+        user_id = fields.IntField()
+        art_id = fields.IntField()
+        score = fields.IntField()
+
+        class Meta:
+            table = "like"
+            app = "models"
+            constraints = [
+                UniqueConstraint(fields=("types", "user_id", "art_id"), name="unique_like"),
+                CheckConstraint(check="score >= 0", name="chk_score_positive"),
+            ]
+
+    client = FakeClient("sql")
+    editor = TestSchemaEditor(client)
+    await editor.create_model(Like)
+
+    assert len(client.executed) == 1
+    sql = client.executed[0]
+    assert 'CONSTRAINT "unique_like" UNIQUE ("types", "user_id", "art_id")' in sql
+    assert 'CONSTRAINT "chk_score_positive" CHECK (score >= 0)' in sql
+
+
+@pytest.mark.asyncio
+async def test_create_model_skips_unique_constraint_already_in_unique_together() -> None:
+    """Do not emit a second UNIQUE for UniqueConstraint fields already in unique_together."""
+
+    class WidgetConstrained(Model):
+        id = fields.IntField(pk=True)
+        name = fields.CharField(max_length=100)
+        category = fields.CharField(max_length=50)
+
+        class Meta:
+            table = "widget"
+            app = "models"
+            unique_together = (("name", "category"),)
+            constraints = [
+                UniqueConstraint(fields=("name", "category"), name="uid_name_category"),
+            ]
+
+    client = FakeClient("sql")
+    editor = TestSchemaEditor(client)
+    await editor.create_model(WidgetConstrained)
+
+    sql = client.executed[0]
+    assert "uid_name_category" not in sql
+    assert sql.count("UNIQUE") == 1
+
+
+@pytest.mark.asyncio
+async def test_create_model_skips_unique_constraint_matching_unique_together_columns() -> None:
+    """Skip UniqueConstraint when its resolved columns match unique_together."""
+
+    class Organization(Model):
+        id = fields.IntField(pk=True)
+
+        class Meta:
+            table = "organization"
+            app = "models"
+
+    class Membership(Model):
+        id = fields.IntField(pk=True)
+        organization: fields.ForeignKeyRelation[Organization] = fields.ForeignKeyField(
+            "models.Organization", related_name="memberships"
+        )
+        user_email = fields.CharField(max_length=255)
+
+        class Meta:
+            table = "membership"
+            app = "models"
+            unique_together = (("organization", "user_email"),)
+            constraints = [
+                UniqueConstraint(fields=("organization_id", "user_email"), name="uid_org_email"),
+            ]
+
+    init_apps(Organization, Membership)
+
+    client = FakeClient("sql")
+    editor = TestSchemaEditor(client)
+    await editor.create_model(Membership)
+
+    sql = client.executed[0]
+    assert "uid_org_email" not in sql
+    assert sql.count("UNIQUE") == 1
+
+
+@pytest.mark.asyncio
+async def test_mysql_create_model_uses_named_unique_key() -> None:
+    """MySQL CREATE TABLE must use the UniqueConstraint name as UNIQUE KEY."""
+
+    class Like(Model):
+        id = fields.IntField(pk=True)
+        types = fields.CharField(max_length=10)
+        user_id = fields.IntField()
+        art_id = fields.IntField()
+        score = fields.IntField()
+
+        class Meta:
+            table = "like"
+            app = "models"
+            constraints = [
+                UniqueConstraint(fields=("types", "user_id", "art_id"), name="unique_like"),
+                CheckConstraint(check="score >= 0", name="chk_score_positive"),
+            ]
+
+    client = FakeClient("mysql")
+    editor = MySQLSchemaEditor(client)
+    await editor.create_model(Like)
+
+    sql = client.executed[0]
+    assert "UNIQUE KEY `unique_like` (`types`, `user_id`, `art_id`)" in sql
+    assert "CONSTRAINT `chk_score_positive` CHECK (score >= 0)" in sql
+
+
+@pytest.mark.asyncio
+async def test_create_model_postgres_partial_unique_index() -> None:
+    """PostgreSQL CREATE TABLE emits partial UniqueConstraint as CREATE UNIQUE INDEX."""
+
+    class UserAccount(Model):
+        id = fields.IntField(pk=True)
+        email = fields.CharField(max_length=255)
+        is_active = fields.BooleanField(default=True)
+
+        class Meta:
+            table = "user_account"
+            app = "models"
+            constraints = [
+                UniqueConstraint(
+                    fields=("email",), name="uq_active_email", condition="is_active = true"
+                ),
+            ]
+
+    client = FakeClient("postgres", inline_comment=False)
+    editor = BasePostgresSchemaEditor(client)
+    await editor.create_model(UserAccount)
+
+    sql = client.executed[0]
+    assert (
+        'CREATE UNIQUE INDEX "uq_active_email" ON "user_account" ("email") WHERE is_active = true;'
+    ) in sql
+
+
+def test_generate_schema_includes_meta_constraints() -> None:
+    """generate_schemas CREATE TABLE must include Meta.constraints."""
+
+    class Like(Model):
+        id = fields.IntField(pk=True)
+        types = fields.CharField(max_length=10)
+        user_id = fields.IntField()
+        art_id = fields.IntField()
+        score = fields.IntField()
+
+        class Meta:
+            table = "like"
+            app = "models"
+            constraints = [
+                UniqueConstraint(fields=("types", "user_id", "art_id"), name="unique_like"),
+                CheckConstraint(check="score >= 0", name="chk_score_positive"),
+            ]
+
+    generator = BaseSchemaGenerator(FakeClient("sql"))
+    sql = generator._get_table_sql(Like, safe=False)["table_creation_string"]
+    assert 'CONSTRAINT "unique_like" UNIQUE ("types", "user_id", "art_id")' in sql
+    assert 'CONSTRAINT "chk_score_positive" CHECK (score >= 0)' in sql

--- a/tortoise/backends/base/schema_generator.py
+++ b/tortoise/backends/base/schema_generator.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:  # pragma: nocoverage
         ForeignKeyFieldInstance,
         ManyToManyFieldInstance,
     )
+    from tortoise.migrations.constraints import UniqueConstraint
     from tortoise.models import Model
 
 # pylint: disable=R0201
@@ -31,6 +32,7 @@ class BaseSchemaGenerator(SchemaQuotingMixin):
     )
     UNIQUE_INDEX_CREATE_TEMPLATE = INDEX_CREATE_TEMPLATE.replace("INDEX", "UNIQUE INDEX")
     UNIQUE_CONSTRAINT_CREATE_TEMPLATE = 'CONSTRAINT "{index_name}" UNIQUE ({fields})'
+    CHECK_CONSTRAINT_CREATE_TEMPLATE = 'CONSTRAINT "{name}" CHECK ({check})'
     GENERATED_PK_TEMPLATE = '"{field_name}" {generated_sql}{comment}'
     FK_TEMPLATE = ' REFERENCES {table} ("{field}") ON DELETE {on_delete}{comment}'
     M2M_TABLE_TEMPLATE = (
@@ -205,11 +207,96 @@ class BaseSchemaGenerator(SchemaQuotingMixin):
             extra="",
         )
 
-    def _get_unique_constraint_sql(self, model: type[Model], field_names: Sequence[str]) -> str:
+    def _get_unique_constraint_sql(
+        self,
+        model: type[Model],
+        field_names: Sequence[str],
+        index_name: str | None = None,
+    ) -> str:
         return self.UNIQUE_CONSTRAINT_CREATE_TEMPLATE.format(
-            index_name=self._get_index_name("uid", model, field_names),
+            index_name=index_name or self._get_index_name("uid", model, field_names),
             fields=", ".join([self.quote(f) for f in field_names]),
         )
+
+    def _resolve_fields_to_columns(
+        self, model: type[Model], field_names: tuple[str, ...] | Sequence[str]
+    ) -> list[str]:
+        resolved = []
+        for field_name in field_names:
+            field_object = model._meta.fields_map.get(field_name)
+            if field_object is not None:
+                resolved.append(field_object.source_field or field_name)
+            else:
+                resolved.append(field_name)
+        return resolved
+
+    def _constraint_name_for_model(self, model: type[Model], constraint: UniqueConstraint) -> str:
+        if constraint.name:
+            return constraint.name
+        return self._get_index_name("uid", model, list(constraint.fields))
+
+    def _table_constraint_sqls(self, model: type[Model]) -> list[str]:
+        """In-table UNIQUE/CHECK clauses from ``Meta.constraints``."""
+        from tortoise.migrations.constraints import CheckConstraint, UniqueConstraint
+
+        sqls: list[str] = []
+        unique_together_columns = {
+            tuple(self._resolve_fields_to_columns(model, fields))
+            for fields in (model._meta.unique_together or ())
+        }
+        for constraint in getattr(model._meta, "constraints", None) or ():
+            if isinstance(constraint, UniqueConstraint):
+                if constraint.condition:
+                    continue
+                resolved_fields = self._resolve_fields_to_columns(model, constraint.fields)
+                if tuple(resolved_fields) in unique_together_columns:
+                    continue
+                resolved = UniqueConstraint(fields=tuple(resolved_fields), name=constraint.name)
+                sqls.append(
+                    self._get_unique_constraint_sql(
+                        model,
+                        resolved_fields,
+                        index_name=self._constraint_name_for_model(model, resolved),
+                    )
+                )
+            elif isinstance(constraint, CheckConstraint):
+                sqls.append(
+                    self.CHECK_CONSTRAINT_CREATE_TEMPLATE.format(
+                        name=constraint.name,
+                        check=constraint.check,
+                    )
+                )
+        return sqls
+
+    def _partial_unique_index_sqls(self, model: type[Model], safe: bool) -> list[str]:
+        """``CREATE UNIQUE INDEX ... WHERE`` for partial ``UniqueConstraint``s (PostgreSQL)."""
+        if self.DIALECT != "postgres":
+            return []
+        from tortoise.migrations.constraints import UniqueConstraint
+
+        exists = "IF NOT EXISTS " if safe else ""
+        sqls: list[str] = []
+        for constraint in getattr(model._meta, "constraints", None) or ():
+            if not isinstance(constraint, UniqueConstraint) or not constraint.condition:
+                continue
+            resolved_fields = self._resolve_fields_to_columns(model, constraint.fields)
+            resolved = UniqueConstraint(
+                fields=tuple(resolved_fields),
+                name=constraint.name,
+                condition=constraint.condition,
+            )
+            index_name = self._constraint_name_for_model(model, resolved)
+            sqls.append(
+                self.UNIQUE_INDEX_CREATE_TEMPLATE.format(
+                    exists=exists,
+                    index_name=index_name,
+                    index_type="",
+                    table_name=self._qualify_table_name(model._meta.db_table, model._meta.schema),
+                    fields=", ".join(self.quote(field) for field in resolved_fields),
+                    extra=f" WHERE {constraint.condition}",
+                )
+            )
+        return sqls
 
     def _get_pk_field_sql_type(self, pk_field: Field) -> str:
         if isinstance(pk_field, OneToOneFieldInstance):
@@ -477,7 +564,10 @@ class BaseSchemaGenerator(SchemaQuotingMixin):
                     self._get_unique_constraint_sql(model, unique_together_to_create)
                 )
 
+        fields_to_create.extend(self._table_constraint_sqls(model))
+
         field_indexes_sqls = self._get_field_indexes_sqls(model, fields_with_index, safe)
+        field_indexes_sqls.extend(self._partial_unique_index_sqls(model, safe))
 
         fields_to_create.extend(self._get_inner_statements())
 

--- a/tortoise/backends/mssql/schema_generator.py
+++ b/tortoise/backends/mssql/schema_generator.py
@@ -18,6 +18,7 @@ class MSSQLSchemaGenerator(MSSQLQuotingMixin, BaseSchemaGenerator):
     FIELD_TEMPLATE = "[{name}] {type}{nullable}{unique}{primary}{default}"
     INDEX_CREATE_TEMPLATE = "CREATE INDEX [{index_name}] ON {table_name} ({fields});"
     UNIQUE_CONSTRAINT_CREATE_TEMPLATE = "CONSTRAINT [{index_name}] UNIQUE ({fields})"
+    CHECK_CONSTRAINT_CREATE_TEMPLATE = "CONSTRAINT [{name}] CHECK ({check})"
     GENERATED_PK_TEMPLATE = "[{field_name}] {generated_sql}"
     FK_TEMPLATE = (
         "{constraint}FOREIGN KEY ([{db_column}])"

--- a/tortoise/backends/mysql/schema_generator.py
+++ b/tortoise/backends/mysql/schema_generator.py
@@ -18,6 +18,7 @@ class MySQLSchemaGenerator(MySQLQuotingMixin, BaseSchemaGenerator):
     INDEX_CREATE_TEMPLATE = "{index_type}KEY `{index_name}` ({fields}){extra}"
     UNIQUE_CONSTRAINT_CREATE_TEMPLATE = "UNIQUE KEY `{index_name}` ({fields})"
     UNIQUE_INDEX_CREATE_TEMPLATE = UNIQUE_CONSTRAINT_CREATE_TEMPLATE
+    CHECK_CONSTRAINT_CREATE_TEMPLATE = "CONSTRAINT `{name}` CHECK ({check})"
     FIELD_TEMPLATE = "`{name}` {type}{nullable}{unique}{primary}{comment}{default}"
     GENERATED_PK_TEMPLATE = "`{field_name}` {generated_sql}{comment}"
     FK_TEMPLATE = (

--- a/tortoise/migrations/schema_editor/base.py
+++ b/tortoise/migrations/schema_editor/base.py
@@ -193,6 +193,64 @@ class BaseSchemaEditor(SchemaQuotingMixin):
     def _get_unique_constraint_name(self, model: type[Model], field_names: list[str]) -> str:
         return self._generate_index_name("uid", model, field_names)
 
+    def _table_constraint_sqls(self, model: type[Model]) -> list[str]:
+        """In-table UNIQUE/CHECK clauses from ``Meta.constraints``.
+
+        ``UniqueConstraint`` entries whose fields already appear in
+        ``unique_together`` are skipped to avoid duplicate keys.
+        Partial unique constraints (``condition``) are not table constraints.
+        """
+        sqls: list[str] = []
+        unique_together_columns = {
+            tuple(self._resolve_fields_to_columns(model, fields))
+            for fields in (model._meta.unique_together or ())
+        }
+        for constraint in getattr(model._meta, "constraints", None) or ():
+            if isinstance(constraint, UniqueConstraint):
+                if constraint.condition:
+                    continue
+                resolved_fields = self._resolve_fields_to_columns(model, constraint.fields)
+                if tuple(resolved_fields) in unique_together_columns:
+                    continue
+                resolved = UniqueConstraint(fields=tuple(resolved_fields), name=constraint.name)
+                sqls.append(
+                    self.UNIQUE_CONSTRAINT_CREATE_TEMPLATE.format(
+                        index_name=self._constraint_name_for_model(model, resolved),
+                        fields=", ".join(self.quote(field) for field in resolved_fields),
+                    )
+                )
+            elif isinstance(constraint, CheckConstraint):
+                sqls.append(
+                    self.CHECK_CONSTRAINT_CREATE_TEMPLATE.format(
+                        name=constraint.name,
+                        check=constraint.check,
+                    )
+                )
+        return sqls
+
+    def _partial_unique_index_sqls(self, model: type[Model]) -> list[str]:
+        """``CREATE UNIQUE INDEX ... WHERE`` for partial ``UniqueConstraint``s (PostgreSQL)."""
+        if self.DIALECT != "postgres":
+            return []
+        sqls: list[str] = []
+        for constraint in getattr(model._meta, "constraints", None) or ():
+            if not isinstance(constraint, UniqueConstraint) or not constraint.condition:
+                continue
+            resolved_fields = self._resolve_fields_to_columns(model, constraint.fields)
+            resolved = UniqueConstraint(
+                fields=tuple(resolved_fields),
+                name=constraint.name,
+                condition=constraint.condition,
+            )
+            index_name = self._constraint_name_for_model(model, resolved)
+            sqls.append(
+                f'CREATE UNIQUE INDEX "{index_name}" '
+                f"ON {self._qualify_table_name(model._meta.db_table, model._meta.schema)} "
+                f"({', '.join(self.quote(field) for field in resolved_fields)}) "
+                f"WHERE {constraint.condition};"
+            )
+        return sqls
+
     def _get_index_sql(
         self,
         model: type[Model],
@@ -393,7 +451,10 @@ class BaseSchemaEditor(SchemaQuotingMixin):
                     self._get_unique_constraint_sql(model, unique_together_to_create)
                 )
 
+        in_table_definitions.extend(self._table_constraint_sqls(model))
+
         _indexes = [self._get_index_sql(model, [field_name]) for field_name in fields_with_index]
+        _indexes.extend(self._partial_unique_index_sqls(model))
 
         if model._meta.indexes:
             for index in model._meta.indexes:

--- a/tortoise/migrations/schema_editor/mysql.py
+++ b/tortoise/migrations/schema_editor/mysql.py
@@ -365,7 +365,7 @@ class MySQLSchemaEditor(MySQLQuotingMixin, BaseSchemaEditor):
             )
         resolved_fields = self._resolve_fields_to_columns(model, constraint.fields)
         table = self._qualify_table_name(model._meta.db_table, model._meta.schema)
-        index_name = self._generate_index_name_for_table(
+        index_name = constraint.name or self._generate_index_name_for_table(
             "uidx", model._meta.db_table, resolved_fields
         )
         columns = ", ".join([self.quote(f) for f in resolved_fields])

--- a/tortoise/migrations/schema_editor/sqlite.py
+++ b/tortoise/migrations/schema_editor/sqlite.py
@@ -387,16 +387,7 @@ class SqliteSchemaEditor(SqliteQuotingMixin, BaseSchemaEditor):
 
             field_definitions.append(field_def)
 
-        # Include CHECK constraints from model._meta.constraints in the CREATE TABLE
-        from tortoise.migrations.constraints import CheckConstraint as _CheckConstraint
-
-        for constraint in getattr(model._meta, "constraints", None) or ():
-            if isinstance(constraint, _CheckConstraint):
-                field_definitions.append(
-                    self.CHECK_CONSTRAINT_CREATE_TEMPLATE.format(
-                        name=constraint.name, check=constraint.check
-                    )
-                )
+        field_definitions.extend(self._table_constraint_sqls(model))
 
         qualified_new = self._qualify_table_name(new_table_name, model._meta.schema)
         qualified_old = self._qualify_table_name(db_table, model._meta.schema)


### PR DESCRIPTION
Named UniqueConstraint and CheckConstraint were stored on CreateModel but never applied when creating tables, and MySQL add_constraint ignored custom names.

## Description
`Meta.constraints` (`UniqueConstraint` / `CheckConstraint`) are now emitted in `CREATE TABLE` for both `tortoise migrate` and `generate_schemas`.

Previously `makemigrations` stored them on `CreateModel`, but table creation only applied `unique_together`, so a new model never got `AddConstraint` and named uniques like `unique_like` never appeared. MySQL `add_constraint` also ignored `name` and generated `uidx_*` instead.

- Named unique and check constraints are inlined in `CREATE TABLE`
- Partial unique constraints (`condition`) become `CREATE UNIQUE INDEX ... WHERE` on PostgreSQL
- A `UniqueConstraint` whose resolved columns already match `unique_together` is skipped
- MySQL `add_constraint` honors `constraint.name` when set

## Motivation and Context
Fixes https://github.com/tortoise/tortoise-orm/issues/2272

Reporter used `tortoise makemigrations` / `tortoise migrate` on MySQL 8.4 with:

```python
class Meta:
    constraints = [
        UniqueConstraint(fields=("types", "user_id", "art_id"), name="unique_like"),
    ]
```

Expected a unique index named `unique_like`; nothing was created, with no error.

## How Has This Been Tested?
Added regression tests in `tests/migrations/test_schema_editor_sql.py` and `tests/migrations/test_schema_editor_constraints.py` covering:

- `CreateModel` SQL for named unique + check constraints (ANSI and MySQL)
- skip when `UniqueConstraint` duplicates `unique_together` (including FK field vs `organization_id` columns)
- PostgreSQL partial unique index on create
- `generate_schemas` including `Meta.constraints`
- MySQL `add_constraint` using the custom name

Ran:
```
uv run pytest tests/migrations/test_schema_editor_sql.py tests/migrations/test_schema_editor_constraints.py
```
(52 passed)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.