### PR TITLE
Fix naive DatetimeField timezone drift

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Fixed
 ^^^^^
 - ``QuerySet.distinct().count()`` no longer counts rows duplicated by a join (e.g. filtering on a m2m relation); it now counts distinct primary keys and matches the number of rows the query returns. (#2255)
 - BlackSheep: ``register_tortoise`` now enables the global connection fallback, so database access works when BlackSheep runs handlers in tasks other than the one that initialized the ORM. (#2248)
+- Fix naive DatetimeField timezone drift. (#2277)
 
 1.1.8
 -----

--- a/tests/fields/test_time.py
+++ b/tests/fields/test_time.py
@@ -838,11 +838,26 @@ async def test_datetime_naive_input_with_custom_timezone_update(db, enable_tz):
 
     model = testmodels.DatetimeFields
     naive_dt = datetime(2026, 9, 7, 9, 0)
+    expected_dt = timezone.make_aware(naive_dt, tz)
 
     obj = await model.create(datetime=naive_dt)
+    assert obj.datetime == expected_dt, f"Expected {expected_dt}, got {obj.datetime}"
 
     with pytest.warns(RuntimeWarning, match="received a naive datetime"):
-        await model.filter(id=obj.id).update(datetime=naive_dt)
+        await model.filter(id=obj.id).update(datetime_null=naive_dt)
     obj_get = await model.get(id=obj.id)
-    expected_dt = timezone.make_aware(naive_dt, tz)
-    assert obj_get.datetime == expected_dt, f"Expected {expected_dt}, got {obj_get.datetime}"
+    assert obj_get.datetime_null == expected_dt, (
+        f"Expected {expected_dt}, got {obj_get.datetime_null}"
+    )
+
+    started_at = timezone.localtime()
+    obj.datetime = started_at.replace(tzinfo=None)
+    with pytest.warns(RuntimeWarning, match="received a naive datetime"):
+        await obj.save()
+    now = timezone.localtime()
+    obj = await model.get(id=obj.id)
+    assert obj.datetime == started_at, f"Expected {started_at}, got {obj.datetime}"
+    assert obj.datetime_add < started_at, f"Expected: {obj.datetime_add} < {started_at}"
+    assert now > obj.datetime_auto > started_at, (
+        f"Expected: {now} > {obj.datetime_auto} > {started_at}"
+    )

--- a/tests/fields/test_time.py
+++ b/tests/fields/test_time.py
@@ -814,29 +814,27 @@ def test_timezone(tz_env):
 @pytest.mark.asyncio
 async def test_datetime_naive_input_with_custom_timezone(db, enable_tz):
     """Test naive input honors TIMEZONE instead of hardcoded UTC when use_tz=True."""
-    enable_tz("Asia/Shanghai")
+    tz = enable_tz("Asia/Shanghai")
 
     model = testmodels.DatetimeFields
     naive_dt = datetime(2026, 9, 7, 9, 0)
-
     obj = await model.create(datetime=naive_dt)
 
     # When we create with a naive dt, the timezone module now assumes
     # it belongs to the configured timezone (Asia/Shanghai)
     # So 09:00 naive becomes 09:00+08:00
-
     # Reload from DB
     obj_get = await model.get(id=obj.id)
 
     # It should still be 09:00+08:00 because it correctly roundtripped
-    expected_dt = timezone.make_aware(naive_dt, "Asia/Shanghai")
+    expected_dt = timezone.make_aware(naive_dt, tz)
     assert obj_get.datetime == expected_dt, f"Expected {expected_dt}, got {obj_get.datetime}"
 
 
 @pytest.mark.asyncio
 async def test_datetime_naive_input_with_custom_timezone_update(db, enable_tz):
     """Test naive input honors TIMEZONE during update."""
-    enable_tz("Asia/Shanghai")
+    tz = enable_tz("Asia/Shanghai")
 
     model = testmodels.DatetimeFields
     naive_dt = datetime(2026, 9, 7, 9, 0)
@@ -845,7 +843,6 @@ async def test_datetime_naive_input_with_custom_timezone_update(db, enable_tz):
 
     with pytest.warns(RuntimeWarning, match="received a naive datetime"):
         await model.filter(id=obj.id).update(datetime=naive_dt)
-
     obj_get = await model.get(id=obj.id)
-    expected_dt = timezone.make_aware(naive_dt, "Asia/Shanghai")
+    expected_dt = timezone.make_aware(naive_dt, tz)
     assert obj_get.datetime == expected_dt, f"Expected {expected_dt}, got {obj_get.datetime}"

--- a/tests/fields/test_time.py
+++ b/tests/fields/test_time.py
@@ -800,3 +800,47 @@ def test_timezone(tz_env):
         assert (
             localtime_shanghai.utcoffset() == timezone.localtime(timezone=pytz_shanghai).utcoffset()
         )
+
+@pytest.mark.asyncio
+async def test_datetime_naive_input_with_custom_timezone(db, tz_env):
+    """Test naive input honors TIMEZONE instead of hardcoded UTC when use_tz=True."""
+    os.environ["USE_TZ"] = "True"
+    os.environ["TIMEZONE"] = "Asia/Shanghai"
+    timezone._reset_timezone_cache()
+
+    model = testmodels.DatetimeFields
+    naive_dt = datetime(2026, 9, 7, 9, 0)
+    
+    obj = await model.create(datetime=naive_dt)
+
+    # When we create with a naive dt, the timezone module now assumes 
+    # it belongs to the configured timezone (Asia/Shanghai)
+    # So 09:00 naive becomes 09:00+08:00
+    
+    # Reload from DB
+    obj_get = await model.get(id=obj.id)
+    
+    # It should still be 09:00+08:00 because it correctly roundtripped
+    expected_dt = timezone.make_aware(naive_dt, "Asia/Shanghai")
+    assert obj_get.datetime == expected_dt, f"Expected {expected_dt}, got {obj_get.datetime}"
+
+
+@pytest.mark.asyncio
+async def test_datetime_naive_input_with_custom_timezone_update(db, tz_env):
+    """Test naive input honors TIMEZONE during update."""
+    os.environ["USE_TZ"] = "True"
+    os.environ["TIMEZONE"] = "Asia/Shanghai"
+    timezone._reset_timezone_cache()
+
+    model = testmodels.DatetimeFields
+    naive_dt = datetime(2026, 9, 7, 9, 0)
+    
+    obj = await model.create(datetime=naive_dt)
+    
+    with pytest.warns(RuntimeWarning, match="received a naive datetime"):
+        await model.filter(id=obj.id).update(datetime=naive_dt)
+
+    obj_get = await model.get(id=obj.id)
+    expected_dt = timezone.make_aware(naive_dt, "Asia/Shanghai")
+    assert obj_get.datetime == expected_dt, f"Expected {expected_dt}, got {obj_get.datetime}"
+

--- a/tests/fields/test_time.py
+++ b/tests/fields/test_time.py
@@ -1,5 +1,6 @@
 import contextlib
 import os
+from collections.abc import Callable
 from datetime import date, datetime, time, timedelta
 from datetime import timezone as dt_timezone
 from unittest.mock import patch
@@ -63,6 +64,18 @@ def tz_env():
     timezone._reset_timezone_cache()
 
 
+@pytest.fixture
+def enable_tz(tz_env) -> Callable[[str | None], str]:
+    def _enable_tz(zone: str | None = None) -> str:
+        os.environ["USE_TZ"] = "True"
+        if zone is not None:
+            os.environ["TIMEZONE"] = zone
+        timezone._reset_timezone_cache()
+        return zone or "UTC"
+
+    return _enable_tz
+
+
 def test_datetime_both_auto_bad(db):
     """Test that setting both auto_now and auto_now_add raises ConfigurationError."""
     with pytest.raises(
@@ -96,11 +109,10 @@ async def test_datetime_create(db):
 
 
 @pytest.mark.asyncio
-async def test_datetime_update(db, tz_env):
+async def test_datetime_update(db, enable_tz):
     """Test updating datetime fields via filter().update() with use_tz=True."""
     model = testmodels.DatetimeFields
-    os.environ["USE_TZ"] = "True"
-    timezone._reset_timezone_cache()
+    enable_tz()
 
     obj0 = await model.create(datetime=datetime(2019, 9, 1, 0, 0, 0, tzinfo=get_default_timezone()))
     await model.filter(id=obj0.id).update(
@@ -152,11 +164,10 @@ async def test_datetime_values_list(db):
 
 
 @pytest.mark.asyncio
-async def test_datetime_get_utcnow(db, tz_env):
+async def test_datetime_get_utcnow(db, enable_tz):
     """Test getting datetime using UTC now with use_tz=True."""
     model = testmodels.DatetimeFields
-    os.environ["USE_TZ"] = "True"
-    timezone._reset_timezone_cache()
+    enable_tz()
 
     now = datetime.now(dt_timezone.utc).replace(tzinfo=get_default_timezone())
     await model.create(datetime=now)
@@ -186,11 +197,10 @@ async def test_datetime_count(db):
 
 
 @pytest.mark.asyncio
-async def test_datetime_default_timezone(db, tz_env):
+async def test_datetime_default_timezone(db, enable_tz):
     """Test default timezone is UTC when use_tz=True."""
     model = testmodels.DatetimeFields
-    os.environ["USE_TZ"] = "True"
-    timezone._reset_timezone_cache()
+    enable_tz()
 
     now = timezone.now()
     obj = await model.create(datetime=now)
@@ -204,13 +214,10 @@ async def test_datetime_default_timezone(db, tz_env):
 
 
 @pytest.mark.asyncio
-async def test_datetime_set_timezone(db, tz_env):
+async def test_datetime_set_timezone(db, enable_tz):
     """Test setting a custom timezone via environment variable with use_tz=True."""
     model = testmodels.DatetimeFields
-    tz = "Asia/Shanghai"
-    os.environ["TIMEZONE"] = tz
-    os.environ["USE_TZ"] = "True"
-    timezone._reset_timezone_cache()
+    tz = enable_tz("Asia/Shanghai")
 
     now = datetime.now(parse_timezone(tz))
     obj = await model.create(datetime=now)
@@ -224,13 +231,10 @@ async def test_datetime_set_timezone(db, tz_env):
 
 
 @pytest.mark.asyncio
-async def test_datetime_timezone(db, tz_env):
+async def test_datetime_timezone(db, enable_tz):
     """Test timezone handling with USE_TZ enabled."""
     model = testmodels.DatetimeFields
-    tz = "Asia/Shanghai"
-    os.environ["TIMEZONE"] = tz
-    os.environ["USE_TZ"] = "True"
-    timezone._reset_timezone_cache()
+    tz = enable_tz("Asia/Shanghai")
 
     now = datetime.now(parse_timezone(tz))
     obj = await model.create(datetime=now)
@@ -308,12 +312,10 @@ async def test_datetime_two_fields_naive_no_comparison_error(db, tz_env):
 
 
 @pytest.mark.asyncio
-async def test_datetime_aware_behavior_unchanged_with_use_tz_true(db, tz_env):
+async def test_datetime_aware_behavior_unchanged_with_use_tz_true(db, enable_tz):
     """Test aware datetime behavior is unchanged with use_tz=True."""
     model = testmodels.DatetimeFields
-    os.environ["USE_TZ"] = "True"
-    os.environ["TIMEZONE"] = "UTC"
-    timezone._reset_timezone_cache()
+    enable_tz("UTC")
 
     aware_dt = timezone.now()
     assert timezone.is_aware(aware_dt)
@@ -373,7 +375,7 @@ async def test_datetime_auto_now_naive_with_use_tz_false(db, tz_env):
 
 @pytest.mark.asyncio
 @test.requireCapability(dialect=NotIn("mssql", "mysql"))
-async def test_datetime_auto_now_add_matches_db_on_create(db, tz_env):
+async def test_datetime_auto_now_add_matches_db_on_create(db, enable_tz):
     """Test auto_now_add value on instance after create() matches what DB returns.
 
     Note: MSSQL (DATETIME2) and MySQL (DATETIME) use timezone-naive columns.
@@ -381,9 +383,7 @@ async def test_datetime_auto_now_add_matches_db_on_create(db, tz_env):
     to be stored and misinterpreted as local time on read with custom timezones.
     """
     model = testmodels.DatetimeFields
-    os.environ["USE_TZ"] = "True"
-    os.environ["TIMEZONE"] = "Asia/Shanghai"
-    timezone._reset_timezone_cache()
+    enable_tz("Asia/Shanghai")
 
     obj = await model.create(datetime=datetime(2021, 1, 1, tzinfo=get_default_timezone()))
     obj_get = await model.get(pk=obj.pk)
@@ -397,7 +397,7 @@ async def test_datetime_auto_now_add_matches_db_on_create(db, tz_env):
 
 @pytest.mark.asyncio
 @test.requireCapability(dialect=NotIn("mssql", "mysql"))
-async def test_datetime_auto_now_matches_db_on_save(db, tz_env):
+async def test_datetime_auto_now_matches_db_on_save(db, enable_tz):
     """Test auto_now value on instance after save() matches what DB returns.
 
     Note: MSSQL (DATETIME2) and MySQL (DATETIME) use timezone-naive columns.
@@ -405,9 +405,7 @@ async def test_datetime_auto_now_matches_db_on_save(db, tz_env):
     to be stored and misinterpreted as local time on read with custom timezones.
     """
     model = testmodels.DatetimeFields
-    os.environ["USE_TZ"] = "True"
-    os.environ["TIMEZONE"] = "Asia/Shanghai"
-    timezone._reset_timezone_cache()
+    enable_tz("Asia/Shanghai")
 
     obj = await model.create(datetime=datetime(2021, 1, 1, tzinfo=get_default_timezone()))
     await sleep(0.01)
@@ -814,11 +812,9 @@ def test_timezone(tz_env):
 
 
 @pytest.mark.asyncio
-async def test_datetime_naive_input_with_custom_timezone(db, tz_env):
+async def test_datetime_naive_input_with_custom_timezone(db, enable_tz):
     """Test naive input honors TIMEZONE instead of hardcoded UTC when use_tz=True."""
-    os.environ["USE_TZ"] = "True"
-    os.environ["TIMEZONE"] = "Asia/Shanghai"
-    timezone._reset_timezone_cache()
+    enable_tz("Asia/Shanghai")
 
     model = testmodels.DatetimeFields
     naive_dt = datetime(2026, 9, 7, 9, 0)
@@ -838,11 +834,9 @@ async def test_datetime_naive_input_with_custom_timezone(db, tz_env):
 
 
 @pytest.mark.asyncio
-async def test_datetime_naive_input_with_custom_timezone_update(db, tz_env):
+async def test_datetime_naive_input_with_custom_timezone_update(db, enable_tz):
     """Test naive input honors TIMEZONE during update."""
-    os.environ["USE_TZ"] = "True"
-    os.environ["TIMEZONE"] = "Asia/Shanghai"
-    timezone._reset_timezone_cache()
+    enable_tz("Asia/Shanghai")
 
     model = testmodels.DatetimeFields
     naive_dt = datetime(2026, 9, 7, 9, 0)

--- a/tests/fields/test_time.py
+++ b/tests/fields/test_time.py
@@ -2,11 +2,11 @@ import contextlib
 import os
 from datetime import date, datetime, time, timedelta
 from datetime import timezone as dt_timezone
-from time import sleep
 from unittest.mock import patch
 from zoneinfo import ZoneInfoNotFoundError
 
 import pytest
+from anyio import sleep
 from iso8601 import ParseError
 
 from tests import testmodels
@@ -83,7 +83,7 @@ async def test_datetime_create(db):
     assert obj.datetime_auto - now < timedelta(seconds=1)
     assert obj.datetime_add - now < timedelta(seconds=1)
     datetime_auto = obj.datetime_auto
-    sleep(0.012)
+    await sleep(0.012)
     await obj.save()
     obj2 = await model.get(id=obj.id)
     assert obj2.datetime == now
@@ -194,9 +194,11 @@ async def test_datetime_default_timezone(db, tz_env):
 
     now = timezone.now()
     obj = await model.create(datetime=now)
+    assert isinstance(obj.datetime.tzinfo, ZoneInfo)
     assert obj.datetime.tzinfo.zone == "UTC"
 
     obj_get = await model.get(pk=obj.pk)
+    assert isinstance(obj_get.datetime.tzinfo, ZoneInfo)
     assert obj_get.datetime.tzinfo.zone == "UTC"
     assert obj_get.datetime == now
 
@@ -212,9 +214,11 @@ async def test_datetime_set_timezone(db, tz_env):
 
     now = datetime.now(parse_timezone(tz))
     obj = await model.create(datetime=now)
+    assert isinstance(obj.datetime.tzinfo, ZoneInfo)
     assert obj.datetime.tzinfo.zone == tz
 
     obj_get = await model.get(pk=obj.pk)
+    assert isinstance(obj_get.datetime.tzinfo, ZoneInfo)
     assert obj_get.datetime.tzinfo.zone == tz
     assert obj_get.datetime == now
 
@@ -230,8 +234,10 @@ async def test_datetime_timezone(db, tz_env):
 
     now = datetime.now(parse_timezone(tz))
     obj = await model.create(datetime=now)
+    assert isinstance(obj.datetime.tzinfo, ZoneInfo)
     assert obj.datetime.tzinfo.zone == tz
     obj_get = await model.get(pk=obj.pk)
+    assert isinstance(obj.datetime.tzinfo, ZoneInfo)
     assert obj.datetime.tzinfo.zone == tz
     assert obj_get.datetime == now
 
@@ -352,7 +358,7 @@ async def test_datetime_auto_now_naive_with_use_tz_false(db, tz_env):
     original_auto_now = obj.datetime_auto
 
     # Update object to trigger auto_now
-    sleep(0.01)  # Ensure time difference
+    await sleep(0.01)  # Ensure time difference
     obj.datetime = datetime(2021, 2, 2)
     await obj.save()
 
@@ -385,6 +391,7 @@ async def test_datetime_auto_now_add_matches_db_on_create(db, tz_env):
     # Instance from create() should match instance from get() — no refresh needed
     assert obj.datetime_add == obj_get.datetime_add
     assert obj.datetime_add.tzinfo is not None
+    assert isinstance(obj.datetime_add.tzinfo, ZoneInfo)
     assert obj.datetime_add.tzinfo.key == "Asia/Shanghai"
 
 
@@ -403,7 +410,7 @@ async def test_datetime_auto_now_matches_db_on_save(db, tz_env):
     timezone._reset_timezone_cache()
 
     obj = await model.create(datetime=datetime(2021, 1, 1, tzinfo=get_default_timezone()))
-    sleep(0.01)
+    await sleep(0.01)
     obj.datetime = datetime(2021, 2, 2, tzinfo=get_default_timezone())
     await obj.save()
     obj_get = await model.get(pk=obj.pk)
@@ -411,6 +418,7 @@ async def test_datetime_auto_now_matches_db_on_save(db, tz_env):
     # Instance from save() should match instance from get() — no refresh needed
     assert obj.datetime_auto == obj_get.datetime_auto
     assert obj.datetime_auto.tzinfo is not None
+    assert isinstance(obj.datetime_auto.tzinfo, ZoneInfo)
     assert obj.datetime_auto.tzinfo.key == "Asia/Shanghai"
 
 
@@ -427,7 +435,7 @@ async def test_datetime_auto_fields_match_db_with_use_tz_false(db, tz_env):
     assert obj.datetime_add == obj_get.datetime_add
     assert timezone.is_naive(obj.datetime_add)
 
-    sleep(0.01)
+    await sleep(0.01)
     obj.datetime = datetime(2021, 2, 2)
     await obj.save()
     obj_get = await model.get(pk=obj.pk)
@@ -745,6 +753,8 @@ def test_zoneinfo():
     tz_utc = parse_timezone("UTC")
     tz_utc2 = parse_timezone("utc")
     tz_utc3 = parse_timezone("Utc")
+    assert isinstance(tz_utc, ZoneInfo)
+    assert isinstance(tz_utc2, ZoneInfo)
     assert tz_utc.key == tz_utc2.zone == "UTC"
     assert (
         now.replace(tzinfo=UTC)
@@ -781,6 +791,7 @@ def test_timezone(tz_env):
     now_shanghai = datetime.now(tz_shanghai)
     offset = now_shanghai.utcoffset()
     naive_now = timezone.make_naive(utcnow, tz_shanghai.key)
+    assert offset is not None
     assert (utcnow + offset).isoformat().split("+")[0] == naive_now.isoformat()
     # test make_aware
     with pytest.raises(ValueError):
@@ -801,6 +812,7 @@ def test_timezone(tz_env):
             localtime_shanghai.utcoffset() == timezone.localtime(timezone=pytz_shanghai).utcoffset()
         )
 
+
 @pytest.mark.asyncio
 async def test_datetime_naive_input_with_custom_timezone(db, tz_env):
     """Test naive input honors TIMEZONE instead of hardcoded UTC when use_tz=True."""
@@ -810,16 +822,16 @@ async def test_datetime_naive_input_with_custom_timezone(db, tz_env):
 
     model = testmodels.DatetimeFields
     naive_dt = datetime(2026, 9, 7, 9, 0)
-    
+
     obj = await model.create(datetime=naive_dt)
 
-    # When we create with a naive dt, the timezone module now assumes 
+    # When we create with a naive dt, the timezone module now assumes
     # it belongs to the configured timezone (Asia/Shanghai)
     # So 09:00 naive becomes 09:00+08:00
-    
+
     # Reload from DB
     obj_get = await model.get(id=obj.id)
-    
+
     # It should still be 09:00+08:00 because it correctly roundtripped
     expected_dt = timezone.make_aware(naive_dt, "Asia/Shanghai")
     assert obj_get.datetime == expected_dt, f"Expected {expected_dt}, got {obj_get.datetime}"
@@ -834,13 +846,12 @@ async def test_datetime_naive_input_with_custom_timezone_update(db, tz_env):
 
     model = testmodels.DatetimeFields
     naive_dt = datetime(2026, 9, 7, 9, 0)
-    
+
     obj = await model.create(datetime=naive_dt)
-    
+
     with pytest.warns(RuntimeWarning, match="received a naive datetime"):
         await model.filter(id=obj.id).update(datetime=naive_dt)
 
     obj_get = await model.get(id=obj.id)
     expected_dt = timezone.make_aware(naive_dt, "Asia/Shanghai")
     assert obj_get.datetime == expected_dt, f"Expected {expected_dt}, got {obj_get.datetime}"
-

--- a/tortoise/fields/data.py
+++ b/tortoise/fields/data.py
@@ -18,7 +18,7 @@ from pypika_tortoise.terms import Term
 from tortoise import timezone
 from tortoise.exceptions import ConfigurationError, FieldError
 from tortoise.fields.base import Field
-from tortoise.timezone import UTC, get_default_timezone, get_timezone, get_use_tz, localtime
+from tortoise.timezone import get_default_timezone, get_use_tz
 from tortoise.validators import MaxLengthValidator
 
 try:
@@ -471,9 +471,9 @@ class DatetimeField(Field[T_DATETIME], datetime.datetime):
             if get_use_tz():
                 # When use_tz=True, ensure all datetimes are timezone-aware
                 if timezone.is_naive(value):
-                    value = timezone.make_aware(value, get_timezone())
+                    value = timezone.make_aware(value)
                 else:
-                    value = localtime(value)
+                    value = value.astimezone(get_default_timezone())
             else:
                 # When use_tz=False, ensure all datetimes are naive
                 # Some backends (PostgreSQL TIMESTAMPTZ) return aware datetimes natively
@@ -506,7 +506,7 @@ class DatetimeField(Field[T_DATETIME], datetime.datetime):
                 RuntimeWarning,
                 stacklevel=2,
             )
-            value = timezone.make_aware(value).astimezone(UTC)  # ty:ignore[invalid-assignment]
+            value = timezone.make_aware(value)  # ty:ignore[invalid-assignment]
         self.validate(value)
         return value
 

--- a/tortoise/fields/data.py
+++ b/tortoise/fields/data.py
@@ -489,7 +489,7 @@ class DatetimeField(Field[T_DATETIME], datetime.datetime):
             self.auto_now
             or (self.auto_now_add and getattr(instance, self.model_field_name) is None)
         ):
-            now = timezone.now()
+            now = timezone.localtime()
             # Convert to match what would be read from DB (apply timezone conversion)
             now_python = self.to_python_value(now)
             setattr(instance, self.model_field_name, now_python)

--- a/tortoise/fields/data.py
+++ b/tortoise/fields/data.py
@@ -18,7 +18,7 @@ from pypika_tortoise.terms import Term
 from tortoise import timezone
 from tortoise.exceptions import ConfigurationError, FieldError
 from tortoise.fields.base import Field
-from tortoise.timezone import get_default_timezone, get_timezone, get_use_tz, localtime
+from tortoise.timezone import UTC, get_default_timezone, get_timezone, get_use_tz, localtime
 from tortoise.validators import MaxLengthValidator
 
 try:
@@ -462,12 +462,12 @@ class DatetimeField(Field[T_DATETIME], datetime.datetime):
 
     def to_python_value(self, value: Any) -> datetime.datetime | None:
         if value is not None:
-            if isinstance(value, datetime.datetime):
-                value = value
-            elif isinstance(value, int):
-                value = datetime.datetime.fromtimestamp(value)
-            else:
-                value = parse_datetime(value)
+            if not isinstance(value, datetime.datetime):
+                value = (
+                    datetime.datetime.fromtimestamp(value)
+                    if isinstance(value, int)
+                    else parse_datetime(value)
+                )
             if get_use_tz():
                 # When use_tz=True, ensure all datetimes are timezone-aware
                 if timezone.is_naive(value):
@@ -506,7 +506,7 @@ class DatetimeField(Field[T_DATETIME], datetime.datetime):
                 RuntimeWarning,
                 stacklevel=2,
             )
-            value = timezone.make_aware(value)  # ty:ignore[invalid-assignment]
+            value = timezone.make_aware(value).astimezone(UTC)  # ty:ignore[invalid-assignment]
         self.validate(value)
         return value
 

--- a/tortoise/fields/data.py
+++ b/tortoise/fields/data.py
@@ -32,7 +32,7 @@ try:
     from pydantic import BaseModel as _PydanticBaseModel
     from pydantic._internal._model_construction import ModelMetaclass as _PydanticModelMetaclass
 except ImportError:
-    _PydanticBaseModel = None  # type: ignore[assignment,misc]
+    _PydanticBaseModel = None  # type: ignore
     _PydanticModelMetaclass = None  # type: ignore[assignment,misc]
 
 if TYPE_CHECKING:  # pragma: nocoverage
@@ -244,7 +244,7 @@ class CharField(Field[T_STR]):
         }
 
     @property
-    def SQL_TYPE(self) -> str:  # type: ignore
+    def SQL_TYPE(self) -> str:  # type: ignore[override]
         return f"VARCHAR({self.max_length})"
 
     class _db_oracle:
@@ -256,7 +256,7 @@ class CharField(Field[T_STR]):
             return f"NVARCHAR2({self.field.max_length})"
 
 
-class TextField(Field[str], str):  # type: ignore
+class TextField(Field[str], str):  # type: ignore[misc]
     """
     Large Text field.
     """
@@ -386,7 +386,7 @@ class DecimalField(Field[T_DECIMAL], Decimal):  # type: ignore
         return value
 
     @property
-    def SQL_TYPE(self) -> str:  # type: ignore
+    def SQL_TYPE(self) -> str:  # type: ignore[override]
         return f"DECIMAL({self.max_digits},{self.decimal_places})"
 
     class _db_sqlite:
@@ -493,16 +493,20 @@ class DatetimeField(Field[T_DATETIME], datetime.datetime):
             # Convert to match what would be read from DB (apply timezone conversion)
             now_python = self.to_python_value(now)
             setattr(instance, self.model_field_name, now_python)
-            return now  # type:ignore[return-value]
-        if value is not None:
-            if isinstance(value, datetime.datetime) and get_use_tz():
-                if timezone.is_naive(value):
-                    warnings.warn(
-                        f"DateTimeField {self.model_field_name} received a naive datetime ({value})"
-                        " while time zone support is active.",
-                        RuntimeWarning,
-                    )
-                    value = timezone.make_aware(value, get_timezone())
+            return now  # type: ignore
+        if (
+            value is not None
+            and isinstance(value, datetime.datetime)
+            and get_use_tz()
+            and timezone.is_naive(value)
+        ):
+            warnings.warn(
+                f"DateTimeField {self.model_field_name} received a naive datetime ({value})"
+                " while time zone support is active.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            value = timezone.make_aware(value)  # ty:ignore[invalid-assignment]
         self.validate(value)
         return value
 
@@ -551,7 +555,7 @@ class DateField(Field[T_DATE], datetime.date):
     ) -> DateFieldQueryValueType | None:
         if value is not None and isinstance(value, str) and len(value) > 4:
             with contextlib.suppress(ValueError):
-                value = parse_datetime(value).date()  # type: ignore[assignment]
+                value = parse_datetime(value).date()  # type: ignore
         self.validate(value)
         return value
 
@@ -626,14 +630,14 @@ class TimeField(Field[T_TIME], datetime.time):
         if value is not None:
             if isinstance(value, datetime.timedelta):
                 return value
-            if get_use_tz():
-                if timezone.is_naive(value):
-                    warnings.warn(
-                        f"TimeField {self.model_field_name} received a naive time ({value})"
-                        " while time zone support is active.",
-                        RuntimeWarning,
-                    )
-                    value = value.replace(tzinfo=get_default_timezone())
+            if get_use_tz() and timezone.is_naive(value):
+                warnings.warn(
+                    f"TimeField {self.model_field_name} received a naive time ({value})"
+                    " while time zone support is active.",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+                value = value.replace(tzinfo=get_default_timezone())
         self.validate(value)
         return value
 
@@ -708,7 +712,7 @@ class FloatField(Field[T_FLOAT], float):
         SQL_TYPE = "DOUBLE"
 
 
-class JSONField(Field[T], dict, list):  # type: ignore
+class JSONField(Field[T], dict, list):  # type: ignore[misc]
     """
     JSON field.
 
@@ -768,8 +772,8 @@ class JSONField(Field[T], dict, list):  # type: ignore
         if isinstance(value, (str, bytes)):
             try:
                 self.decoder(value)
-            except Exception:
-                raise FieldError(f"Value {value!r} is invalid json value.")
+            except Exception as e:
+                raise FieldError(f"Value {value!r} is invalid json value.") from e
             if isinstance(value, bytes):
                 return value.decode()
             return value
@@ -788,10 +792,10 @@ class JSONField(Field[T], dict, list):  # type: ignore
         if isinstance(value, (str, bytes)):
             try:
                 data = self.decoder(value)
-            except Exception:
+            except Exception as e:
                 raise FieldError(
                     f"Value {value if isinstance(value, str) else value.decode()} is invalid json value."
-                )
+                ) from e
 
             if (
                 _PydanticModelMetaclass is not None
@@ -839,7 +843,7 @@ class UUIDField(Field[T_UUID], UUID):
         return UUID(value)
 
 
-class BinaryField(Field[T_BINARY], bytes):  # type: ignore
+class BinaryField(Field[T_BINARY], bytes):  # type: ignore[misc]
     """
     Binary field.
 
@@ -886,8 +890,8 @@ class IntEnumFieldInstance(SmallIntField):
         for item in enum_type:
             try:
                 value = int(item.value)
-            except ValueError:
-                raise ConfigurationError("IntEnumField only supports integer enums!")
+            except ValueError as e:
+                raise ConfigurationError("IntEnumField only supports integer enums!") from e
             if not minimum <= value < 32768:
                 raise ConfigurationError(
                     f"The valid range of IntEnumField's values is {minimum}..32767!"

--- a/tortoise/fields/data.py
+++ b/tortoise/fields/data.py
@@ -502,7 +502,7 @@ class DatetimeField(Field[T_DATETIME], datetime.datetime):
                         " while time zone support is active.",
                         RuntimeWarning,
                     )
-                    value = timezone.make_aware(value, "UTC")
+                    value = timezone.make_aware(value, get_timezone())
         self.validate(value)
         return value
 


### PR DESCRIPTION
Fixes #2273. Interprets naive datetime inputs with the configured timezone rather than unconditionally UTC, making it symmetric with to_python_value.