### PR TITLE
fix(models): apply defaults after concurrent inserts

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Added
 ^^^^^
 - ``Q.__bool__()`` so ``Q`` objects with no filters/children (including nested empty ``Q`` children) are falsy.
 
+Fixed
+^^^^^
+- ``Model.update_or_create()`` now applies the caller's defaults after losing a concurrent insert, re-reading the current row through the existing transactional update path. (#2060)
+
 1.1.8
 -----
 

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -3,7 +3,7 @@ import sys
 
 import pytest
 
-from tests.testmodels import Tournament, UniqueName
+from tests.testmodels import Tournament, UniqueName, UniqueNameRequired
 from tortoise import connections
 from tortoise.contrib.test import requireCapability
 from tortoise.contrib.test.condition import NotEQ
@@ -54,7 +54,7 @@ async def test_concurrent_create_applies_defaults(
     db_isolated, monkeypatch, method_name, defaults_pair
 ):
     """Both callers read a missing row before either attempts the real INSERT."""
-    original_create_or_get = UniqueName._create_or_get
+    original_create_or_get = UniqueNameRequired._create_or_get
     both_missing = asyncio.Event()
     create_attempts = 0
 
@@ -66,8 +66,10 @@ async def test_concurrent_create_applies_defaults(
         await both_missing.wait()
         return await original_create_or_get(db, defaults, **kwargs)
 
-    monkeypatch.setattr(UniqueName, "_create_or_get", classmethod(synchronized_create_or_get))
-    method = getattr(UniqueName, method_name)
+    monkeypatch.setattr(
+        UniqueNameRequired, "_create_or_get", classmethod(synchronized_create_or_get)
+    )
+    method = getattr(UniqueNameRequired, method_name)
     tasks = [
         asyncio.create_task(method(name="race", defaults=defaults)) for defaults in defaults_pair
     ]
@@ -81,8 +83,8 @@ async def test_concurrent_create_applies_defaults(
 
     assert create_attempts == 2
     assert sum(created for _, created in results) == 1
-    assert await UniqueName.filter(name="race").count() == 1
-    stored = await UniqueName.get(name="race")
+    assert await UniqueNameRequired.filter(name="race").count() == 1
+    stored = await UniqueNameRequired.get(name="race")
     if method_name == "update_or_create":
         for defaults, (instance, _) in zip(defaults_pair, results):
             for field, value in defaults.items():
@@ -104,7 +106,7 @@ async def test_concurrent_create_applies_defaults(
 @pytest.mark.asyncio
 async def test_update_or_create_refreshes_after_create_race(db_isolated, monkeypatch):
     """The unlocked conflict lookup must not overwrite another writer's later changes."""
-    original_create_or_get = UniqueName._create_or_get
+    original_create_or_get = UniqueNameRequired._create_or_get
 
     async def racing_create_or_get(cls, db, defaults, **kwargs):
         await cls.create(name=kwargs["name"], optional="winner", other_optional="old")
@@ -113,14 +115,14 @@ async def test_update_or_create_refreshes_after_create_race(db_isolated, monkeyp
         await cls.filter(pk=instance.pk).update(other_optional="concurrent")
         return instance, created
 
-    monkeypatch.setattr(UniqueName, "_create_or_get", classmethod(racing_create_or_get))
-    instance, created = await UniqueName.update_or_create(
+    monkeypatch.setattr(UniqueNameRequired, "_create_or_get", classmethod(racing_create_or_get))
+    instance, created = await UniqueNameRequired.update_or_create(
         name="race", defaults={"optional": "loser"}
     )
     assert created is False
     assert instance.optional == "loser"
     assert instance.other_optional == "concurrent"
-    stored = await UniqueName.get(pk=instance.pk)
+    stored = await UniqueNameRequired.get(pk=instance.pk)
     assert stored.optional == "loser"
     assert stored.other_optional == "concurrent"
 
@@ -128,7 +130,7 @@ async def test_update_or_create_refreshes_after_create_race(db_isolated, monkeyp
 @pytest.mark.asyncio
 async def test_update_or_create_retries_deleted_race_winner(db_isolated, monkeypatch):
     """A row deleted after the conflict lookup can be created by the retry."""
-    original_create_or_get = UniqueName._create_or_get
+    original_create_or_get = UniqueNameRequired._create_or_get
     create_attempts = 0
 
     async def racing_create_or_get(cls, db, defaults, **kwargs):
@@ -142,38 +144,38 @@ async def test_update_or_create_retries_deleted_race_winner(db_isolated, monkeyp
             await instance.delete()
         return instance, created
 
-    monkeypatch.setattr(UniqueName, "_create_or_get", classmethod(racing_create_or_get))
-    instance, created = await UniqueName.update_or_create(
+    monkeypatch.setattr(UniqueNameRequired, "_create_or_get", classmethod(racing_create_or_get))
+    instance, created = await UniqueNameRequired.update_or_create(
         name="race", defaults={"optional": "retry"}
     )
     assert created is True
     assert create_attempts == 2
     assert instance.optional == "retry"
-    assert await UniqueName.filter(name="race").count() == 1
-    assert (await UniqueName.get(pk=instance.pk)).optional == "retry"
+    assert await UniqueNameRequired.filter(name="race").count() == 1
+    assert (await UniqueNameRequired.get(pk=instance.pk)).optional == "retry"
 
 
 @requireCapability(supports_transactions=True)
 @pytest.mark.asyncio
 async def test_update_or_create_race_in_existing_transaction(db_isolated, monkeypatch):
     """Conflict recovery and its UPDATE must remain inside the caller's transaction."""
-    original_create_or_get = UniqueName._create_or_get
+    original_create_or_get = UniqueNameRequired._create_or_get
 
     async def racing_create_or_get(cls, db, defaults, **kwargs):
         await cls.create(using_db=db, name=kwargs["name"], optional="winner")
         return await original_create_or_get(db, defaults, **kwargs)
 
-    monkeypatch.setattr(UniqueName, "_create_or_get", classmethod(racing_create_or_get))
+    monkeypatch.setattr(UniqueNameRequired, "_create_or_get", classmethod(racing_create_or_get))
     with pytest.raises(RuntimeError, match="rollback caller transaction"):
         async with in_transaction("models") as connection:
-            instance, created = await UniqueName.update_or_create(
+            instance, created = await UniqueNameRequired.update_or_create(
                 name="race", defaults={"optional": "loser"}, using_db=connection
             )
             assert created is False
             assert instance.optional == "loser"
-            assert (await UniqueName.get(name="race")).optional == "loser"
+            assert (await UniqueNameRequired.get(name="race")).optional == "loser"
             raise RuntimeError("rollback caller transaction")
-    assert await UniqueName.filter(name="race").count() == 0
+    assert await UniqueNameRequired.filter(name="race").count() == 0
 
 
 @pytest.mark.skipif(

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -41,6 +41,141 @@ async def test_nonconcurrent_get_or_create_isolated(db_isolated):
         assert una[0] == unas[0][0]
 
 
+@pytest.mark.parametrize("method_name", ["update_or_create", "get_or_create"])
+@pytest.mark.parametrize(
+    "defaults_pair",
+    [
+        ({"optional": "writer-a"}, {"optional": "writer-b"}),
+        ({"optional": "writer-a"}, {"other_optional": "writer-b"}),
+    ],
+)
+@pytest.mark.asyncio
+async def test_concurrent_create_applies_defaults(
+    db_isolated, monkeypatch, method_name, defaults_pair
+):
+    """Both callers read a missing row before either attempts the real INSERT."""
+    original_create_or_get = UniqueName._create_or_get
+    both_missing = asyncio.Event()
+    create_attempts = 0
+
+    async def synchronized_create_or_get(cls, db, defaults, **kwargs):
+        nonlocal create_attempts
+        create_attempts += 1
+        if create_attempts == 2:
+            both_missing.set()
+        await both_missing.wait()
+        return await original_create_or_get(db, defaults, **kwargs)
+
+    monkeypatch.setattr(UniqueName, "_create_or_get", classmethod(synchronized_create_or_get))
+    method = getattr(UniqueName, method_name)
+    tasks = [
+        asyncio.create_task(method(name="race", defaults=defaults)) for defaults in defaults_pair
+    ]
+    try:
+        results = await asyncio.wait_for(asyncio.gather(*tasks), timeout=30)
+    finally:
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+    assert create_attempts == 2
+    assert sum(created for _, created in results) == 1
+    assert await UniqueName.filter(name="race").count() == 1
+    stored = await UniqueName.get(name="race")
+    if method_name == "update_or_create":
+        for defaults, (instance, _) in zip(defaults_pair, results):
+            for field, value in defaults.items():
+                assert getattr(instance, field) == value
+        for defaults, (_, created) in zip(defaults_pair, results):
+            if not created:
+                for field, value in defaults.items():
+                    assert getattr(stored, field) == value
+        if "other_optional" in defaults_pair[1]:
+            assert stored.optional == "writer-a"
+            assert stored.other_optional == "writer-b"
+    else:
+        winner = next(instance for instance, created in results if created)
+        for instance, _ in results:
+            assert instance.optional == stored.optional == winner.optional
+            assert instance.other_optional == stored.other_optional == winner.other_optional
+
+
+@pytest.mark.asyncio
+async def test_update_or_create_refreshes_after_create_race(db_isolated, monkeypatch):
+    """The unlocked conflict lookup must not overwrite another writer's later changes."""
+    original_create_or_get = UniqueName._create_or_get
+
+    async def racing_create_or_get(cls, db, defaults, **kwargs):
+        await cls.create(name=kwargs["name"], optional="winner", other_optional="old")
+        instance, created = await original_create_or_get(db, defaults, **kwargs)
+        assert created is False
+        await cls.filter(pk=instance.pk).update(other_optional="concurrent")
+        return instance, created
+
+    monkeypatch.setattr(UniqueName, "_create_or_get", classmethod(racing_create_or_get))
+    instance, created = await UniqueName.update_or_create(
+        name="race", defaults={"optional": "loser"}
+    )
+    assert created is False
+    assert instance.optional == "loser"
+    assert instance.other_optional == "concurrent"
+    stored = await UniqueName.get(pk=instance.pk)
+    assert stored.optional == "loser"
+    assert stored.other_optional == "concurrent"
+
+
+@pytest.mark.asyncio
+async def test_update_or_create_retries_deleted_race_winner(db_isolated, monkeypatch):
+    """A row deleted after the conflict lookup can be created by the retry."""
+    original_create_or_get = UniqueName._create_or_get
+    create_attempts = 0
+
+    async def racing_create_or_get(cls, db, defaults, **kwargs):
+        nonlocal create_attempts
+        create_attempts += 1
+        if create_attempts == 1:
+            await cls.create(name=kwargs["name"], optional="winner")
+        instance, created = await original_create_or_get(db, defaults, **kwargs)
+        if create_attempts == 1:
+            assert created is False
+            await instance.delete()
+        return instance, created
+
+    monkeypatch.setattr(UniqueName, "_create_or_get", classmethod(racing_create_or_get))
+    instance, created = await UniqueName.update_or_create(
+        name="race", defaults={"optional": "retry"}
+    )
+    assert created is True
+    assert create_attempts == 2
+    assert instance.optional == "retry"
+    assert await UniqueName.filter(name="race").count() == 1
+    assert (await UniqueName.get(pk=instance.pk)).optional == "retry"
+
+
+@requireCapability(supports_transactions=True)
+@pytest.mark.asyncio
+async def test_update_or_create_race_in_existing_transaction(db_isolated, monkeypatch):
+    """Conflict recovery and its UPDATE must remain inside the caller's transaction."""
+    original_create_or_get = UniqueName._create_or_get
+
+    async def racing_create_or_get(cls, db, defaults, **kwargs):
+        await cls.create(using_db=db, name=kwargs["name"], optional="winner")
+        return await original_create_or_get(db, defaults, **kwargs)
+
+    monkeypatch.setattr(UniqueName, "_create_or_get", classmethod(racing_create_or_get))
+    with pytest.raises(RuntimeError, match="rollback caller transaction"):
+        async with in_transaction("models") as connection:
+            instance, created = await UniqueName.update_or_create(
+                name="race", defaults={"optional": "loser"}, using_db=connection
+            )
+            assert created is False
+            assert instance.optional == "loser"
+            assert (await UniqueName.get(name="race")).optional == "loser"
+            raise RuntimeError("rollback caller transaction")
+    assert await UniqueName.filter(name="race").count() == 0
+
+
 @pytest.mark.skipif(
     sys.version_info < (3, 7), reason="aiocontextvars backport not handling this well"
 )

--- a/tests/test_model_methods.py
+++ b/tests/test_model_methods.py
@@ -14,6 +14,7 @@ from tests.testmodels import (
     RequiredPKModel,
     Team,
     Tournament,
+    UniqueName,
     UUIDFkRelatedNullModel,
 )
 from tortoise.contrib.test import requireCapability
@@ -281,6 +282,28 @@ async def test_update_or_create_with_defaults(tournament_model):
     )
     assert created is True
     assert not_exist_name == created_mdl.name
+
+
+@pytest.mark.asyncio
+async def test_update_or_create_falsy_existing_instance(db, monkeypatch):
+    instance = await UniqueName.create(name="existing", optional="old")
+    monkeypatch.setattr(UniqueName, "__bool__", lambda self: False, raising=False)
+    updated, created = await UniqueName.update_or_create(
+        name="existing", defaults={"optional": "updated"}
+    )
+    assert created is False
+    assert updated.pk == instance.pk
+    assert updated.optional == "updated"
+    assert (await UniqueName.get(pk=instance.pk)).optional == "updated"
+
+
+@pytest.mark.asyncio
+async def test_update_or_create_propagates_unrelated_integrity_error(db):
+    instance = await UniqueName.create(name="existing", optional="original")
+    with pytest.raises(IntegrityError):
+        await UniqueName.update_or_create(optional="missing", defaults={"name": "existing"})
+    assert await UniqueName.all().count() == 1
+    assert (await UniqueName.get(pk=instance.pk)).optional == "original"
 
 
 @pytest.mark.asyncio

--- a/tests/test_model_methods.py
+++ b/tests/test_model_methods.py
@@ -14,7 +14,7 @@ from tests.testmodels import (
     RequiredPKModel,
     Team,
     Tournament,
-    UniqueName,
+    UniqueNameRequired,
     UUIDFkRelatedNullModel,
 )
 from tortoise.contrib.test import requireCapability
@@ -286,24 +286,24 @@ async def test_update_or_create_with_defaults(tournament_model):
 
 @pytest.mark.asyncio
 async def test_update_or_create_falsy_existing_instance(db, monkeypatch):
-    instance = await UniqueName.create(name="existing", optional="old")
-    monkeypatch.setattr(UniqueName, "__bool__", lambda self: False, raising=False)
-    updated, created = await UniqueName.update_or_create(
+    instance = await UniqueNameRequired.create(name="existing", optional="old")
+    monkeypatch.setattr(UniqueNameRequired, "__bool__", lambda self: False, raising=False)
+    updated, created = await UniqueNameRequired.update_or_create(
         name="existing", defaults={"optional": "updated"}
     )
     assert created is False
     assert updated.pk == instance.pk
     assert updated.optional == "updated"
-    assert (await UniqueName.get(pk=instance.pk)).optional == "updated"
+    assert (await UniqueNameRequired.get(pk=instance.pk)).optional == "updated"
 
 
 @pytest.mark.asyncio
 async def test_update_or_create_propagates_unrelated_integrity_error(db):
-    instance = await UniqueName.create(name="existing", optional="original")
+    instance = await UniqueNameRequired.create(name="existing", optional="original")
     with pytest.raises(IntegrityError):
-        await UniqueName.update_or_create(optional="missing", defaults={"name": "existing"})
-    assert await UniqueName.all().count() == 1
-    assert (await UniqueName.get(pk=instance.pk)).optional == "original"
+        await UniqueNameRequired.update_or_create(optional="missing", defaults={"name": "existing"})
+    assert await UniqueNameRequired.all().count() == 1
+    assert (await UniqueNameRequired.get(pk=instance.pk)).optional == "original"
 
 
 @pytest.mark.asyncio

--- a/tests/testmodels.py
+++ b/tests/testmodels.py
@@ -445,6 +445,13 @@ class UniqueName(Model):
     other_optional = fields.CharField(max_length=20, null=True)
 
 
+class UniqueNameRequired(Model):
+    id = fields.IntField(primary_key=True)
+    name = fields.CharField(max_length=20, unique=True)
+    optional = fields.CharField(max_length=20, null=True)
+    other_optional = fields.CharField(max_length=20, null=True)
+
+
 class UniqueTogetherFields(Model):
     id = fields.IntField(primary_key=True)
     first_name = fields.CharField(max_length=64)

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -1353,12 +1353,16 @@ class Model(metaclass=ModelMeta):
         if not defaults:
             defaults = {}
         db = using_db or cls._choose_db(True)
-        async with in_transaction(connection_name=db.connection_name) as connection:
-            instance = await cls.select_for_update().using_db(connection).get_or_none(**kwargs)
-            if instance:
-                await instance.update_from_dict(defaults).save(using_db=connection)
-                return instance, False
-        return await cls._create_or_get(db, defaults, **kwargs)
+        while True:
+            async with in_transaction(connection_name=db.connection_name) as connection:
+                instance = await cls.select_for_update().using_db(connection).get_or_none(**kwargs)
+                if instance is not None:
+                    await instance.update_from_dict(defaults).save(using_db=connection)
+                    return instance, False
+            instance, created = await cls._create_or_get(db, defaults, **kwargs)
+            if created:
+                return instance, True
+            # Retry the update path with a fresh instance after a concurrent insert.
 
     @classmethod
     async def create(


### PR DESCRIPTION
## Description

Retry the existing transactional update path when another caller wins the initial insert. The losing `update_or_create()` call now applies its own defaults to a freshly read row rather than returning the other caller's values unchanged.

The creation transaction boundary and `get_or_create()` behavior stay unchanged. An explicit `None` check also keeps falsy model instances on the update path.

## Motivation and Context

Closes #2060.

Re-reading the row matters: the unlocked conflict lookup may already be stale or its row may have been deleted. The retry uses the normal update path and its existing backend locking behavior, without adding backend-specific upsert SQL or changing the public API.

## How Has This Been Tested?

- The [unchanged upstream CI workflow on the fork](https://github.com/fzlzjerry/tortoise-orm/actions/runs/34341676313) passed **all 23 jobs** on `45676b9`: Python 3.10–3.14 across SQLite, PostgreSQL (asyncpg/psycopg), MySQL (InnoDB/MyISAM and asyncmy), and SQL Server, plus checks and coverage.
- Nine regression/control cases cover concurrent defaults, disjoint fields, a stale conflict lookup, a deleted winner, caller transaction rollback, falsy instances, unrelated integrity errors, and unchanged `get_or_create()` semantics. Final fixtures yield six failures and three passing controls against the original implementation.
- The race tests call the real creation helper and synchronize before its INSERT; no success/failure result is fabricated. Their unique name is non-nullable so SQL Server enforces the constraint as well.
- Independent runs without method instrumentation passed 78 concurrent API calls on each of SQLite, PostgreSQL, and MySQL.

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation. N/A — behavior correction, no API change.
- [ ] I have updated the documentation accordingly. N/A.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
