### PR TITLE
Clear removed model options in AlterModelOptions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Fixed
 - ``QuerySet.distinct().count()`` no longer counts rows duplicated by a join (e.g. filtering on a m2m relation); it now counts distinct primary keys and matches the number of rows the query returns. (#2255)
 - BlackSheep: ``register_tortoise`` now enables the global connection fallback, so database access works when BlackSheep runs handlers in tasks other than the one that initialized the ORM. (#2248)
 - Fix naive DatetimeField timezone drift. (#2277)
+- ``AlterModelOptions`` now clears options that were removed from the model, instead of only merging in the ones that remain; removing a model docstring no longer makes ``makemigrations`` regenerate the same migration on every run. (#2279)
 
 1.1.8
 -----

--- a/tests/migrations/test_operations_state.py
+++ b/tests/migrations/test_operations_state.py
@@ -341,6 +341,36 @@ def test_alter_options(state_with_model: State):
     assert model_state.options["ordering"] == ["-id"]
 
 
+def test_alter_options_removes_dropped_key(state_with_model: State):
+    model_state = state_with_model.models[("models", "TestModel")]
+    AlterModelOptions(
+        name="TestModel", options={**model_state.options, "table_description": "A model."}
+    ).state_forward("models", state_with_model)
+    assert model_state.options["table_description"] == "A model."
+
+    options_without_description = {
+        key: value for key, value in model_state.options.items() if key != "table_description"
+    }
+    AlterModelOptions(name="TestModel", options=options_without_description).state_forward(
+        "models", state_with_model
+    )
+
+    assert "table_description" not in model_state.options
+
+
+def test_alter_options_keeps_unmanaged_keys(state_with_model: State):
+    model_state = state_with_model.models[("models", "TestModel")]
+    model_state.options["unique_together"] = (("name",),)
+    model_state.options["table"] = "test_model"
+
+    AlterModelOptions(name="TestModel", options={"ordering": ["-id"]}).state_forward(
+        "models", state_with_model
+    )
+
+    assert model_state.options["unique_together"] == (("name",),)
+    assert model_state.options["table"] == "test_model"
+
+
 def test_add_field(state_with_model: State):
     operation = AddField(model_name="TestModel", name="name", field=fields.TextField())
     operation.state_forward("models", state_with_model)

--- a/tests/migrations/test_state_diff_operations.py
+++ b/tests/migrations/test_state_diff_operations.py
@@ -16,6 +16,7 @@ from tortoise.migrations.operations import (
     AddField,
     AddIndex,
     AlterField,
+    AlterModelOptions,
     CreateModel,
     DeleteModel,
     RemoveConstraint,
@@ -445,6 +446,28 @@ def test_generate_alter_field_and_remove_index_in_correct_order() -> None:
     assert len(operations) == 2
     assert isinstance(operations[0], RemoveIndex)
     assert isinstance(operations[1], RemoveField)
+
+
+def test_removing_table_description_settles_after_one_migration() -> None:
+    """Regression test: dropping a model docstring used to re-emit the same
+    AlterModelOptions on every run, because the operation merged its options into
+    state and could never clear the key it was emitted to remove."""
+    Described = make_model(
+        "Widget", "widget", {"table_description": "A widget."}, id=fields.IntField(pk=True)
+    )
+    Undescribed = make_model("Widget", "widget", id=fields.IntField(pk=True))
+
+    old_state = build_state("models", Described)
+    new_state = build_state("models", Undescribed)
+
+    operations = OperationGenerator(old_state, new_state).generate()
+    assert len(operations) == 1
+    assert isinstance(operations[0], AlterModelOptions)
+
+    for operation in operations:
+        operation.state_forward("models", old_state)
+
+    assert OperationGenerator(old_state, new_state).generate() == []
 
 
 def test_generate_alter_field_and_remove_constraint_in_correct_order() -> None:

--- a/tortoise/migrations/operations.py
+++ b/tortoise/migrations/operations.py
@@ -363,6 +363,9 @@ class DeleteModel(TortoiseOperation):
 
 
 class AlterModelOptions(TortoiseOperation):
+    # Options carried by other operations; the rest belong to this one.
+    UNMANAGED_OPTION_KEYS = frozenset({"table", "app", "indexes", "unique_together", "constraints"})
+
     def __init__(self, name: str, options: dict[str, Any]):
         self.name = name
         self.options = options
@@ -374,6 +377,11 @@ class AlterModelOptions(TortoiseOperation):
         model_state = self.get_model_state(state, app_label, self.name)
 
         model_state.options.update(self.options)
+        # update() only adds or changes keys, so an option removed from the model would
+        # otherwise survive here and be re-detected on every later makemigrations run.
+        for key in list(model_state.options):
+            if key not in self.UNMANAGED_OPTION_KEYS and key not in self.options:
+                del model_state.options[key]
         state.reload_model(app_label, self.name)
 
     async def database_forward(

--- a/tortoise/migrations/schema_generator/state_diff.py
+++ b/tortoise/migrations/schema_generator/state_diff.py
@@ -82,7 +82,7 @@ def _model_options_for_compare(options: dict[str, object]) -> dict[str, object]:
     return {
         key: value
         for key, value in options.items()
-        if key not in ("table", "app", "indexes", "unique_together", "constraints")
+        if key not in AlterModelOptions.UNMANAGED_OPTION_KEYS
     }
 
 


### PR DESCRIPTION
## Description

`AlterModelOptions.state_forward` applied its options with `model_state.options.update(...)`, which can only add or change keys. When an option is removed from a model the generator emits an `AlterModelOptions` whose options simply don't contain it, so the old value stayed in the state and the same operation was emitted again on the next run.

This clears the keys that belong to this operation and aren't in the new options. The five keys carried by other operations (`table`, `app`, `indexes`, `unique_together`, `constraints`) are left alone — that list already existed as a literal in `_model_options_for_compare`, so I moved it to `AlterModelOptions.UNMANAGED_OPTION_KEYS` and had the diff use it. The bug was the two sides disagreeing about which keys this operation owns, so it seemed worth having one definition.

## Motivation and Context

Fixes #2279.

Deleting a model's docstring clears `table_description`, and from then on makemigrations writes the same migration on every run and never gets back to `No changes detected`. In a project with a few such models, every later migration carries a block of no-op operations unrelated to the change being made.

In practice `table_description` is the only key this affects today, since `pk_attr` is always present.

Not covered here: `database_forward` returns `None` and table comments are only written by `CreateModel`, so on PostgreSQL a changed or deleted docstring still never reaches `COMMENT ON TABLE`. Same root cause, but it needs SQL emission per backend, so I left it out of this PR.

## How Has This Been Tested?

Three tests, in the files already covering these units:

- `test_alter_options_removes_dropped_key` — a removed key is gone from the state after the operation applies.
- `test_alter_options_keeps_unmanaged_keys` — `unique_together` and `table` survive, guarding against the clearing being too broad.
- `test_removing_table_description_settles_after_one_migration` — generates the operation, applies it, and asserts the next diff is empty. This is the reported symptom.

The first and third fail on `develop` and pass with the change.

Also reproduced end to end before and after: a one-model SQLite project, docstring removed, `makemigrations` + `migrate` three times. Before, three identical migrations; after, one, then `No changes detected`.

`make check` passes. `pytest tests/migrations/` is 302 passed, 6 skipped; the full SQLite suite is 1917 passed, 148 skipped, 2 xfailed. One unrelated failure locally, `tests/fields/test_time.py::test_zoneinfo`, is a missing tzdata on my machine and fails the same way without this change.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
